### PR TITLE
Close Mermaid xychart runtime parity gaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -393,12 +393,12 @@ Works in both flowcharts and state diagrams.
 
 ### XY Charts
 
-Bar charts, line charts, and combinations — using Mermaid's `xychart-beta` syntax.
+Bar charts, line charts, and combinations — using Mermaid's current `xychart` syntax. `xychart-beta` remains accepted for backward compatibility.
 
 **Bar chart:**
 
 ```
-xychart-beta
+xychart
     title "Monthly Revenue"
     x-axis [Jan, Feb, Mar, Apr, May, Jun]
     y-axis "Revenue ($K)" 0 --> 500
@@ -408,7 +408,7 @@ xychart-beta
 **Line chart:**
 
 ```
-xychart-beta
+xychart
     title "User Growth"
     x-axis [Jan, Feb, Mar, Apr, May, Jun]
     line [1200, 1800, 2500, 3100, 3800, 4500]
@@ -417,7 +417,7 @@ xychart-beta
 **Combined bar + line:**
 
 ```
-xychart-beta
+xychart
     title "Sales with Trend"
     x-axis [Jan, Feb, Mar, Apr, May, Jun]
     bar [300, 380, 280, 450, 350, 520]
@@ -427,7 +427,7 @@ xychart-beta
 **Horizontal orientation:**
 
 ```
-xychart-beta horizontal
+xychart horizontal
     title "Language Popularity"
     x-axis [Python, JavaScript, Java, Go, Rust]
     bar [30, 25, 20, 12, 8]
@@ -440,22 +440,72 @@ xychart-beta horizontal
 - Axis titles: `x-axis "Category" [A, B, C]`
 - Y-axis range: `y-axis "Score" 0 --> 100`
 
+**Beautiful Mermaid currently supports the full documented Mermaid xychart config/theme surface below, via YAML frontmatter or Mermaid `%%{init: ...}%%` / `%%{initialize: ...}%%` directives:**
+
+- `config.useMaxWidth` / `config.useWidth`
+- `config.xyChart.width` / `config.xyChart.height` as total chart size
+- `config.xyChart.titleFontSize` / `config.xyChart.titlePadding`
+- `config.xyChart.showDataLabel`
+- `config.xyChart.showTitle`
+- `config.xyChart.chartOrientation`
+- `config.xyChart.plotReservedSpacePercent`
+- `config.xyChart.xAxis.showLabel` / `showTitle`
+- `config.xyChart.xAxis.labelFontSize` / `labelPadding`
+- `config.xyChart.xAxis.titleFontSize` / `titlePadding`
+- `config.xyChart.xAxis.showTick` / `tickLength` / `tickWidth`
+- `config.xyChart.xAxis.showAxisLine` / `axisLineWidth`
+- `config.xyChart.yAxis.showLabel` / `showTitle`
+- `config.xyChart.yAxis.labelFontSize` / `labelPadding`
+- `config.xyChart.yAxis.titleFontSize` / `titlePadding`
+- `config.xyChart.yAxis.showTick` / `tickLength` / `tickWidth`
+- `config.xyChart.yAxis.showAxisLine` / `axisLineWidth`
+- `config.themeVariables.xyChart.backgroundColor`
+- `config.themeVariables.xyChart.titleColor`
+- `config.themeVariables.xyChart.xAxisLabelColor`
+- `config.themeVariables.xyChart.xAxisTickColor`
+- `config.themeVariables.xyChart.xAxisLineColor`
+- `config.themeVariables.xyChart.xAxisTitleColor`
+- `config.themeVariables.xyChart.yAxisLabelColor`
+- `config.themeVariables.xyChart.yAxisTickColor`
+- `config.themeVariables.xyChart.yAxisLineColor`
+- `config.themeVariables.xyChart.yAxisTitleColor`
+- `config.themeVariables.xyChart.plotColorPalette`
+- `config.themeCSS`
+- top-level Mermaid `theme` / `fontFamily` values when supplied through YAML frontmatter or `init` / `initialize` directives
+
+It also matches Mermaid's runtime affordances for:
+
+- semicolon-separated xychart statements on a single line
+- Mermaid accessibility directives: `accTitle` and `accDescr`
+- Mermaid YAML frontmatter lists, nested maps, and block scalars
+- Mermaid-style loose object literals inside `init` / `initialize` directives
+
+```yaml
+---
+config:
+  xyChart:
+    showDataLabel: true
+  themeVariables:
+    xyChart:
+      plotColorPalette: "#ff6b6b, #0ea5e9"
+---
+```
+
 **Multi-series:** Add multiple `bar` and/or `line` declarations. Each series gets a distinct color from a monochromatic palette derived from the theme's accent color.
 
 ### XY Chart Styling
 
-The chart renderer follows a clean, minimal design philosophy inspired by Apple and Craft:
+The current xychart renderer stays intentionally close to Mermaid while still following Beautiful Mermaid's theme system and spacing standards:
 
-- **Dot grid** — A subtle dot pattern fills the plot area instead of traditional solid grid lines
-- **Rounded bars** — All bar corners are rounded for a modern, polished look
-- **Smooth curves** — Line series use natural cubic spline interpolation, producing mathematically smooth curves through all data points (not straight segments or staircase steps)
-- **Floating labels** — No visible axis lines or tick marks; labels float freely for a clutter-free aesthetic
-- **Drop-shadow lines** — Each line series has a subtle shadow beneath it for depth
-- **Monochromatic palette** — Series 0 uses the theme's accent color; additional series get darker/lighter shades of the same hue with subtle hue drift, adapting automatically to light or dark backgrounds
-- **Interactive tooltips** — When rendered with `interactive: true`, hovering over bars or data points shows value tooltips. Multi-line tooltips appear when multiple series share an x-position
-- **Sparse line dots** — Lines with 12 or fewer data points show data point dots by default for readability
-- **Full theme support** — All 15 built-in themes (and custom themes) apply to charts. The accent color drives the entire series color palette
-- **Live theme switching** — Chart series colors are CSS custom properties (`--xychart-color-N`), so theme changes apply instantly without re-rendering
+- **Explicit axes and ticks** - Axis lines and tick marks are rendered by default, with Mermaid frontmatter available to hide or restyle them
+- **Shared Mermaid config entry points** - The same supported xychart config/theme subset works through YAML frontmatter and Mermaid `init` / `initialize` directives
+- **Accessible SVG metadata** - `accTitle` / `accDescr` are emitted as root SVG `<title>` / `<desc>` metadata with Mermaid-style labeling attributes
+- **Clean grid lines** - The plot uses subtle guide lines instead of a decorative dot field so numeric reading stays easy
+- **Straight line segments** - Line series connect points directly, matching Mermaid's own xychart geometry
+- **Bar-only data labels** - `showDataLabel` labels bars, matching Mermaid behavior and avoiding clutter on line charts
+- **Opt-in interactivity** - `interactive: true` adds hover targets, dots, and tooltips for bars and line points without changing the static SVG structure
+- **Theme-driven palette** - Series colors come from the accent color by default, or from Mermaid `plotColorPalette` when frontmatter provides one
+- **Live theme switching** - Chart series colors are CSS custom properties (`--xychart-color-N`), so theme changes apply instantly without re-rendering
 
 ---
 
@@ -547,7 +597,7 @@ Render a Mermaid diagram to SVG. Synchronous. Auto-detects diagram type.
 | `interactive` | `boolean` | `false` | Enable hover tooltips on XY chart bars and data points |
 | `mermaidConfig` | `MermaidRuntimeConfig` | — | Optional Mermaid-style config merged with frontmatter and `%%{init}` / `%%{initialize}` directives |
 
-**Timeline + XY Charts:** Diagrams starting with `timeline` or `xychart-beta` are auto-detected — no separate function needed. The `accent` color option drives the chart series color palette.
+**Timeline + XY Charts:** Diagrams starting with `timeline`, `xychart`, or `xychart-beta` are auto-detected — no separate function needed. For xychart, the `accent` color option drives the series palette unless Mermaid config provides `plotColorPalette`, and Mermaid `xyChart.width` / `height` are treated as total chart dimensions, matching Mermaid's own renderer.
 
 ### `renderMermaidSVGAsync(text, options?): Promise<string>`
 

--- a/src/__tests__/property-xychart.test.ts
+++ b/src/__tests__/property-xychart.test.ts
@@ -1,31 +1,30 @@
 import { describe, expect, it } from 'bun:test'
 import fc from 'fast-check'
 
+import { preprocessMermaidSource, toMermaidLines } from '../mermaid-source.ts'
 import { layoutXYChart } from '../xychart/layout.ts'
 import { parseXYChart } from '../xychart/parser.ts'
 
-const PROPERTY_RUNS = 50
+const PROPERTY_RUNS = 60
 const WORD_CHARS = [...'abcdefghijklmnopqrstuvwxyz']
 
 const wordArb = fc
   .array(fc.constantFrom(...WORD_CHARS), { minLength: 1, maxLength: 8 })
   .map(chars => chars.join(''))
 
-const categoryLabelArb = fc
-  .array(wordArb, { minLength: 1, maxLength: 2 })
-  .map(parts => parts.join(' '))
+const categoryLabelArb = fc.record({
+  left: wordArb,
+  right: fc.option(wordArb, { nil: undefined }),
+  withComma: fc.boolean(),
+}).map(({ left, right, withComma }) => {
+  if (!right) return left
+  return withComma ? `${left}, ${right}` : `${left} ${right}`
+})
 
 const numberArb = fc.integer({ min: -30, max: 90 })
 
-function toLines(source: string): string[] {
-  return source
-    .split('\n')
-    .map(line => line.trim())
-    .filter(line => line.length > 0 && !line.startsWith('%%'))
-}
-
-function renderCategories(labels: string[]): string {
-  return labels.join(', ')
+function renderQuotedCategories(labels: string[]): string {
+  return labels.map(label => `"${label}"`).join(', ')
 }
 
 function renderSeriesLine(type: 'bar' | 'line', values: number[]): string {
@@ -47,20 +46,20 @@ function expectInsidePlotArea(
 }
 
 describe('property-based xychart parsing', () => {
-  it('preserves category labels and per-series data', () => {
+  it('parses quoted category labels, including embedded commas and spaces', () => {
     const chartArb = fc.uniqueArray(categoryLabelArb, { minLength: 1, maxLength: 5 }).chain(labels =>
       fc.record({
         labels: fc.constant(labels),
         barValues: fc.array(numberArb, { minLength: labels.length, maxLength: labels.length }),
         lineValues: fc.array(numberArb, { minLength: labels.length, maxLength: labels.length }),
-      }),
+      })
     )
 
     fc.assert(
       fc.property(chartArb, ({ labels, barValues, lineValues }) => {
-        const lines = toLines([
-          'xychart-beta',
-          `x-axis [${renderCategories(labels)}]`,
+        const lines = toMermaidLines([
+          'xychart',
+          `x-axis [${renderQuotedCategories(labels)}]`,
           renderSeriesLine('bar', barValues),
           renderSeriesLine('line', lineValues),
         ].join('\n'))
@@ -86,14 +85,14 @@ describe('property-based xychart parsing', () => {
           }),
           { minLength: 1, maxLength: 3 },
         ),
-      }),
+      })
     )
 
     fc.assert(
       fc.property(chartArb, ({ labels, series }) => {
-        const lines = toLines([
-          'xychart-beta',
-          `x-axis [${renderCategories(labels)}]`,
+        const lines = toMermaidLines([
+          'xychart',
+          `x-axis [${renderQuotedCategories(labels)}]`,
           ...series.map(entry => renderSeriesLine(entry.type, entry.values)),
         ].join('\n'))
 
@@ -103,6 +102,48 @@ describe('property-based xychart parsing', () => {
         expect(chart.yAxis.range).toBeDefined()
         expect(chart.yAxis.range!.min <= Math.min(...allValues)).toBe(true)
         expect(chart.yAxis.range!.max >= Math.max(...allValues)).toBe(true)
+      }),
+      { numRuns: PROPERTY_RUNS },
+    )
+  })
+
+  it('propagates frontmatter config and theme overrides into the parsed chart', () => {
+    const frontmatterArb = fc.record({
+      width: fc.integer({ min: 200, max: 900 }),
+      height: fc.integer({ min: 120, max: 480 }),
+      orientation: fc.constantFrom<'horizontal' | 'vertical'>('horizontal', 'vertical'),
+      showDataLabel: fc.boolean(),
+      backgroundColor: fc.constantFrom('#101010', '#f8fafc', '#0ea5e9'),
+    })
+
+    fc.assert(
+      fc.property(frontmatterArb, ({ width, height, orientation, showDataLabel, backgroundColor }) => {
+        const source = [
+          '---',
+          'config:',
+          '  xyChart:',
+          `    width: ${width}`,
+          `    height: ${height}`,
+          `    chartOrientation: ${orientation}`,
+          `    showDataLabel: ${showDataLabel}`,
+          'themeVariables:',
+          '  xyChart:',
+          `    backgroundColor: "${backgroundColor}"`,
+          '---',
+          'xychart',
+          'x-axis ["Q1", "Q2"]',
+          'bar [1, 2]',
+        ].join('\n')
+
+        const processed = preprocessMermaidSource(source)
+        const chart = parseXYChart(processed.lines, processed.frontmatter)
+
+        expect(chart.config.width).toBe(width)
+        expect(chart.config.height).toBe(height)
+        expect(chart.config.chartOrientation).toBe(orientation)
+        expect(chart.config.showDataLabel).toBe(showDataLabel)
+        expect(chart.theme.backgroundColor).toBe(backgroundColor)
+        expect(chart.horizontal).toBe(orientation === 'horizontal')
       }),
       { numRuns: PROPERTY_RUNS },
     )
@@ -117,15 +158,15 @@ describe('property-based xychart layout', () => {
         labels: fc.uniqueArray(categoryLabelArb, { minLength: length, maxLength: length }),
         barValues: fc.array(numberArb, { minLength: length, maxLength: length }),
         lineValues: fc.array(numberArb, { minLength: length, maxLength: length }),
-      }),
+      })
     ).filter(({ barValues }) => barValues.some(value => value >= 0))
 
     fc.assert(
       fc.property(layoutArb, ({ orientation, labels, barValues, lineValues }) => {
-        const header = orientation === 'horizontal' ? 'xychart-beta horizontal' : 'xychart-beta'
-        const chart = parseXYChart(toLines([
+        const header = orientation === 'horizontal' ? 'xychart horizontal' : 'xychart'
+        const chart = parseXYChart(toMermaidLines([
           header,
-          `x-axis [${renderCategories(labels)}]`,
+          `x-axis [${renderQuotedCategories(labels)}]`,
           renderSeriesLine('bar', barValues),
           renderSeriesLine('line', lineValues),
         ].join('\n')))
@@ -142,6 +183,7 @@ describe('property-based xychart layout', () => {
         }
 
         for (const line of positioned.lines) {
+          expect(line.points).toHaveLength(labels.length)
           for (const point of line.points) {
             expect(point.x >= positioned.plotArea.x - 0.0001).toBe(true)
             expect(point.x <= positioned.plotArea.x + positioned.plotArea.width + 0.0001).toBe(true)
@@ -150,14 +192,7 @@ describe('property-based xychart layout', () => {
           }
         }
 
-        for (const tick of positioned.xAxis.ticks) {
-          expect(Number.isFinite(tick.x)).toBe(true)
-          expect(Number.isFinite(tick.y)).toBe(true)
-          expect(Number.isFinite(tick.labelX)).toBe(true)
-          expect(Number.isFinite(tick.labelY)).toBe(true)
-        }
-
-        for (const tick of positioned.yAxis.ticks) {
+        for (const tick of [...positioned.xAxis.ticks, ...positioned.yAxis.ticks]) {
           expect(Number.isFinite(tick.x)).toBe(true)
           expect(Number.isFinite(tick.y)).toBe(true)
           expect(Number.isFinite(tick.labelX)).toBe(true)

--- a/src/__tests__/xychart-ascii.test.ts
+++ b/src/__tests__/xychart-ascii.test.ts
@@ -1,8 +1,9 @@
 /**
- * Tests for xychart-beta ASCII rendering.
+ * Tests for xychart ASCII rendering.
  *
  * Tests bar charts, line charts, mixed charts, horizontal orientation,
- * multi-series support, staircase line routing, and edge cases.
+ * Mermaid parity features, multi-series support, staircase routing,
+ * and edge cases.
  */
 import { describe, it, expect } from 'bun:test'
 import { renderMermaidASCII } from '../ascii/index.ts'
@@ -220,6 +221,90 @@ describe('xychart ASCII – titles and axes', () => {
     // First non-empty line should be chart content, not a title
     const lines = result.split('\n').filter(l => l.trim().length > 0)
     expect(lines.length).toBeGreaterThan(0)
+  })
+})
+
+describe('xychart ASCII – Mermaid parity', () => {
+  it('accepts the stable xychart header and strips quotes from category labels', () => {
+    const result = render(`xychart
+      title Revenue
+      x-axis [Q1, "Q2 Growth", Q3]
+      bar [10, 20, 30]`)
+    expect(result).toContain('Revenue')
+    expect(result).toContain('Q2 Growth')
+    expect(result).not.toContain('"Q2 Growth"')
+  })
+
+  it('supports frontmatter showDataLabel and axis label visibility', () => {
+    const result = render(`---
+      config:
+        xyChart:
+          showDataLabel: true
+          xAxis:
+            showLabel: false
+      ---
+      xychart
+      x-axis [Cat1, Cat2, Cat3]
+      bar [10, 20, 30]`)
+    expect(result).toContain('10')
+    expect(result).toContain('30')
+    expect(result).not.toContain('Cat1')
+    expect(result).not.toContain('Cat2')
+    expect(result).not.toContain('Cat3')
+  })
+
+  it('shows data labels for bars only, not line points', () => {
+    const result = render(`---
+      config:
+        xyChart:
+          showDataLabel: true
+      ---
+      xychart
+      x-axis [A, B, C]
+      bar [10, 20, 30]
+      line [17, 18, 27]`)
+    expect(result).toContain('10')
+    expect(result).toContain('20')
+    expect(result).toContain('30')
+    expect(result).not.toContain('17')
+    expect(result).not.toContain('18')
+    expect(result).not.toContain('27')
+  })
+
+  it('supports CRLF frontmatter for horizontal orientation and hidden titles', () => {
+    const result = render([
+      '---',
+      'config:',
+      '  xyChart:',
+      '    chartOrientation: horizontal',
+      '    showTitle: false',
+      '---',
+      'xychart',
+      '  title Revenue',
+      '  x-axis [Python, JavaScript, Go]',
+      '  bar [30, 25, 12]',
+    ].join('\r\n'))
+    expect(result).not.toContain('Revenue')
+    expect(result).toMatch(/Python[│|]/)
+    expect(result).toMatch(/JavaScript[│|]/)
+  })
+
+  it('supports Mermaid init directives for xychart config in ASCII output', () => {
+    const result = render(`%%{init: {
+      "xyChart": {
+        "showDataLabel": true,
+        "xAxis": { "showLabel": false }
+      }
+    }}%%
+xychart
+  x-axis [Q1, Q2, Q3]
+  y-axis Users 0 --> 100
+  bar [30, 60, 45]
+  line [25, 55, 50]`)
+
+    expect(result).toContain('30')
+    expect(result).toContain('60')
+    expect(result).not.toContain('Q1')
   })
 })
 

--- a/src/__tests__/xychart-integration.test.ts
+++ b/src/__tests__/xychart-integration.test.ts
@@ -1,8 +1,8 @@
 /**
- * Integration tests for xychart-beta rendering.
+ * Integration tests for xychart rendering.
  *
- * Tests data-* attributes (always emitted) and interactive tooltip
- * groups (only when interactive: true).
+ * Tests data-* attributes (always emitted), interactive tooltip
+ * groups (only when interactive: true), and Mermaid-compat behavior.
  */
 import { describe, it, expect } from 'bun:test'
 import { renderMermaid } from '../index.ts'
@@ -22,6 +22,79 @@ const MIXED_CHART = `xychart-beta
   y-axis "Sales" 0 --> 200
   bar [50, 80, 120, 90]
   line [40, 100, 110, 85]`
+
+const STABLE_XYCHART = `xychart
+  title Revenue
+  x-axis [Q1, "Q2 Growth", Q3]
+  y-axis Users 0 --> 100
+  bar [30, 60, 45]`
+
+const FRONTMATTER_XYCHART = `---
+config:
+  xyChart:
+    showDataLabel: true
+    xAxis:
+      showLabel: false
+  themeVariables:
+    xyChart:
+      backgroundColor: "#f8fafc"
+      plotColorPalette: "#ff6b6b, #0ea5e9"
+      titleColor: "#123456"
+      xAxisLabelColor: "#654321"
+      xAxisTickColor: "#aa5500"
+      yAxisLineColor: "#0055aa"
+---
+xychart
+  title Revenue
+  x-axis [Q1, "Q2 Growth", Q3]
+  y-axis Users 0 --> 100
+  bar [30, 60, 45]
+  line [25, 55, 50]`
+
+const FRONTMATTER_HORIZONTAL_XYCHART = [
+  '---',
+  'config:',
+  '  xyChart:',
+  '    chartOrientation: horizontal',
+  '    showTitle: false',
+  '    width: 720',
+  '    height: 240',
+  '---',
+  'xychart',
+  '  title Revenue',
+  '  x-axis [A, B, C]',
+  '  y-axis Users 0 --> 100',
+  '  bar [10, 20, 30]',
+].join('\r\n')
+
+const INIT_DIRECTIVE_XYCHART = `%%{init: {
+  "theme": "dark",
+  "fontFamily": "Fira Code",
+  "xyChart": {
+    "showDataLabel": true,
+    "xAxis": { "showLabel": false }
+  },
+  "themeVariables": {
+    "xyChart": {
+      "plotColorPalette": ["#ff6b6b", "#0ea5e9"]
+    }
+  }
+}}%%
+xychart
+  title Revenue
+  x-axis [Q1, "Q2 Growth", Q3]
+  y-axis Users 0 --> 100
+  bar [30, 60, 45]
+  line [25, 55, 50]`
+
+function getSvgSize(svg: string): { width: number; height: number } {
+  const sizeMatch = svg.match(/<svg[^>]*viewBox="0 0 (\d+) (\d+)"/)
+  expect(sizeMatch).toBeTruthy()
+  return {
+    width: Number(sizeMatch![1]),
+    height: Number(sizeMatch![2]),
+  }
+}
 
 // ============================================================================
 // Data attributes (always present)
@@ -45,12 +118,10 @@ describe('xychart – data attributes', () => {
     expect(svg).toContain('data-label="Mar"')
   })
 
-  it('shows dots on sparse line charts even without interactive', async () => {
-    // Sparse charts (≤12 points) render dots as visual markers
+  it('does not render line dots unless interactive, matching Mermaid', async () => {
     const svg = await renderMermaid(LINE_CHART)
-    expect(svg).toContain('<circle')
-    expect(svg).toContain('data-value="100"')
-    // But no tooltips without interactive
+    expect(svg).not.toContain('<circle')
+    expect(svg).not.toContain('data-value="100"')
     expect(svg).not.toContain('xychart-tip-bg')
     expect(svg).not.toContain('xychart-dot-group')
   })
@@ -133,5 +204,87 @@ describe('xychart – CSS variable color inputs', () => {
     expect(svg).not.toContain('NaN')
     expect(svg).toContain('xychart-color-0')
     expect(svg).toContain('xychart-color-1')
+  })
+})
+
+describe('xychart – Mermaid parity', () => {
+  it('accepts the stable xychart header and cleans quoted category labels', async () => {
+    const svg = await renderMermaid(STABLE_XYCHART)
+    expect(svg).toContain('>Revenue</text>')
+    expect(svg).toContain('Q2 Growth')
+    expect(svg).not.toContain('&quot;Q2 Growth&quot;')
+  })
+
+  it('supports Mermaid frontmatter config and theme variables', async () => {
+    const svg = await renderMermaid(FRONTMATTER_XYCHART)
+    expect(svg).toContain('class="xychart-data-label')
+    expect(svg).toContain('--xychart-color-0: #ff6b6b;')
+    expect(svg).toContain('--xychart-color-1: #0ea5e9;')
+    expect(svg).toContain('.xychart-title { fill: #123456; }')
+    expect(svg).toContain('.xychart-x-label { fill: #654321; }')
+    expect(svg).toContain('.xychart-x-tick { stroke: #aa5500; }')
+    expect(svg).toContain('.xychart-y-axis-line { stroke: #0055aa; }')
+    expect(svg).toContain('--bg:#f8fafc')
+    expect(svg).toContain('class="xychart-axis-line xychart-x-axis-line"')
+    expect(svg).toContain('class="xychart-tick xychart-y-tick"')
+    expect(svg).not.toContain('>Q1</text>')
+  })
+
+  it('renders showDataLabel for bars only, matching Mermaid behavior', async () => {
+    const svg = await renderMermaid(FRONTMATTER_XYCHART)
+    expect(svg).toContain('>30</text>')
+    expect(svg).toContain('>60</text>')
+    expect(svg).toContain('>45</text>')
+    expect(svg.match(/class="xychart-data-label"/g)?.length ?? 0).toBe(3)
+  })
+
+  it('supports CRLF frontmatter for orientation, title visibility, and chart sizing', async () => {
+    const defaultSvg = await renderMermaid(`xychart horizontal
+  title Revenue
+  x-axis [A, B, C]
+  y-axis Users 0 --> 100
+  bar [10, 20, 30]`)
+    const svg = await renderMermaid(FRONTMATTER_HORIZONTAL_XYCHART)
+    const defaultSize = getSvgSize(defaultSvg)
+    const configuredSize = getSvgSize(svg)
+
+    expect(svg).not.toContain('>Revenue</text>')
+    expect(svg).toContain('class="xychart-label xychart-x-label">A</text>')
+    expect(svg).toContain('class="xychart-axis-title xychart-y-axis-title">Users</text>')
+    expect(configuredSize.width).toBeGreaterThan(defaultSize.width)
+    expect(configuredSize.height).toBeLessThan(defaultSize.height)
+  })
+
+  it('supports Mermaid init directives for routing, theme, font, and xychart config', async () => {
+    const svg = await renderMermaid(INIT_DIRECTIVE_XYCHART)
+    expect(svg).toContain('--bg:#18181B')
+    expect(svg).toContain('Fira%20Code')
+    expect(svg).toContain('class="xychart-data-label"')
+    expect(svg).toContain('--xychart-color-0: #ff6b6b;')
+    expect(svg).toContain('--xychart-color-1: #0ea5e9;')
+    expect(svg).not.toContain('>Q1</text>')
+  })
+
+  it('renders accessibility metadata on the root SVG', async () => {
+    const svg = await renderMermaid(`xychart
+  accTitle: Revenue chart
+  accDescr {
+    Quarterly sales
+    across two regions.
+  }
+  bar [10, 20]`)
+
+    expect(svg).toContain('aria-roledescription="xychart"')
+    expect(svg).toContain('<title id="chart-title-')
+    expect(svg).toContain('<desc id="chart-desc-')
+    expect(svg).toContain('Quarterly sales')
+  })
+
+  it('supports semicolon-separated Mermaid xychart statements', async () => {
+    const svg = await renderMermaid('xychart; title Revenue; x-axis [Q1, Q2]; bar [10, 20]')
+
+    expect(svg).toContain('>Revenue</text>')
+    expect(svg).toContain('data-label="Q1"')
+    expect(svg).toContain('data-value="20"')
   })
 })

--- a/src/__tests__/xychart-layout.test.ts
+++ b/src/__tests__/xychart-layout.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Layout tests for xychart diagrams.
+ *
+ * These assert the coordinate-space rules directly so renderer changes do not
+ * hide plot sizing or axis-placement regressions.
+ */
+import { describe, it, expect } from 'bun:test'
+import { preprocessMermaidSource } from '../mermaid-source.ts'
+import { parseXYChart } from '../xychart/parser.ts'
+import { layoutXYChart } from '../xychart/layout.ts'
+
+function layout(text: string) {
+  const processed = preprocessMermaidSource(text)
+  return layoutXYChart(parseXYChart(processed.lines, processed.frontmatter))
+}
+
+describe('xychart layout – dimensions and bounds', () => {
+  it('uses Mermaid width and height as total chart dimensions', () => {
+    const chart = layout(`---
+config:
+  xyChart:
+    width: 720
+    height: 240
+---
+xychart
+  title Revenue
+  x-axis [Q1, Q2, Q3]
+  y-axis Users 0 --> 100
+  bar [10, 20, 30]`)
+
+    expect(chart.width).toBe(720)
+    expect(chart.height).toBe(240)
+    expect(chart.plotArea.x).toBeGreaterThanOrEqual(0)
+    expect(chart.plotArea.y).toBeGreaterThanOrEqual(0)
+    expect(chart.plotArea.x + chart.plotArea.width).toBeLessThanOrEqual(chart.width)
+    expect(chart.plotArea.y + chart.plotArea.height).toBeLessThanOrEqual(chart.height)
+
+    for (const bar of chart.bars) {
+      expect(bar.x).toBeGreaterThanOrEqual(chart.plotArea.x)
+      expect(bar.x + bar.width).toBeLessThanOrEqual(chart.plotArea.x + chart.plotArea.width)
+      expect(bar.y).toBeGreaterThanOrEqual(chart.plotArea.y)
+      expect(bar.y + bar.height).toBeLessThanOrEqual(chart.plotArea.y + chart.plotArea.height)
+    }
+  })
+
+  it('keeps numeric x-axis line points inside the plot area', () => {
+    const chart = layout(`xychart
+      x-axis 0 --> 100
+      y-axis 0 --> 50
+      line [10, 20, 35, 40, 45]`)
+
+    expect(chart.lines).toHaveLength(1)
+    expect(chart.legend).toEqual([])
+
+    for (const point of chart.lines[0]!.points) {
+      expect(point.x).toBeGreaterThanOrEqual(chart.plotArea.x)
+      expect(point.x).toBeLessThanOrEqual(chart.plotArea.x + chart.plotArea.width)
+      expect(point.y).toBeGreaterThanOrEqual(chart.plotArea.y)
+      expect(point.y).toBeLessThanOrEqual(chart.plotArea.y + chart.plotArea.height)
+    }
+  })
+})
+
+describe('xychart layout – axis placement', () => {
+  it('places the category axis on the left and the value axis at the top in horizontal mode', () => {
+    const chart = layout(`xychart horizontal
+      title Revenue
+      x-axis "Team" [Eng, Sales, Ops]
+      y-axis "Users" 0 --> 100
+      bar [10, 20, 30]
+      line [12, 18, 26]`)
+
+    expect(chart.horizontal).toBe(true)
+    expect(chart.xAxis.line.x1).toBeCloseTo(chart.xAxis.line.x2, 5)
+    expect(chart.xAxis.line.y1).toBeCloseTo(chart.plotArea.y, 5)
+    expect(chart.xAxis.line.y2).toBeCloseTo(chart.plotArea.y + chart.plotArea.height, 5)
+    expect(chart.xAxis.ticks[0]!.textAnchor).toBe('end')
+
+    expect(chart.yAxis.line.y1).toBeCloseTo(chart.yAxis.line.y2, 5)
+    expect(chart.yAxis.line.x1).toBeCloseTo(chart.plotArea.x, 5)
+    expect(chart.yAxis.line.x2).toBeCloseTo(chart.plotArea.x + chart.plotArea.width, 5)
+    expect(chart.yAxis.line.y1).toBeLessThanOrEqual(chart.plotArea.y)
+    expect(chart.yAxis.ticks[0]!.textAnchor).toBe('middle')
+  })
+
+  it('propagates axis visibility config into the positioned chart', () => {
+    const chart = layout(`---
+config:
+  xyChart:
+    xAxis:
+      showLabel: false
+      showTick: false
+    yAxis:
+      showTitle: false
+---
+xychart
+  title Revenue
+  x-axis Month [Jan, Feb, Mar]
+  y-axis Users 0 --> 100
+  bar [10, 20, 30]`)
+
+    expect(chart.xAxis.config.showLabel).toBe(false)
+    expect(chart.xAxis.config.showTick).toBe(false)
+    expect(chart.xAxis.ticks).toHaveLength(0)
+    expect(chart.yAxis.config.showTitle).toBe(false)
+    expect(chart.yAxis.title).toBeUndefined()
+  })
+})

--- a/src/__tests__/xychart-parser.test.ts
+++ b/src/__tests__/xychart-parser.test.ts
@@ -1,0 +1,365 @@
+/**
+ * Tests for the xychart parser.
+ *
+ * Covers stable syntax, quoted labels, frontmatter config/theme values,
+ * comment stripping, and malformed Mermaid lines that should not crash parsing.
+ */
+import { describe, it, expect } from 'bun:test'
+import { preprocessMermaidSource } from '../mermaid-source.ts'
+import { parseXYChart } from '../xychart/parser.ts'
+
+function parse(text: string) {
+  const processed = preprocessMermaidSource(text)
+  return parseXYChart(processed.lines, processed.frontmatter)
+}
+
+describe('parseXYChart – syntax', () => {
+  it('parses the stable header, strips comments, and normalizes quoted categories', () => {
+    const chart = parse(`%% ignore me
+      xychart
+      %% still ignored
+      title Revenue
+      x-axis ["Q1 Growth", Q2, 'Q3 Upsell']
+      bar [10, 20, 30]`)
+
+    expect(chart.title).toBe('Revenue')
+    expect(chart.horizontal).toBe(false)
+    expect(chart.xAxis.categories).toEqual(['Q1 Growth', 'Q2', 'Q3 Upsell'])
+    expect(chart.series).toHaveLength(1)
+    expect(chart.series[0]!.type).toBe('bar')
+    expect(chart.series[0]!.data).toEqual([10, 20, 30])
+  })
+
+  it('supports semicolon-separated Mermaid statements on one line', () => {
+    const chart = parse('xychart; title Revenue; x-axis [Q1, Q2]; bar [10, 20]')
+
+    expect(chart.title).toBe('Revenue')
+    expect(chart.xAxis.categories).toEqual(['Q1', 'Q2'])
+    expect(chart.series).toHaveLength(1)
+    expect(chart.series[0]!.data).toEqual([10, 20])
+  })
+
+  it('parses numeric axes and quoted axis titles', () => {
+    const chart = parse(`xychart-beta
+      x-axis "Month Index" 0 --> 12
+      y-axis "Users" -10 --> 90
+      line [0, 20, 40, 60]`)
+
+    expect(chart.xAxis.title).toBe('Month Index')
+    expect(chart.xAxis.range).toEqual({ min: 0, max: 12 })
+    expect(chart.yAxis.title).toBe('Users')
+    expect(chart.yAxis.range).toEqual({ min: -10, max: 90 })
+    expect(chart.series[0]!.type).toBe('line')
+  })
+
+  it('parses Mermaid accessibility directives, including block descriptions', () => {
+    const chart = parse(`xychart
+      accTitle: Revenue chart
+      accDescr {
+        Quarterly sales
+        across two regions.
+      }
+      bar [10, 20]`)
+
+    expect(chart.accessibility).toEqual({
+      title: 'Revenue chart',
+      description: 'Quarterly sales\nacross two regions.',
+    })
+  })
+
+  it('applies Mermaid frontmatter config and theme overrides', () => {
+    const chart = parse(`---
+config:
+  xyChart:
+    width: 720
+    height: 320
+    showDataLabel: true
+    xAxis:
+      showLabel: false
+  themeVariables:
+    xyChart:
+      titleColor: "#123456"
+      plotColorPalette: "#ff6b6b, #0ea5e9"
+---
+xychart
+  title Revenue
+  x-axis [Q1, Q2]
+  bar [30, 60]`)
+
+    expect(chart.config.width).toBe(720)
+    expect(chart.config.height).toBe(320)
+    expect(chart.config.showDataLabel).toBe(true)
+    expect(chart.config.xAxis?.showLabel).toBe(false)
+    expect(chart.theme.titleColor).toBe('#123456')
+    expect(chart.theme.plotColorPalette).toEqual(['#ff6b6b', '#0ea5e9'])
+  })
+
+  it('parses Mermaid init directives into the same config surface', () => {
+    const chart = parse(`%%{init: {
+      "theme": "dark",
+      "fontFamily": "Fira Code",
+      "xyChart": {
+        "showDataLabel": true,
+        "xAxis": { "showLabel": false }
+      },
+      "themeVariables": {
+        "xyChart": {
+          "plotColorPalette": ["#ff6b6b", "#0ea5e9"]
+        }
+      }
+    }}%%
+xychart
+  title Revenue
+  x-axis [Q1, Q2]
+  bar [30, 60]`)
+
+    expect(chart.config.showDataLabel).toBe(true)
+    expect(chart.config.xAxis?.showLabel).toBe(false)
+    expect(chart.theme.plotColorPalette).toEqual(['#ff6b6b', '#0ea5e9'])
+  })
+
+  it('accepts Mermaid init directives written as loose object literals', () => {
+    const chart = parse(`%%{init: {
+      'useMaxWidth': false,
+      'xyChart': {
+        'showDataLabel': true
+      }
+    }}%%
+xychart
+  x-axis [Q1, Q2]
+  bar [30, 60]`)
+
+    expect(chart.config.useMaxWidth).toBe(false)
+    expect(chart.config.showDataLabel).toBe(true)
+  })
+
+  it('merges grouped Mermaid directives with later values winning', () => {
+    const chart = parse(`%%{init: {
+      "xyChart": {
+        "showDataLabel": false,
+        "xAxis": { "showLabel": true }
+      }
+    }}%%
+%%{initialize: {
+      "xyChart": {
+        "showDataLabel": true,
+        "xAxis": { "showLabel": false }
+      },
+      "themeVariables": {
+        "xyChart": {
+          "plotColorPalette": ["#ff6b6b", "#0ea5e9"]
+        }
+      }
+    }}%%
+xychart
+  x-axis [Q1, Q2]
+  bar [30, 60]`)
+
+    expect(chart.config.showDataLabel).toBe(true)
+    expect(chart.config.xAxis?.showLabel).toBe(false)
+    expect(chart.theme.plotColorPalette).toEqual(['#ff6b6b', '#0ea5e9'])
+  })
+
+  it('accepts the Mermaid initialize alias for directives', () => {
+    const chart = parse(`%%{initialize: {
+      "xyChart": {
+        "showDataLabel": true
+      }
+    }}%%
+xychart
+  x-axis [Q1, Q2]
+  bar [30, 60]`)
+
+    expect(chart.config.showDataLabel).toBe(true)
+  })
+
+  it('parses the full documented Mermaid xychart config surface', () => {
+    const chart = parse(`---
+config:
+  xyChart:
+    width: 640
+    height: 320
+    titleFontSize: 24
+    titlePadding: 12
+    showDataLabel: true
+    showTitle: true
+    chartOrientation: horizontal
+    plotReservedSpacePercent: 62
+    xAxis:
+      showLabel: false
+      labelFontSize: 13
+      labelPadding: 7
+      showTitle: false
+      titleFontSize: 15
+      titlePadding: 8
+      showTick: false
+      tickLength: 9
+      tickWidth: 3
+      showAxisLine: false
+      axisLineWidth: 4
+    yAxis:
+      showLabel: true
+      labelFontSize: 12
+      labelPadding: 6
+      showTitle: true
+      titleFontSize: 17
+      titlePadding: 10
+      showTick: true
+      tickLength: 11
+      tickWidth: 5
+      showAxisLine: true
+      axisLineWidth: 6
+  themeVariables:
+    xyChart:
+      backgroundColor: "#fdfaf5"
+      titleColor: "#102030"
+      xAxisLabelColor: "#203040"
+      xAxisTickColor: "#304050"
+      xAxisLineColor: "#405060"
+      xAxisTitleColor: "#506070"
+      yAxisLabelColor: "#607080"
+      yAxisTickColor: "#708090"
+      yAxisLineColor: "#8090a0"
+      yAxisTitleColor: "#90a0b0"
+      plotColorPalette: "#ff6b6b, #0ea5e9"
+---
+xychart
+  title Revenue
+  x-axis Month [Jan, Feb]
+  y-axis Users 0 --> 100
+  bar [30, 60]`)
+
+    expect(chart.config).toEqual({
+      width: 640,
+      height: 320,
+      useMaxWidth: undefined,
+      useWidth: undefined,
+      titleFontSize: 24,
+      titlePadding: 12,
+      showDataLabel: true,
+      showTitle: true,
+      chartOrientation: 'horizontal',
+      plotReservedSpacePercent: 62,
+      xAxis: {
+        showLabel: false,
+        labelFontSize: 13,
+        labelPadding: 7,
+        showTitle: false,
+        titleFontSize: 15,
+        titlePadding: 8,
+        showTick: false,
+        tickLength: 9,
+        tickWidth: 3,
+        showAxisLine: false,
+        axisLineWidth: 4,
+      },
+      yAxis: {
+        showLabel: true,
+        labelFontSize: 12,
+        labelPadding: 6,
+        showTitle: true,
+        titleFontSize: 17,
+        titlePadding: 10,
+        showTick: true,
+        tickLength: 11,
+        tickWidth: 5,
+        showAxisLine: true,
+        axisLineWidth: 6,
+      },
+    })
+    expect(chart.theme).toEqual({
+      backgroundColor: '#fdfaf5',
+      themeCss: undefined,
+      titleColor: '#102030',
+      xAxisLabelColor: '#203040',
+      xAxisTickColor: '#304050',
+      xAxisLineColor: '#405060',
+      xAxisTitleColor: '#506070',
+      yAxisLabelColor: '#607080',
+      yAxisTickColor: '#708090',
+      yAxisLineColor: '#8090a0',
+      yAxisTitleColor: '#90a0b0',
+      plotColorPalette: ['#ff6b6b', '#0ea5e9'],
+    })
+  })
+
+  it('parses YAML palette lists and block-scalar themeCSS from frontmatter', () => {
+    const chart = parse(`---
+  config:
+    themeCSS: |
+      .xychart-title { letter-spacing: 0.08em; }
+    xyChart:
+      xAxis:
+        showLabel: false
+  themeVariables:
+    xyChart:
+      plotColorPalette:
+        - "#ff0000"
+        - "#00ff00"
+---
+xychart
+  bar [10, 20]`)
+
+    expect(chart.config.xAxis?.showLabel).toBe(false)
+    expect(chart.theme.plotColorPalette).toEqual(['#ff0000', '#00ff00'])
+    expect(chart.theme.themeCss).toContain('.xychart-title { letter-spacing: 0.08em; }')
+  })
+
+  it('uses header orientation ahead of frontmatter orientation', () => {
+    const chart = parse(`---
+config:
+  xyChart:
+    chartOrientation: vertical
+---
+xychart horizontal
+  x-axis [A, B, C]
+  bar [1, 2, 3]`)
+
+    expect(chart.horizontal).toBe(true)
+  })
+
+  it('lets later init directives override YAML frontmatter when both are present', () => {
+    const chart = parse(`---
+config:
+  xyChart:
+    showDataLabel: false
+---
+%%{init: { "xyChart": { "showDataLabel": true } }}%%
+xychart
+  x-axis [A, B]
+  bar [1, 2]`)
+
+    expect(chart.config.showDataLabel).toBe(true)
+  })
+
+  it('auto-derives a y-axis range when malformed directives are ignored', () => {
+    const chart = parse(`xychart
+      x-axis not-a-range --> still-not-a-range
+      y-axis nope --> ???
+      bar [10, 20, 30]`)
+
+    expect(chart.xAxis.range).toBeUndefined()
+    expect(chart.yAxis.title).toBeUndefined()
+    expect(chart.yAxis.range).toBeDefined()
+    expect(chart.yAxis.range!.min).toBe(0)
+    expect(chart.yAxis.range!.max).toBeGreaterThan(30)
+  })
+
+  it('ignores unsupported categorical y-axis syntax instead of treating it as valid data', () => {
+    const chart = parse(`xychart
+      y-axis [Low, Medium, High]
+      bar [10, 20, 30]`)
+
+    expect(chart.yAxis.categories).toBeUndefined()
+    expect(chart.yAxis.range).toBeDefined()
+  })
+
+  it('falls back to the default y-axis range when there is no series data', () => {
+    const chart = parse(`xychart
+      title Empty
+      x-axis [A, B, C]`)
+
+    expect(chart.series).toHaveLength(0)
+    expect(chart.yAxis.range).toEqual({ min: 0, max: 100 })
+  })
+})

--- a/src/__tests__/xychart-renderer.test.ts
+++ b/src/__tests__/xychart-renderer.test.ts
@@ -1,0 +1,182 @@
+/**
+ * Tests for the xychart SVG renderer.
+ *
+ * Uses the real xychart parse/layout pipeline to produce positioned charts,
+ * then asserts renderer-specific SVG structure and escaping behavior.
+ */
+import { describe, it, expect } from 'bun:test'
+import { preprocessMermaidSource } from '../mermaid-source.ts'
+import { parseXYChart } from '../xychart/parser.ts'
+import { layoutXYChart } from '../xychart/layout.ts'
+import { renderXYChartSvg } from '../xychart/renderer.ts'
+import type { DiagramColors } from '../theme.ts'
+
+const lightColors: DiagramColors = { bg: '#FFFFFF', fg: '#27272A' }
+
+function render(text: string, interactive: boolean = false) {
+  const processed = preprocessMermaidSource(text)
+  const chart = layoutXYChart(parseXYChart(processed.lines, processed.frontmatter))
+  return renderXYChartSvg(chart, lightColors, 'Inter', false, interactive)
+}
+
+describe('renderXYChartSvg – structure', () => {
+  it('emits semantic grid, axis, tick, bar, and line classes', () => {
+    const svg = render(`xychart
+      x-axis [Q1, Q2, Q3]
+      y-axis Revenue 0 --> 100
+      bar [10, 20, 30]
+      line [15, 25, 35]`)
+
+    expect(svg).toContain('data-xychart-colors="1"')
+    expect(svg).toContain('class="xychart-grid"')
+    expect(svg).toContain('class="xychart-axis-line xychart-x-axis-line"')
+    expect(svg).toContain('class="xychart-axis-line xychart-y-axis-line"')
+    expect(svg).toContain('class="xychart-tick xychart-x-tick"')
+    expect(svg).toContain('class="xychart-tick xychart-y-tick"')
+    expect(svg).toContain('class="xychart-bar xychart-color-0"')
+    expect(svg).toContain('class="xychart-line xychart-color-1"')
+  })
+
+  it('escapes text nodes and data-label attributes', () => {
+    const svg = render(`xychart
+      title "Revenue < Growth"
+      x-axis "Team <Label>" ["R&D", "<Q2>", "Ops & Support"]
+      y-axis "Users > Total" 0 --> 100
+      bar [30, 60, 45]`)
+
+    expect(svg).toContain('Revenue &lt; Growth')
+    expect(svg).toContain('Team &lt;Label&gt;')
+    expect(svg).toContain('Users &gt; Total')
+    expect(svg).toContain('data-label="R&amp;D"')
+    expect(svg).toContain('data-label="&lt;Q2&gt;"')
+    expect(svg).toContain('Ops &amp; Support')
+  })
+})
+
+describe('renderXYChartSvg – theming and interactivity', () => {
+  it('uses theme overrides and renders bar-only data labels', () => {
+    const svg = render(`---
+config:
+  xyChart:
+    showDataLabel: true
+  themeVariables:
+    xyChart:
+      xAxisLineColor: "#112233"
+      yAxisTickColor: "#445566"
+      plotColorPalette: "#ff0000, #00ff00"
+---
+xychart
+  title Revenue
+  x-axis [A, B, C]
+  y-axis Users 0 --> 100
+  bar [10, 20, 30]
+  line [15, 25, 35]`)
+
+    expect(svg).toContain('--xychart-color-0: #ff0000;')
+    expect(svg).toContain('--xychart-color-1: #00ff00;')
+    expect(svg).toContain('.xychart-x-axis-line { stroke: #112233; }')
+    expect(svg).toContain('.xychart-y-tick { stroke: #445566; }')
+    expect(svg.match(/class="xychart-data-label"/g)?.length ?? 0).toBe(3)
+  })
+
+  it('renders the full documented Mermaid xychart style surface', () => {
+    const svg = render(`---
+config:
+  xyChart:
+    width: 640
+    height: 320
+    titleFontSize: 24
+    titlePadding: 12
+    showTitle: true
+    xAxis:
+      showLabel: false
+      showTitle: false
+      showTick: false
+      showAxisLine: false
+    yAxis:
+      labelFontSize: 13
+      titleFontSize: 17
+      tickWidth: 5
+      axisLineWidth: 4
+  themeVariables:
+    xyChart:
+      titleColor: "#102030"
+      yAxisLabelColor: "#304050"
+      yAxisTickColor: "#506070"
+      yAxisLineColor: "#708090"
+      yAxisTitleColor: "#90a0b0"
+      plotColorPalette: "#ff0000, #00ff00"
+---
+xychart
+  title Revenue
+  x-axis Month [Jan, Feb, Mar]
+  y-axis Users 0 --> 100
+  bar [10, 20, 30]
+  line [15, 25, 35]`)
+
+    expect(svg).toContain('viewBox="0 0 640 320"')
+    expect(svg).toContain('width="100%"')
+    expect(svg).toContain('height="100%"')
+    expect(svg).toContain('max-width:640px')
+    expect(svg).toContain('--xychart-color-0: #ff0000;')
+    expect(svg).toContain('--xychart-color-1: #00ff00;')
+    expect(svg).toContain('.xychart-title { fill: #102030; }')
+    expect(svg).toContain('.xychart-y-label { fill: #304050; }')
+    expect(svg).toContain('.xychart-y-tick { stroke: #506070; }')
+    expect(svg).toContain('.xychart-y-axis-line { stroke: #708090; }')
+    expect(svg).toContain('.xychart-y-axis-title { fill: #90a0b0; }')
+    expect(svg).not.toContain('class="xychart-label xychart-x-label"')
+    expect(svg).not.toContain('class="xychart-axis-title xychart-x-axis-title"')
+    expect(svg).not.toContain('class="xychart-tick xychart-x-tick"')
+    expect(svg).not.toContain('class="xychart-axis-line xychart-x-axis-line"')
+    expect(svg).toContain('class="xychart-tick xychart-y-tick" stroke-width="5"')
+    expect(svg).toContain('class="xychart-axis-line xychart-y-axis-line" stroke-width="4"')
+    expect(svg).toContain('dominant-baseline="middle"')
+    expect(svg).toContain('font-size="13" font-weight="400"')
+    expect(svg).toContain('font-size="17" font-weight="400" dy="0.35em" class="xychart-axis-title xychart-y-axis-title">Users</text>')
+  })
+
+  it('renders tooltip groups and line dots only when interactive', () => {
+    const source = `xychart
+      x-axis [Q1, Q2, Q3]
+      y-axis Revenue 0 --> 100
+      bar [10, 20, 30]
+      line [15, 25, 35]`
+
+    const staticSvg = render(source, false)
+    expect(staticSvg).not.toContain('xychart-bar-group')
+    expect(staticSvg).not.toContain('xychart-dot-group')
+
+    const interactiveSvg = render(source, true)
+    expect(interactiveSvg).toContain('xychart-bar-group')
+    expect(interactiveSvg).toContain('xychart-dot-group')
+    expect(interactiveSvg).toContain('xychart-tip xychart-tip-bg')
+  })
+
+  it('emits fixed SVG sizing when Mermaid useMaxWidth is disabled', () => {
+    const svg = render(`---
+config:
+  useMaxWidth: false
+  useWidth: 900
+---
+xychart
+  bar [10, 20]`)
+
+    expect(svg).toContain('width="900"')
+    expect(svg).toContain('height="643"')
+    expect(svg).not.toContain('max-width:')
+  })
+
+  it('appends Mermaid themeCSS from frontmatter to the SVG styles', () => {
+    const svg = render(`---
+config:
+  themeCSS: |
+    .xychart-title { letter-spacing: 0.08em; }
+---
+xychart
+  title Revenue
+  bar [10, 20]`)
+
+    expect(svg).toContain('.xychart-title { letter-spacing: 0.08em; }')
+  })
+})

--- a/src/ascii/index.ts
+++ b/src/ascii/index.ts
@@ -129,7 +129,7 @@ export function renderMermaidASCII(
 
   switch (diagramType) {
     case 'xychart':
-      return renderXYChartAscii(normalizedSource.text, config, colorMode, theme)
+      return renderXYChartAscii(normalizedSource.text, config, colorMode, theme, normalizedSource.frontmatter)
 
     case 'sequence':
       return renderSequenceAscii(normalizedSource.text, config, colorMode, theme)

--- a/src/ascii/xychart.ts
+++ b/src/ascii/xychart.ts
@@ -1,7 +1,7 @@
 // ============================================================================
 // ASCII renderer — XY Chart
 //
-// Renders xychart-beta diagrams to ASCII/Unicode text art.
+// Renders xychart / xychart-beta diagrams to ASCII/Unicode text art.
 // Uses the parsed XYChart type directly (not PositionedXYChart) since
 // pixel coordinates don't map to character grids.
 //
@@ -13,9 +13,10 @@
 
 import { parseXYChart } from '../xychart/parser.ts'
 import type { XYChart } from '../xychart/types.ts'
+import type { MermaidFrontmatterMap } from '../mermaid-source.ts'
 import type { AsciiConfig, AsciiTheme, ColorMode, CharRole, Canvas, RoleCanvas } from './types.ts'
 import { colorizeText } from './ansi.ts'
-import { getSeriesColor, CHART_ACCENT_FALLBACK } from '../xychart/colors.ts'
+import { getSeriesColor, CHART_ACCENT_FALLBACK, isValidHex } from '../xychart/colors.ts'
 
 // ============================================================================
 // Constants
@@ -62,7 +63,13 @@ const ASC = {
 type HexCanvas = (string | null)[][]
 
 /** Generate an array of hex colors, one per series. */
-function getSeriesColors(total: number, theme: AsciiTheme): string[] {
+function getSeriesColors(total: number, theme: AsciiTheme, palette?: string[]): string[] {
+  if (palette && palette.length > 0) {
+    const usable = palette.filter(isValidHex)
+    if (usable.length > 0) {
+      return Array.from({ length: total }, (_, i) => usable[i % usable.length]!)
+    }
+  }
   const accent = theme.accent ?? CHART_ACCENT_FALLBACK
   if (total <= 1) return [accent]
   return Array.from({ length: total }, (_, i) => getSeriesColor(i, accent, theme.bg))
@@ -90,9 +97,10 @@ export function renderXYChartAscii(
   config: AsciiConfig,
   colorMode: ColorMode,
   theme: AsciiTheme,
+  frontmatter: MermaidFrontmatterMap = {},
 ): string {
   const lines = text.split('\n').map(l => l.trim()).filter(l => l.length > 0 && !l.startsWith('%%'))
-  const chart = parseXYChart(lines)
+  const chart = parseXYChart(lines, frontmatter)
   const ch = config.useAscii ? ASC : UNI
 
   if (chart.horizontal) {
@@ -117,7 +125,9 @@ function renderVertical(
   const yRange = chart.yAxis.range!
   const yTicks = niceTickValues(yRange.min, yRange.max)
   const yLabels = yTicks.map(v => formatTickValue(v))
-  const yGutter = Math.max(...yLabels.map(l => l.length)) + 1
+  const showYLabels = chart.config.yAxis?.showLabel !== false
+  const showXLabels = chart.config.xAxis?.showLabel !== false
+  const yGutter = showYLabels ? Math.max(...yLabels.map(l => l.length)) + 1 : 0
 
   const plotW = Math.max(PLOT_WIDTH, dataCount * 6)
   const plotH = PLOT_HEIGHT
@@ -125,17 +135,17 @@ function renderVertical(
   const catLabels = getCategoryLabels(chart, dataCount)
 
   // Canvas dimensions
-  const hasTitle = !!chart.title
-  const hasXTitle = !!chart.xAxis.title
+  const hasTitle = !!chart.title && chart.config.showTitle !== false
+  const hasXTitle = !!chart.xAxis.title && chart.config.xAxis?.showTitle !== false
   const hasLegend = chart.series.length > 1
   const titleRow = hasTitle ? 0 : -1
   const plotTop = (hasTitle ? 2 : 0) + (hasLegend ? 1 : 0)
   const plotLeft = yGutter + 1 // +1 for axis character
   const totalW = plotLeft + bandW * dataCount + 2
   const xAxisRow = plotTop + plotH
-  const xLabelRow = xAxisRow + 1
-  const xTitleRow = hasXTitle ? xLabelRow + 1 : -1
-  const totalH = xLabelRow + 1 + (hasXTitle ? 1 : 0) + (hasLegend && !hasTitle ? 0 : 0)
+  const xLabelRow = showXLabels ? xAxisRow + 1 : -1
+  const xTitleRow = hasXTitle ? xAxisRow + (showXLabels ? 2 : 1) : -1
+  const totalH = xAxisRow + 1 + (showXLabels ? 1 : 0) + (hasXTitle ? 1 : 0)
 
   // Create canvas
   const canvas = createCanvas(totalW, totalH)
@@ -143,7 +153,7 @@ function renderVertical(
   const hexColors = createHexCanvas(totalW, totalH)
 
   // Series colors
-  const seriesColors = getSeriesColors(chart.series.length, theme)
+  const seriesColors = getSeriesColors(chart.series.length, theme, chart.theme.plotColorPalette)
 
   // Scales
   const valueToRow = (v: number): number => {
@@ -179,8 +189,10 @@ function renderVertical(
     // Tick mark on axis
     set(canvas, roles, displayRow, plotLeft - 1, row === 0 ? ch.origin : ch.yTick, 'border')
     // Label
-    const labelStart = yGutter - label.length
-    writeText(canvas, roles, displayRow, Math.max(0, labelStart), label, 'text')
+    if (showYLabels) {
+      const labelStart = yGutter - label.length
+      writeText(canvas, roles, displayRow, Math.max(0, labelStart), label, 'text')
+    }
   }
 
   // 4. X-axis line + ticks + labels
@@ -190,10 +202,11 @@ function renderVertical(
   for (let i = 0; i < dataCount; i++) {
     const cx = bandCenter(i)
     set(canvas, roles, xAxisRow, cx, ch.xTick, 'border')
-    // Label below
-    const label = catLabels[i]!
-    const labelStart = cx - Math.floor(label.length / 2)
-    writeText(canvas, roles, xLabelRow, Math.max(0, labelStart), label, 'text')
+    if (showXLabels && xLabelRow >= 0) {
+      const label = catLabels[i]!
+      const labelStart = cx - Math.floor(label.length / 2)
+      writeText(canvas, roles, xLabelRow, Math.max(0, labelStart), label, 'text')
+    }
   }
 
   // 5. X-axis title
@@ -244,6 +257,17 @@ function renderVertical(
             set(canvas, roles, displayRow, c, ch.bar, 'arrow', hexColors, hexColor)
           }
         }
+
+        if (chart.config.showDataLabel) {
+          const label = formatTickValue(entry.data[i]!)
+          const topDisplayRow = plotTop + (plotH - 1 - toRow)
+          const bottomDisplayRow = plotTop + (plotH - 1 - fromRow)
+          const labelRow = entry.data[i]! >= 0
+            ? Math.max(plotTop, topDisplayRow - 1)
+            : Math.min(xAxisRow - 1, bottomDisplayRow + 1)
+          const labelCol = Math.max(plotLeft, cx - Math.floor(label.length / 2))
+          writeColoredText(canvas, roles, hexColors, labelRow, labelCol, label, 'text', hexColor)
+        }
       }
     }
   }
@@ -254,7 +278,8 @@ function renderVertical(
     if (chart.series[si]!.type === 'line') lineEntries.push({ data: chart.series[si]!.data, globalIdx: si })
   }
 
-  for (const entry of lineEntries) {
+  for (let lineIdx = 0; lineIdx < lineEntries.length; lineIdx++) {
+    const entry = lineEntries[lineIdx]!
     if (entry.data.length === 0) continue
     const hexColor = seriesColors[entry.globalIdx]!
     drawStaircaseLine(canvas, roles, entry.data, bandCenter, valueToRow, plotTop, plotH, plotLeft, bandW * dataCount, ch, hexColors, hexColor)
@@ -279,19 +304,22 @@ function renderHorizontal(
   const yRange = chart.yAxis.range!
   const valueTicks = niceTickValues(yRange.min, yRange.max)
   const catLabels = getCategoryLabels(chart, dataCount)
-  const catGutter = Math.max(...catLabels.map(l => l.length)) + 1
+  const showCategoryLabels = chart.config.xAxis?.showLabel !== false
+  const showValueLabels = chart.config.yAxis?.showLabel !== false
+  const catGutter = showCategoryLabels ? Math.max(...catLabels.map(l => l.length)) + 1 : 0
 
   const plotW = Math.max(PLOT_WIDTH, 40)
   const bandH = Math.max(2, Math.floor(PLOT_HEIGHT / dataCount))
   const plotH = bandH * dataCount
 
-  const hasTitle = !!chart.title
-  const hasYTitle = !!chart.yAxis.title
+  const hasTitle = !!chart.title && chart.config.showTitle !== false
+  const hasYTitle = !!chart.yAxis.title && chart.config.yAxis?.showTitle !== false
   const hasLegend = chart.series.length > 1
   const plotTop = (hasTitle ? 2 : 0) + (hasLegend ? 1 : 0)
   const plotLeft = catGutter + 1
-  const totalW = plotLeft + plotW + 2
-  const totalH = plotTop + plotH + 2 + (hasYTitle ? 1 : 0)
+  const dataLabelPad = chart.config.showDataLabel ? 12 : 2
+  const totalW = plotLeft + plotW + dataLabelPad
+  const totalH = plotTop + plotH + 1 + (showValueLabels ? 1 : 0) + (hasYTitle ? 1 : 0)
   const xAxisRow = plotTop + plotH
 
   const canvas = createCanvas(totalW, totalH)
@@ -299,7 +327,7 @@ function renderHorizontal(
   const hexColors = createHexCanvas(totalW, totalH)
 
   // Series colors
-  const seriesColors = getSeriesColors(chart.series.length, theme)
+  const seriesColors = getSeriesColors(chart.series.length, theme, chart.theme.plotColorPalette)
 
   // Value scale (horizontal)
   const valueToCol = (v: number): number => {
@@ -328,8 +356,10 @@ function renderHorizontal(
   for (let i = 0; i < dataCount; i++) {
     const my = bandMid(i)
     const label = catLabels[i]!
-    const labelStart = catGutter - label.length
-    writeText(canvas, roles, my, Math.max(0, labelStart), label, 'text')
+    if (showCategoryLabels) {
+      const labelStart = catGutter - label.length
+      writeText(canvas, roles, my, Math.max(0, labelStart), label, 'text')
+    }
   }
 
   // X-axis (value axis on bottom)
@@ -340,8 +370,10 @@ function renderHorizontal(
     const cx = valueToCol(tick)
     if (cx < plotLeft || cx >= plotLeft + plotW) continue
     set(canvas, roles, xAxisRow, cx, ch.xTick, 'border')
-    const label = formatTickValue(tick)
-    writeText(canvas, roles, xAxisRow + 1, cx - Math.floor(label.length / 2), label, 'text')
+    if (showValueLabels) {
+      const label = formatTickValue(tick)
+      writeText(canvas, roles, xAxisRow + 1, cx - Math.floor(label.length / 2), label, 'text')
+    }
   }
 
   // Y-axis title
@@ -389,6 +421,14 @@ function renderHorizontal(
             set(canvas, roles, r, c, ch.bar, 'arrow', hexColors, hexColor)
           }
         }
+
+        if (chart.config.showDataLabel) {
+          const label = formatTickValue(entry.data[i]!)
+          const labelCol = entry.data[i]! >= 0
+            ? Math.min(totalW - label.length, toCol + 2)
+            : Math.max(plotLeft, fromCol - label.length - 1)
+          writeColoredText(canvas, roles, hexColors, by, labelCol, label, 'text', hexColor)
+        }
       }
     }
   }
@@ -399,7 +439,8 @@ function renderHorizontal(
     if (chart.series[si]!.type === 'line') lineEntries.push({ data: chart.series[si]!.data, globalIdx: si })
   }
 
-  for (const entry of lineEntries) {
+  for (let lineIdx = 0; lineIdx < lineEntries.length; lineIdx++) {
+    const entry = lineEntries[lineIdx]!
     if (entry.data.length === 0) continue
     const hexColor = seriesColors[entry.globalIdx]!
     drawHorizontalStaircaseLine(canvas, roles, entry.data, bandMid, valueToCol, plotTop, plotH, plotLeft, plotW, ch, hexColors, hexColor)
@@ -704,6 +745,21 @@ function get(canvas: Canvas, row: number, col: number): string {
 function writeText(canvas: Canvas, roles: RoleCanvas, row: number, startCol: number, text: string, role: CharRole): void {
   for (let i = 0; i < text.length; i++) {
     set(canvas, roles, row, startCol + i, text[i]!, role)
+  }
+}
+
+function writeColoredText(
+  canvas: Canvas,
+  roles: RoleCanvas,
+  hexCanvas: HexCanvas,
+  row: number,
+  startCol: number,
+  text: string,
+  role: CharRole,
+  hex: string,
+): void {
+  for (let i = 0; i < text.length; i++) {
+    set(canvas, roles, row, startCol + i, text[i]!, role, hexCanvas, hex)
   }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -75,10 +75,26 @@ function detectDiagramType(firstLine: string): 'flowchart' | 'sequence' | 'class
  * Uses DEFAULTS for bg/fg when not provided, and passes through
  * optional enrichment colors (line, accent, muted, surface, border).
  */
+const ZINC_DARK = THEMES['zinc-dark'] ?? { bg: '#18181B', fg: '#FAFAFA' }
+
+const MERMAID_THEME_COLORS: Record<string, DiagramColors> = {
+  default: { bg: DEFAULTS.bg, fg: DEFAULTS.fg },
+  base: { bg: DEFAULTS.bg, fg: DEFAULTS.fg },
+  neutral: { bg: '#ffffff', fg: '#1f2937', line: '#9ca3af', accent: '#6b7280', muted: '#6b7280' },
+  dark: {
+    bg: ZINC_DARK.bg,
+    fg: ZINC_DARK.fg,
+    line: ZINC_DARK.line,
+    accent: ZINC_DARK.accent,
+    muted: ZINC_DARK.muted,
+    surface: ZINC_DARK.surface,
+    border: ZINC_DARK.border,
+  },
+  forest: { bg: '#f0fdf4', fg: '#14532d', line: '#4d7c0f', accent: '#15803d', muted: '#65a30d', border: '#86efac' },
+}
+
 function buildColors(options: RenderOptions, config: MermaidRuntimeConfig): DiagramColors {
-  const theme = config.theme && config.theme in THEMES
-    ? THEMES[config.theme as keyof typeof THEMES]
-    : undefined
+  const theme = resolveThemeColors(config.theme)
   const vars = config.themeVariables
 
   return {
@@ -90,6 +106,12 @@ function buildColors(options: RenderOptions, config: MermaidRuntimeConfig): Diag
     surface: options.surface ?? readThemeValue(vars, 'primaryColor', 'nodeBkg', 'mainBkg') ?? theme?.surface,
     border: options.border ?? readThemeValue(vars, 'primaryBorderColor', 'secondaryBorderColor') ?? theme?.border,
   }
+}
+
+function resolveThemeColors(themeName: string | undefined): DiagramColors | undefined {
+  if (!themeName) return undefined
+  if (themeName in THEMES) return THEMES[themeName as keyof typeof THEMES]
+  return MERMAID_THEME_COLORS[themeName.toLowerCase()]
 }
 
 function readThemeValue(vars: MermaidThemeVariables | undefined, ...keys: string[]): string | undefined {
@@ -178,9 +200,12 @@ export function renderMermaidSVG(
       )
     }
     case 'xychart': {
-      const chart = parseXYChart(lines)
+      const chart = parseXYChart(lines, normalizedSource.frontmatter)
       const positioned = layoutXYChart(chart, options)
-      return renderXYChartSvg(positioned, colors, font, transparent, options.interactive ?? false)
+      const chartColors = !options.bg && chart.theme.backgroundColor
+        ? { ...colors, bg: chart.theme.backgroundColor }
+        : colors
+      return renderXYChartSvg(positioned, chartColors, font, transparent, options.interactive ?? false)
     }
     case 'flowchart':
     default: {

--- a/src/mermaid-source.ts
+++ b/src/mermaid-source.ts
@@ -5,28 +5,48 @@
 //   - UTF-8 BOM stripping
 //   - leading YAML frontmatter
 //   - Mermaid directives / init blocks (%%{init: ...}%%)
-//   - Mermaid comment stripping (%% ...)
+//   - Mermaid comment stripping for downstream line-based parsers
 //   - normalized, trimmed diagram lines for downstream parsers
 // ============================================================================
 
-export type MermaidConfigScalar = string | number | boolean
+export type MermaidConfigScalar = string | number | boolean | null
+export type MermaidConfigValue = MermaidConfigScalar | MermaidConfigValue[] | MermaidConfigMap
 
-export interface MermaidThemeVariables {
-  fontFamily?: string
-  [key: string]: MermaidConfigScalar | undefined
+export interface MermaidConfigMap {
+  [key: string]: MermaidConfigValue | undefined
 }
 
-export interface TimelineRuntimeConfig {
+export type MermaidFrontmatterScalar = MermaidConfigScalar
+export type MermaidFrontmatterValue = MermaidConfigValue
+export type MermaidFrontmatterList = MermaidFrontmatterValue[]
+
+export interface MermaidFrontmatterMap extends MermaidConfigMap {}
+
+export interface MermaidThemeVariables extends MermaidConfigMap {
+  fontFamily?: string
+}
+
+export interface TimelineRuntimeConfig extends MermaidConfigMap {
   disableMulticolor?: boolean
   sectionFills?: string[]
   sectionColours?: string[]
 }
 
-export interface MermaidRuntimeConfig {
+export interface MermaidRuntimeConfig extends MermaidConfigMap {
   theme?: string
   fontFamily?: string
   themeVariables?: MermaidThemeVariables
   timeline?: TimelineRuntimeConfig
+  xyChart?: MermaidConfigMap
+  useMaxWidth?: boolean
+  useWidth?: number
+  themeCSS?: string
+}
+
+export interface ProcessedMermaidSource {
+  body: string
+  lines: string[]
+  frontmatter: MermaidFrontmatterMap
 }
 
 export interface NormalizedMermaidSource {
@@ -34,79 +54,187 @@ export interface NormalizedMermaidSource {
   lines: string[]
   firstLine: string
   config: MermaidRuntimeConfig
+  frontmatter: MermaidFrontmatterMap
 }
+
+const FRONTMATTER_REGEX = /^\uFEFF?\s*---\s*\r?\n([\s\S]*?)\r?\n\s*---\s*(?:\r?\n|$)/
+const INIT_DIRECTIVE_REGEX = /^\s*%%\{\s*(?:init|initialize)\s*:\s*([\s\S]*?)\}\s*%%\s*(?:\r?\n|$)?/gm
 
 export function normalizeMermaidSource(
   text: string,
   baseConfig: MermaidRuntimeConfig = {},
 ): NormalizedMermaidSource {
-  const rawLines = text.replace(/^\uFEFF/, '').split('\n')
-  let index = 0
-  let config = mergeMermaidConfigs(baseConfig)
-
-  while (index < rawLines.length && rawLines[index]!.trim().length === 0) {
-    index++
-  }
-
-  if (rawLines[index]?.trim() === '---') {
-    const frontmatter = collectFrontmatter(rawLines, index)
-    if (frontmatter) {
-      config = mergeMermaidConfigs(config, frontmatter.config)
-      index = frontmatter.nextIndex
-    }
-  }
-
-  const lines: string[] = []
-
-  while (index < rawLines.length) {
-    const rawLine = rawLines[index]!
-    const trimmed = rawLine.trim()
-
-    if (trimmed.startsWith('%%{')) {
-      const directive = collectDirective(rawLines, index)
-      config = mergeMermaidConfigs(config, directive.config)
-      index = directive.nextIndex
-      continue
-    }
-
-    if (trimmed.length > 0 && !trimmed.startsWith('%%')) {
-      lines.push(trimmed)
-    }
-
-    index++
-  }
+  const processed = preprocessMermaidSource(text, runtimeConfigToFrontmatterMap(baseConfig))
 
   return {
-    text: lines.join('\n'),
-    lines,
-    firstLine: lines[0]?.toLowerCase() ?? '',
-    config,
+    text: processed.lines.join('\n'),
+    lines: processed.lines,
+    firstLine: processed.lines[0]?.toLowerCase() ?? '',
+    config: normalizeMermaidRuntimeConfig(processed.frontmatter),
+    frontmatter: processed.frontmatter,
   }
+}
+
+export function preprocessMermaidSource(
+  text: string,
+  baseFrontmatter: MermaidFrontmatterMap = {},
+): ProcessedMermaidSource {
+  const frontmatterMatch = text.match(FRONTMATTER_REGEX)
+  const yamlFrontmatter = frontmatterMatch ? canonicalizeFrontmatterMap(parseFrontmatter(frontmatterMatch[1]!)) : {}
+  const rawBody = frontmatterMatch ? text.slice(frontmatterMatch[0].length) : text
+  const { body, frontmatter: directiveFrontmatter } = extractInitDirectives(rawBody)
+  const frontmatter = mergeFrontmatterMaps(
+    mergeFrontmatterMaps(canonicalizeFrontmatterMap(baseFrontmatter), yamlFrontmatter),
+    canonicalizeFrontmatterMap(directiveFrontmatter),
+  )
+
+  return {
+    body,
+    lines: toMermaidLines(body),
+    frontmatter,
+  }
+}
+
+export function toMermaidLines(text: string): string[] {
+  return text
+    .replace(/^\uFEFF/, '')
+    .split(/\r?\n/)
+    .map(line => line.trim())
+    .filter(line => line.length > 0 && !line.startsWith('%%'))
 }
 
 export function mergeMermaidConfigs(...configs: MermaidRuntimeConfig[]): MermaidRuntimeConfig {
-  const merged: Record<string, unknown> = {}
+  const merged: MermaidFrontmatterMap = {}
 
   for (const config of configs) {
-    mergeInto(merged, config as Record<string, unknown>)
+    mergeInto(merged, runtimeConfigToFrontmatterMap(config))
   }
 
-  return merged as MermaidRuntimeConfig
+  return normalizeMermaidRuntimeConfig(merged)
 }
 
-function mergeInto(target: Record<string, unknown>, source: Record<string, unknown> | undefined): void {
+export function mergeFrontmatterMaps(
+  base: MermaidFrontmatterMap,
+  override: MermaidFrontmatterMap,
+): MermaidFrontmatterMap {
+  const merged = cloneFrontmatterMap(base)
+
+  for (const [key, value] of Object.entries(override)) {
+    if (value === undefined) continue
+
+    const existing = merged[key]
+    if (isFrontmatterMap(existing) && isFrontmatterMap(value)) {
+      merged[key] = mergeFrontmatterMaps(existing, value)
+      continue
+    }
+
+    merged[key] = cloneFrontmatterValue(value)
+  }
+
+  return merged
+}
+
+export function getFrontmatterMap(
+  root: MermaidFrontmatterMap,
+  path: readonly string[],
+): MermaidFrontmatterMap | undefined {
+  let current: MermaidFrontmatterValue | undefined = root
+  for (const segment of path) {
+    if (!isFrontmatterMap(current)) return undefined
+    current = current[segment]
+  }
+  return isFrontmatterMap(current) ? current : undefined
+}
+
+export function getFrontmatterScalar<T extends MermaidFrontmatterScalar>(
+  root: MermaidFrontmatterMap,
+  path: readonly string[],
+): T | undefined {
+  let current: MermaidFrontmatterValue | undefined = root
+  for (const segment of path) {
+    if (!isFrontmatterMap(current)) return undefined
+    current = current[segment]
+  }
+  return current !== undefined && !Array.isArray(current) && (typeof current !== 'object' || current === null)
+    ? current as T
+    : undefined
+}
+
+export function getFrontmatterList<T extends MermaidFrontmatterValue = MermaidFrontmatterValue>(
+  root: MermaidFrontmatterMap,
+  path: readonly string[],
+): T[] | undefined {
+  let current: MermaidFrontmatterValue | undefined = root
+  for (const segment of path) {
+    if (!isFrontmatterMap(current)) return undefined
+    current = current[segment]
+  }
+  return Array.isArray(current) ? current as T[] : undefined
+}
+
+function runtimeConfigToFrontmatterMap(config: MermaidRuntimeConfig): MermaidFrontmatterMap {
+  return canonicalizeFrontmatterMap(toFrontmatterMap(config) ?? {})
+}
+
+function normalizeMermaidRuntimeConfig(raw: MermaidFrontmatterMap): MermaidRuntimeConfig {
+  const config = cloneFrontmatterMap(raw) as MermaidRuntimeConfig
+
+  if (isFrontmatterMap(config.themeVariables)) {
+    config.themeVariables = cloneFrontmatterMap(config.themeVariables) as MermaidThemeVariables
+  }
+
+  if (isFrontmatterMap(config.timeline)) {
+    config.timeline = normalizeTimelineRuntimeConfig(config.timeline)
+  }
+
+  return config
+}
+
+function normalizeTimelineRuntimeConfig(raw: MermaidFrontmatterMap): TimelineRuntimeConfig {
+  const config = cloneFrontmatterMap(raw) as TimelineRuntimeConfig
+
+  if (typeof config.disableMulticolor !== 'boolean') {
+    delete config.disableMulticolor
+  }
+
+  const sectionFills = normalizeStringArray(config.sectionFills)
+  if (sectionFills.length > 0) {
+    config.sectionFills = sectionFills
+  } else {
+    delete config.sectionFills
+  }
+
+  const sectionColours = normalizeStringArray(config.sectionColours)
+  const sectionColors = normalizeStringArray((config as MermaidFrontmatterMap).sectionColors)
+  if (sectionColours.length > 0) {
+    config.sectionColours = sectionColours
+  } else if (sectionColors.length > 0) {
+    config.sectionColours = sectionColors
+  } else {
+    delete config.sectionColours
+  }
+
+  delete (config as MermaidFrontmatterMap).sectionColors
+  return config
+}
+
+function normalizeStringArray(value: MermaidConfigValue | undefined): string[] {
+  return Array.isArray(value) ? value.filter((entry): entry is string => typeof entry === 'string') : []
+}
+
+function mergeInto(target: MermaidFrontmatterMap, source: MermaidFrontmatterMap | undefined): void {
   if (!source) return
 
   for (const [key, value] of Object.entries(source)) {
     if (value === undefined) continue
 
     if (Array.isArray(value)) {
-      target[key] = value.slice()
+      target[key] = value.map(entry => cloneFrontmatterValue(entry)!)
       continue
     }
 
-    if (isPlainObject(value)) {
-      const existing = isPlainObject(target[key]) ? target[key] as Record<string, unknown> : {}
+    if (isFrontmatterMap(value)) {
+      const existing = isFrontmatterMap(target[key]) ? target[key] as MermaidFrontmatterMap : {}
       target[key] = existing
       mergeInto(existing, value)
       continue
@@ -116,483 +244,494 @@ function mergeInto(target: Record<string, unknown>, source: Record<string, unkno
   }
 }
 
-function collectFrontmatter(rawLines: string[], startIndex: number): { config: MermaidRuntimeConfig; nextIndex: number } | undefined {
-  const content: string[] = []
-  let index = startIndex + 1
+function canonicalizeFrontmatterMap(raw: MermaidFrontmatterMap): MermaidFrontmatterMap {
+  const topLevel = cloneFrontmatterMap(raw)
+  const configRoot = isFrontmatterMap(topLevel.config) ? topLevel.config : undefined
+  delete topLevel.config
 
-  while (index < rawLines.length && rawLines[index]!.trim() !== '---') {
-    content.push(rawLines[index]!)
-    index++
-  }
+  return configRoot ? mergeFrontmatterMaps(configRoot, topLevel) : topLevel
+}
 
-  if (index >= rawLines.length) return undefined
+function parseFrontmatter(text: string): MermaidFrontmatterMap {
+  const lines = text.split(/\r?\n/)
+  const firstIndex = skipYamlNoise(lines, 0)
+  if (firstIndex >= lines.length) return {}
 
-  const parsed = parseYamlDocument(content)
-  const frontmatter = isPlainObject(parsed) && isPlainObject(parsed.config)
-    ? parsed.config
-    : parsed
+  const baseIndent = getIndent(lines[firstIndex]!)
+  const state = { lines, index: firstIndex }
+  return parseYamlMap(state, baseIndent).value
+}
 
-  return {
-    config: normalizeMermaidRuntimeConfig(frontmatter),
-    nextIndex: index + 1,
+function extractInitDirectives(text: string): { body: string; frontmatter: MermaidFrontmatterMap } {
+  let merged: MermaidFrontmatterMap = {}
+
+  const body = text.replace(INIT_DIRECTIVE_REGEX, (_match, payload: string) => {
+    const parsed = parseDirectiveMap(payload)
+    if (parsed) merged = mergeFrontmatterMaps(merged, canonicalizeFrontmatterMap(parsed))
+    return ''
+  })
+
+  return { body, frontmatter: merged }
+}
+
+function parseDirectiveMap(text: string): MermaidFrontmatterMap | undefined {
+  try {
+    return toFrontmatterMap(JSON.parse(text))
+  } catch {
+    return parseLooseObjectLiteral(text)
   }
 }
 
-function collectDirective(rawLines: string[], startIndex: number): { config: MermaidRuntimeConfig; nextIndex: number } {
-  const buffer: string[] = []
-  let index = startIndex
+function toFrontmatterMap(value: unknown): MermaidFrontmatterMap | undefined {
+  if (!isPlainObject(value)) return undefined
 
-  while (index < rawLines.length) {
-    buffer.push(rawLines[index]!)
-    if (rawLines[index]!.includes('}%%')) break
-    index++
+  const map: MermaidFrontmatterMap = {}
+  for (const [key, entry] of Object.entries(value)) {
+    const parsed = toFrontmatterValue(entry)
+    if (parsed !== undefined) map[key] = parsed
   }
-
-  const rawDirective = buffer.join('\n').trim()
-  const directiveBody = rawDirective.replace(/^%%\{/, '').replace(/\}%%$/, '').trim()
-  const wrappedBody = directiveBody.startsWith('{') ? directiveBody : `{${directiveBody}}`
-  const parsed = parseObjectLiteral(wrappedBody)
-  const directiveConfig = isPlainObject(parsed) && (isPlainObject(parsed.init) || isPlainObject(parsed.initialize))
-    ? (parsed.init ?? parsed.initialize)
-    : parsed
-
-  return {
-    config: normalizeMermaidRuntimeConfig(directiveConfig),
-    nextIndex: index + 1,
-  }
+  return map
 }
 
-function normalizeMermaidRuntimeConfig(raw: unknown): MermaidRuntimeConfig {
-  if (!isPlainObject(raw)) return {}
+function toFrontmatterValue(value: unknown): MermaidFrontmatterValue | undefined {
+  if (value === null) return null
+  if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') return value
 
-  const config: MermaidRuntimeConfig = {}
-
-  if (typeof raw.theme === 'string') config.theme = raw.theme
-  if (typeof raw.fontFamily === 'string') config.fontFamily = raw.fontFamily
-
-  if (isPlainObject(raw.themeVariables)) {
-    const themeVariables: MermaidThemeVariables = {}
-    for (const [key, value] of Object.entries(raw.themeVariables)) {
-      if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
-        themeVariables[key] = value
-      }
+  if (Array.isArray(value)) {
+    const items: MermaidFrontmatterList = []
+    for (const entry of value) {
+      const parsed = toFrontmatterValue(entry)
+      if (parsed === undefined) return undefined
+      items.push(parsed)
     }
-    if (Object.keys(themeVariables).length > 0) config.themeVariables = themeVariables
+    return items
   }
 
-  if (isPlainObject(raw.timeline)) {
-    const timeline = normalizeTimelineRuntimeConfig(raw.timeline)
-    if (Object.keys(timeline).length > 0) config.timeline = timeline
-  }
-
-  return config
+  return toFrontmatterMap(value)
 }
 
-function normalizeTimelineRuntimeConfig(raw: Record<string, unknown>): TimelineRuntimeConfig {
-  const config: TimelineRuntimeConfig = {}
-
-  if (typeof raw.disableMulticolor === 'boolean') config.disableMulticolor = raw.disableMulticolor
-
-  const sectionFills = normalizeStringArray(raw.sectionFills)
-  if (sectionFills.length > 0) config.sectionFills = sectionFills
-
-  const sectionColours = normalizeStringArray(raw.sectionColours)
-  const sectionColors = normalizeStringArray(raw.sectionColors)
-  const sectionPalette = sectionColours.length > 0 ? sectionColours : sectionColors
-  if (sectionPalette.length > 0) config.sectionColours = sectionPalette
-
-  return config
+function cloneFrontmatterMap(value: MermaidFrontmatterMap): MermaidFrontmatterMap {
+  const clone: MermaidFrontmatterMap = {}
+  for (const [key, entry] of Object.entries(value)) {
+    clone[key] = cloneFrontmatterValue(entry)
+  }
+  return clone
 }
 
-function normalizeStringArray(value: unknown): string[] {
-  return Array.isArray(value) ? value.filter((entry): entry is string => typeof entry === 'string') : []
+function cloneFrontmatterValue(value: MermaidFrontmatterValue | undefined): MermaidFrontmatterValue | undefined {
+  if (value === undefined || value === null) return value
+  if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') return value
+  if (Array.isArray(value)) return value.map(entry => cloneFrontmatterValue(entry)!)
+  return cloneFrontmatterMap(value)
 }
 
-function parseYamlDocument(lines: string[]): unknown {
-  const prepared = dedentYamlLines(lines.map(line => line.replace(/\t/g, '    ')))
-  const { value } = parseYamlBlock(prepared, 0, 0)
-  return value
+function isFrontmatterMap(value: MermaidFrontmatterValue | undefined): value is MermaidFrontmatterMap {
+  return !!value && typeof value === 'object' && !Array.isArray(value)
 }
 
-function dedentYamlLines(lines: string[]): string[] {
-  const indents = lines
-    .filter(line => stripYamlComment(line).trim().length > 0)
-    .map(countIndent)
-
-  const minIndent = indents.length > 0 ? Math.min(...indents) : 0
-  if (minIndent === 0) return lines
-
-  return lines.map(line => line.slice(Math.min(minIndent, line.length)))
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === 'object' && !Array.isArray(value)
 }
 
-function parseYamlBlock(lines: string[], startIndex: number, indent: number): { value: unknown; nextIndex: number } {
-  let index = startIndex
-
-  while (index < lines.length) {
-    const trimmed = stripYamlComment(lines[index]!).trim()
-    if (trimmed.length === 0) {
-      index++
-      continue
-    }
-    break
+function parseScalar(valueText: string): MermaidFrontmatterScalar {
+  if ((valueText.startsWith('"') && valueText.endsWith('"')) || (valueText.startsWith("'") && valueText.endsWith("'"))) {
+    return unescapeQuotedString(valueText)
   }
-
-  if (index >= lines.length) return { value: {}, nextIndex: index }
-
-  const firstIndent = countIndent(lines[index]!)
-  if (firstIndent < indent) return { value: {}, nextIndex: index }
-
-  const firstTrimmed = stripYamlComment(lines[index]!).trim()
-  if (firstTrimmed.startsWith('-')) {
-    const items: unknown[] = []
-
-    while (index < lines.length) {
-      const line = stripYamlComment(lines[index]!)
-      const trimmed = line.trim()
-      if (trimmed.length === 0) {
-        index++
-        continue
-      }
-
-      const currentIndent = countIndent(line)
-      if (currentIndent < indent) break
-      if (!trimmed.startsWith('-')) break
-
-      const rest = trimmed.slice(1).trim()
-      index++
-
-      if (rest.length === 0) {
-        const nested = parseYamlBlock(lines, index, currentIndent + 2)
-        items.push(nested.value)
-        index = nested.nextIndex
-      } else if (looksLikeYamlKeyValue(rest)) {
-        const synthetic = `${' '.repeat(currentIndent + 2)}${rest}`
-        const nestedLines = [synthetic]
-        let nestedIndex = index
-
-        while (nestedIndex < lines.length) {
-          const candidate = lines[nestedIndex]!
-          const candidateTrimmed = stripYamlComment(candidate).trim()
-          if (candidateTrimmed.length === 0) {
-            nestedLines.push(candidate)
-            nestedIndex++
-            continue
-          }
-          if (countIndent(candidate) <= currentIndent) break
-          nestedLines.push(candidate)
-          nestedIndex++
-        }
-
-        const nested = parseYamlBlock(nestedLines, 0, currentIndent + 2)
-        items.push(nested.value)
-        index = nestedIndex
-      } else {
-        items.push(parseYamlScalar(rest))
-      }
-    }
-
-    return { value: items, nextIndex: index }
-  }
-
-  const object: Record<string, unknown> = {}
-
-  while (index < lines.length) {
-    const line = stripYamlComment(lines[index]!)
-    const trimmed = line.trim()
-    if (trimmed.length === 0) {
-      index++
-      continue
-    }
-
-    const currentIndent = countIndent(line)
-    if (currentIndent < indent) break
-    if (currentIndent > indent) {
-      throw new Error(`Invalid Mermaid frontmatter indentation near "${trimmed}"`)
-    }
-
-    const match = trimmed.match(/^([^:]+):(?:\s+(.*))?$/)
-    if (!match) {
-      throw new Error(`Invalid Mermaid frontmatter entry: "${trimmed}"`)
-    }
-
-    const key = match[1]!.trim()
-    const valuePart = match[2]
-    index++
-
-    if (valuePart === undefined || valuePart.trim().length === 0) {
-      const nested = parseYamlBlock(lines, index, currentIndent + 2)
-      object[key] = nested.value
-      index = nested.nextIndex
-      continue
-    }
-
-    object[key] = parseYamlScalar(valuePart.trim())
-  }
-
-  return { value: object, nextIndex: index }
+  if (valueText === 'true') return true
+  if (valueText === 'false') return false
+  if (valueText === 'null') return null
+  if (/^[+-]?(?:\d+(?:\.\d+)?|\.\d+)$/.test(valueText)) return Number(valueText)
+  return valueText
 }
 
-function stripYamlComment(line: string): string {
-  let inSingle = false
-  let inDouble = false
-
-  for (let i = 0; i < line.length; i++) {
-    const char = line[i]!
-    const prev = i > 0 ? line[i - 1]! : ''
-
-    if (char === "'" && !inDouble && prev !== '\\') inSingle = !inSingle
-    if (char === '"' && !inSingle && prev !== '\\') inDouble = !inDouble
-
-    if (char === '#' && !inSingle && !inDouble) {
-      return line.slice(0, i)
-    }
-  }
-
-  return line
+function parseLooseObjectLiteral(text: string): MermaidFrontmatterMap | undefined {
+  const parsed = parseFlowValue(text.trim())
+  return isFrontmatterMap(parsed) ? parsed : undefined
 }
 
-function parseYamlScalar(value: string): unknown {
-  if (value === 'true') return true
-  if (value === 'false') return false
-  if (value === 'null') return null
-  if (/^-?\d+(?:\.\d+)?$/.test(value)) return Number(value)
+function parseFlowValue(text: string): MermaidFrontmatterValue | undefined {
+  const trimmed = text.trim()
+  if (trimmed.length === 0) return undefined
 
-  if ((value.startsWith('"') && value.endsWith('"')) || (value.startsWith("'") && value.endsWith("'"))) {
-    return parseStringLiteral(value)
+  if (trimmed.startsWith('{') && trimmed.endsWith('}')) {
+    return parseFlowMap(trimmed.slice(1, -1))
+  }
+  if (trimmed.startsWith('[') && trimmed.endsWith(']')) {
+    return parseFlowList(trimmed.slice(1, -1))
   }
 
-  if (value.startsWith('[') || value.startsWith('{')) {
-    return parseObjectLiteral(value)
-  }
-
-  return value
+  return parseScalar(trimmed)
 }
 
-function looksLikeYamlKeyValue(value: string): boolean {
-  return /^[^:[\]{}][^:]*:(?:\s+.*)?$/.test(value)
+function parseFlowMap(text: string): MermaidFrontmatterMap | undefined {
+  const map: MermaidFrontmatterMap = {}
+  for (const entry of splitFlowEntries(text)) {
+    const colonIdx = findSeparatorIndex(entry, ':')
+    if (colonIdx === -1) return undefined
+
+    const rawKey = entry.slice(0, colonIdx).trim()
+    const rawValue = entry.slice(colonIdx + 1).trim()
+    const key = parseFlowKey(rawKey)
+    if (!key) return undefined
+
+    const value = parseFlowValue(rawValue)
+    if (value === undefined) return undefined
+    map[key] = value
+  }
+  return map
 }
 
-function countIndent(line: string): number {
-  let count = 0
-  while (count < line.length && line[count] === ' ') count++
-  return count
+function parseFlowList(text: string): MermaidFrontmatterList | undefined {
+  const values: MermaidFrontmatterList = []
+  for (const entry of splitFlowEntries(text)) {
+    const value = parseFlowValue(entry)
+    if (value === undefined) return undefined
+    values.push(value)
+  }
+  return values
 }
 
-type LiteralToken =
-  | { type: 'brace-open' | 'brace-close' | 'bracket-open' | 'bracket-close' | 'colon' | 'comma' }
-  | { type: 'string'; value: string }
-  | { type: 'number'; value: number }
-  | { type: 'boolean'; value: boolean }
-  | { type: 'null'; value: null }
-  | { type: 'identifier'; value: string }
-
-function parseObjectLiteral(input: string): unknown {
-  const tokens = tokenizeLiteral(input)
-  let index = 0
-
-  const parseValue = (): unknown => {
-    const token = tokens[index]
-    if (!token) throw new Error('Unexpected end of Mermaid config')
-
-    switch (token.type) {
-      case 'string':
-      case 'number':
-      case 'boolean':
-      case 'null':
-        index++
-        return token.value
-
-      case 'brace-open':
-        return parseObject()
-
-      case 'bracket-open':
-        return parseArray()
-
-      case 'identifier':
-        index++
-        if (token.value === 'true') return true
-        if (token.value === 'false') return false
-        if (token.value === 'null') return null
-        return token.value
-
-      default:
-        throw new Error(`Unexpected Mermaid config token: ${token.type}`)
-    }
+function parseFlowKey(text: string): string | undefined {
+  const trimmed = text.trim()
+  if (!trimmed) return undefined
+  if ((trimmed.startsWith('"') && trimmed.endsWith('"')) || (trimmed.startsWith("'") && trimmed.endsWith("'"))) {
+    return unescapeQuotedString(trimmed)
   }
-
-  const parseObject = (): Record<string, unknown> => {
-    expectToken('brace-open')
-    const object: Record<string, unknown> = {}
-
-    while (!peekToken('brace-close')) {
-      const keyToken = tokens[index]
-      if (!keyToken || (keyToken.type !== 'identifier' && keyToken.type !== 'string')) {
-        throw new Error('Expected Mermaid config object key')
-      }
-
-      index++
-      const key = keyToken.value
-      expectToken('colon')
-      object[key] = parseValue()
-
-      if (peekToken('comma')) index++
-    }
-
-    expectToken('brace-close')
-    return object
-  }
-
-  const parseArray = (): unknown[] => {
-    expectToken('bracket-open')
-    const array: unknown[] = []
-
-    while (!peekToken('bracket-close')) {
-      array.push(parseValue())
-      if (peekToken('comma')) index++
-    }
-
-    expectToken('bracket-close')
-    return array
-  }
-
-  const expectToken = (type: LiteralToken['type']): void => {
-    const token = tokens[index]
-    if (!token || token.type !== type) {
-      throw new Error(`Expected Mermaid config token ${type}`)
-    }
-    index++
-  }
-
-  const peekToken = (type: LiteralToken['type']): boolean => tokens[index]?.type === type
-
-  const value = parseValue()
-  if (index < tokens.length) {
-    throw new Error('Unexpected trailing Mermaid config tokens')
-  }
-  return value
+  return trimmed
 }
 
-function tokenizeLiteral(input: string): LiteralToken[] {
-  const tokens: LiteralToken[] = []
-  let index = 0
+function splitFlowEntries(text: string): string[] {
+  const entries: string[] = []
+  let current = ''
+  let quote: '"' | "'" | null = null
+  let braceDepth = 0
+  let bracketDepth = 0
 
-  while (index < input.length) {
-    const char = input[index]!
-
-    if (/\s/.test(char)) {
-      index++
-      continue
-    }
-
-    if (char === '{') {
-      tokens.push({ type: 'brace-open' })
-      index++
-      continue
-    }
-    if (char === '}') {
-      tokens.push({ type: 'brace-close' })
-      index++
-      continue
-    }
-    if (char === '[') {
-      tokens.push({ type: 'bracket-open' })
-      index++
-      continue
-    }
-    if (char === ']') {
-      tokens.push({ type: 'bracket-close' })
-      index++
-      continue
-    }
-    if (char === ':') {
-      tokens.push({ type: 'colon' })
-      index++
-      continue
-    }
-    if (char === ',') {
-      tokens.push({ type: 'comma' })
-      index++
+  for (let i = 0; i < text.length; i++) {
+    const char = text[i]!
+    if (quote) {
+      current += char
+      if (char === quote && text[i - 1] !== '\\') quote = null
       continue
     }
 
     if (char === '"' || char === "'") {
-      const { value, nextIndex } = readStringLiteral(input, index)
-      tokens.push({ type: 'string', value })
-      index = nextIndex
+      quote = char
+      current += char
+      continue
+    }
+    if (char === '{') {
+      braceDepth++
+      current += char
+      continue
+    }
+    if (char === '}') {
+      braceDepth--
+      current += char
+      continue
+    }
+    if (char === '[') {
+      bracketDepth++
+      current += char
+      continue
+    }
+    if (char === ']') {
+      bracketDepth--
+      current += char
+      continue
+    }
+    if (char === ',' && braceDepth === 0 && bracketDepth === 0) {
+      const value = current.trim()
+      if (value) entries.push(value)
+      current = ''
       continue
     }
 
-    const numberMatch = input.slice(index).match(/^-?\d+(?:\.\d+)?/)
-    if (numberMatch) {
-      tokens.push({ type: 'number', value: Number(numberMatch[0]) })
-      index += numberMatch[0].length
-      continue
-    }
-
-    const identifierMatch = input.slice(index).match(/^[A-Za-z_$][\w$-]*/)
-    if (identifierMatch) {
-      const value = identifierMatch[0]
-      if (value === 'true' || value === 'false') {
-        tokens.push({ type: 'boolean', value: value === 'true' })
-      } else if (value === 'null') {
-        tokens.push({ type: 'null', value: null })
-      } else {
-        tokens.push({ type: 'identifier', value })
-      }
-      index += value.length
-      continue
-    }
-
-    throw new Error(`Unsupported Mermaid config character: "${char}"`)
+    current += char
   }
 
-  return tokens
+  const trailing = current.trim()
+  if (trailing) entries.push(trailing)
+  return entries
 }
 
-function readStringLiteral(input: string, startIndex: number): { value: string; nextIndex: number } {
-  const quote = input[startIndex]!
-  let value = ''
-  let index = startIndex + 1
+function parseYamlMap(
+  state: { lines: string[]; index: number },
+  indent: number,
+): { value: MermaidFrontmatterMap; index: number } {
+  const map: MermaidFrontmatterMap = {}
+  let index = state.index
 
-  while (index < input.length) {
-    const char = input[index]!
+  while (index < state.lines.length) {
+    index = skipYamlNoise(state.lines, index)
+    if (index >= state.lines.length) break
 
-    if (char === '\\') {
-      const next = input[index + 1]
-      if (next !== undefined) {
-        value += decodeEscape(next)
-        index += 2
-        continue
+    const rawLine = state.lines[index]!
+    const lineIndent = getIndent(rawLine)
+    if (lineIndent < indent) break
+    if (lineIndent > indent) {
+      index++
+      continue
+    }
+
+    const line = rawLine.trim()
+    if (line.startsWith('-')) break
+
+    const colonIdx = findSeparatorIndex(line, ':')
+    if (colonIdx === -1) {
+      index++
+      continue
+    }
+
+    const key = line.slice(0, colonIdx).trim()
+    if (!key) {
+      index++
+      continue
+    }
+
+    const valueText = line.slice(colonIdx + 1).trim()
+    index++
+
+    if (isBlockScalarIndicator(valueText)) {
+      const block = parseYamlBlockScalar(state.lines, index, lineIndent, valueText[0] as '|' | '>')
+      map[key] = block.value
+      index = block.index
+      continue
+    }
+
+    if (valueText.length === 0) {
+      const nested = parseYamlNestedValue(state.lines, index, lineIndent)
+      map[key] = nested.value
+      index = nested.index
+      continue
+    }
+
+    map[key] = parseYamlValue(valueText)
+  }
+
+  state.index = index
+  return { value: map, index }
+}
+
+function parseYamlSequence(
+  state: { lines: string[]; index: number },
+  indent: number,
+): { value: MermaidFrontmatterList; index: number } {
+  const items: MermaidFrontmatterList = []
+  let index = state.index
+
+  while (index < state.lines.length) {
+    index = skipYamlNoise(state.lines, index)
+    if (index >= state.lines.length) break
+
+    const rawLine = state.lines[index]!
+    const lineIndent = getIndent(rawLine)
+    if (lineIndent < indent) break
+    if (lineIndent > indent) {
+      index++
+      continue
+    }
+
+    const line = rawLine.slice(indent).trim()
+    if (!line.startsWith('-')) break
+
+    const valueText = line.slice(1).trim()
+    index++
+
+    if (valueText.length === 0) {
+      const nested = parseYamlNestedValue(state.lines, index, lineIndent)
+      items.push(nested.value)
+      index = nested.index
+      continue
+    }
+
+    if (isBlockScalarIndicator(valueText)) {
+      const block = parseYamlBlockScalar(state.lines, index, lineIndent, valueText[0] as '|' | '>')
+      items.push(block.value)
+      index = block.index
+      continue
+    }
+
+    const colonIdx = findSeparatorIndex(valueText, ':')
+    if (
+      colonIdx !== -1 &&
+      !valueText.startsWith('{') &&
+      !valueText.startsWith('[') &&
+      !valueText.startsWith('"') &&
+      !valueText.startsWith("'")
+    ) {
+      const key = valueText.slice(0, colonIdx).trim()
+      const rawValue = valueText.slice(colonIdx + 1).trim()
+      const item: MermaidFrontmatterMap = {}
+
+      if (isBlockScalarIndicator(rawValue)) {
+        const block = parseYamlBlockScalar(state.lines, index, lineIndent, rawValue[0] as '|' | '>')
+        item[key] = block.value
+        index = block.index
+      } else if (rawValue.length === 0) {
+        const nested = parseYamlNestedValue(state.lines, index, lineIndent)
+        item[key] = nested.value
+        index = nested.index
+      } else {
+        item[key] = parseYamlValue(rawValue)
       }
+
+      const nestedState = { lines: state.lines, index }
+      const extra = parseYamlMap(nestedState, lineIndent + 2)
+      index = nestedState.index
+      items.push(Object.keys(extra.value).length > 0 ? mergeFrontmatterMaps(item, extra.value) : item)
+      continue
     }
 
-    if (char === quote) {
-      return { value, nextIndex: index + 1 }
-    }
+    items.push(parseYamlValue(valueText))
+  }
 
-    value += char
+  state.index = index
+  return { value: items, index }
+}
+
+function parseYamlNestedValue(
+  lines: string[],
+  startIndex: number,
+  parentIndent: number,
+): { value: MermaidFrontmatterValue; index: number } {
+  const nextIndex = skipYamlNoise(lines, startIndex)
+  if (nextIndex >= lines.length) return { value: {}, index: nextIndex }
+
+  const nextLine = lines[nextIndex]!
+  const indent = getIndent(nextLine)
+  if (indent <= parentIndent) return { value: {}, index: nextIndex }
+
+  const state = { lines, index: nextIndex }
+  if (nextLine.slice(indent).trim().startsWith('-')) {
+    return parseYamlSequence(state, indent)
+  }
+  return parseYamlMap(state, indent)
+}
+
+function parseYamlBlockScalar(
+  lines: string[],
+  startIndex: number,
+  parentIndent: number,
+  mode: '|' | '>',
+): { value: string; index: number } {
+  let index = startIndex
+  const chunks: string[] = []
+  let blockIndent: number | undefined
+
+  while (index < lines.length) {
+    const rawLine = lines[index]!
+    const lineIndent = getIndent(rawLine)
+    if (rawLine.trim().length === 0) {
+      chunks.push('')
+      index++
+      continue
+    }
+    if (lineIndent <= parentIndent) break
+
+    if (blockIndent === undefined) blockIndent = lineIndent
+    chunks.push(rawLine.slice(Math.min(rawLine.length, blockIndent)))
     index++
   }
 
-  throw new Error('Unterminated Mermaid config string literal')
-}
-
-function parseStringLiteral(value: string): string {
-  return readStringLiteral(value, 0).value
-}
-
-function decodeEscape(char: string): string {
-  switch (char) {
-    case 'n': return '\n'
-    case 'r': return '\r'
-    case 't': return '\t'
-    case '"': return '"'
-    case "'": return "'"
-    case '\\': return '\\'
-    default: return char
+  return {
+    value: mode === '>' ? foldYamlBlockScalar(chunks) : chunks.join('\n'),
+    index,
   }
 }
 
-function isPlainObject(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null && !Array.isArray(value)
+function parseYamlValue(text: string): MermaidFrontmatterValue {
+  const flowValue = parseFlowValue(text)
+  return flowValue === undefined ? parseScalar(text) : flowValue
+}
+
+function foldYamlBlockScalar(lines: string[]): string {
+  let result = ''
+  let previousBlank = false
+
+  for (const line of lines) {
+    if (line.length === 0) {
+      result += result.endsWith('\n') || result.length === 0 ? '\n' : '\n\n'
+      previousBlank = true
+      continue
+    }
+
+    if (result.length > 0 && !previousBlank && !result.endsWith('\n')) result += ' '
+    result += line
+    previousBlank = false
+  }
+
+  return result
+}
+
+function skipYamlNoise(lines: string[], index: number): number {
+  let cursor = index
+  while (cursor < lines.length) {
+    const trimmed = lines[cursor]!.trim()
+    if (trimmed.length === 0 || trimmed.startsWith('#')) {
+      cursor++
+      continue
+    }
+    break
+  }
+  return cursor
+}
+
+function getIndent(line: string): number {
+  return line.match(/^\s*/)?.[0].length ?? 0
+}
+
+function isBlockScalarIndicator(valueText: string): valueText is '|' | '>' | '|-' | '>-' | '|+' | '>+' {
+  return /^[|>][-+]?$/.test(valueText)
+}
+
+function findSeparatorIndex(text: string, separator: ':' | ','): number {
+  let quote: '"' | "'" | null = null
+  let braceDepth = 0
+  let bracketDepth = 0
+
+  for (let i = 0; i < text.length; i++) {
+    const char = text[i]!
+    if (quote) {
+      if (char === quote && text[i - 1] !== '\\') quote = null
+      continue
+    }
+    if (char === '"' || char === "'") {
+      quote = char
+      continue
+    }
+    if (char === '{') {
+      braceDepth++
+      continue
+    }
+    if (char === '}') {
+      braceDepth--
+      continue
+    }
+    if (char === '[') {
+      bracketDepth++
+      continue
+    }
+    if (char === ']') {
+      bracketDepth--
+      continue
+    }
+    if (char === separator && braceDepth === 0 && bracketDepth === 0) return i
+  }
+
+  return -1
+}
+
+function unescapeQuotedString(valueText: string): string {
+  try {
+    if (valueText.startsWith("'")) {
+      return valueText
+        .slice(1, -1)
+        .replace(/\\\\/g, '\\')
+        .replace(/\\'/g, "'")
+    }
+    return JSON.parse(valueText)
+  } catch {
+    return valueText.slice(1, -1)
+  }
 }

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -283,7 +283,12 @@ export function svgOpenTag(
   height: number,
   colors: DiagramColors,
   transparent?: boolean,
-  extraAttrs: Record<string, string> = {},
+  extra?: Record<string, string> | {
+    width?: string
+    height?: string
+    style?: string
+    attrs?: Record<string, string | undefined>
+  },
 ): string {
   // Build the style string with only the provided color variables
   const vars = [
@@ -297,12 +302,36 @@ export function svgOpenTag(
   ].filter(Boolean).join(';')
 
   const bgStyle = transparent ? '' : ';background:var(--bg)'
-  const attrs = Object.entries(extraAttrs)
-    .map(([key, value]) => ` ${key}="${value}"`)
-    .join('')
+  const overrides = isSvgOpenTagOverrides(extra) ? extra : undefined
+  const attrs = overrides?.attrs ?? (extra as Record<string, string> | undefined) ?? {}
+  const style = `${vars}${bgStyle}${overrides?.style ? `;${overrides.style}` : ''}`
+  const extraAttrs = Object.entries(attrs)
+    .filter(([, value]) => value !== undefined)
+    .map(([key, value]) => `${key}="${value}"`)
+    .join(' ')
+  const attrBlock = extraAttrs ? ` ${extraAttrs}` : ''
 
   return (
     `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ${width} ${height}" ` +
-    `width="${width}" height="${height}" style="${vars}${bgStyle}"${attrs}>`
+    `width="${overrides?.width ?? width}" height="${overrides?.height ?? height}" style="${style}"${attrBlock}>`
+  )
+}
+
+function isSvgOpenTagOverrides(
+  value: Record<string, string> | {
+    width?: string
+    height?: string
+    style?: string
+    attrs?: Record<string, string | undefined>
+  } | undefined,
+): value is {
+  width?: string
+  height?: string
+  style?: string
+  attrs?: Record<string, string | undefined>
+} {
+  return Boolean(
+    value &&
+    ('width' in value || 'height' in value || 'style' in value || 'attrs' in value),
   )
 }

--- a/src/xychart/axis-utils.ts
+++ b/src/xychart/axis-utils.ts
@@ -1,0 +1,111 @@
+import type { XYChart } from './types.ts'
+
+export function getDataCount(chart: Pick<XYChart, 'xAxis' | 'series'>): number {
+  if (chart.xAxis.categories) return chart.xAxis.categories.length
+  for (const series of chart.series) {
+    if (series.data.length > 0) return series.data.length
+  }
+  return 1
+}
+
+export function getDataXValues(chart: Pick<XYChart, 'xAxis' | 'series'>, count = getDataCount(chart)): number[] {
+  if (chart.xAxis.range) {
+    const { min, max } = chart.xAxis.range
+    const step = count > 1 ? (max - min) / (count - 1) : 0
+    return Array.from({ length: count }, (_, index) => min + step * index)
+  }
+  return Array.from({ length: count }, (_, index) => index)
+}
+
+export function getCategoryLabels(chart: Pick<XYChart, 'xAxis' | 'series'>, count = getDataCount(chart)): string[] {
+  if (chart.xAxis.categories) return chart.xAxis.categories
+  if (chart.xAxis.range) return getDataXValues(chart, count).map(value => formatTickValue(value))
+  return Array.from({ length: count }, (_, index) => String(index + 1))
+}
+
+export function getPointSpacing(values: number[], scale: (value: number) => number, fallback: number): number {
+  if (values.length < 2) return fallback
+  let minSpacing = Number.POSITIVE_INFINITY
+  for (let i = 1; i < values.length; i++) {
+    minSpacing = Math.min(minSpacing, Math.abs(scale(values[i]!) - scale(values[i - 1]!)))
+  }
+  return Number.isFinite(minSpacing) && minSpacing > 0 ? minSpacing : fallback
+}
+
+export function linearTicks(min: number, max: number, count = 10): number[] {
+  if (!(count > 0)) return []
+  if (min === max) return [min]
+
+  const reverse = max < min
+  const start = reverse ? max : min
+  const stop = reverse ? min : max
+  const [indexStart, indexStop, increment] = tickSpec(start, stop, count)
+  if (!(indexStop >= indexStart)) return []
+
+  const tickCount = indexStop - indexStart + 1
+  const ticks = new Array<number>(tickCount)
+  if (reverse) {
+    if (increment < 0) {
+      for (let i = 0; i < tickCount; i++) ticks[i] = (indexStop - i) / -increment
+    } else {
+      for (let i = 0; i < tickCount; i++) ticks[i] = (indexStop - i) * increment
+    }
+  } else if (increment < 0) {
+    for (let i = 0; i < tickCount; i++) ticks[i] = (indexStart + i) / -increment
+  } else {
+    for (let i = 0; i < tickCount; i++) ticks[i] = (indexStart + i) * increment
+  }
+
+  return ticks.map(roundTick)
+}
+
+export function formatTickValue(value: number): string {
+  if (!Number.isFinite(value)) return String(value)
+  if (Number.isInteger(value)) return String(value)
+
+  const abs = Math.abs(value)
+  if (abs >= 1000 || abs === 0) return roundTick(value).toString()
+
+  const precision = abs < 1 ? 2 : abs < 10 ? 1 : 0
+  return stripTrailingZeros(value.toFixed(precision))
+}
+
+function tickSpec(start: number, stop: number, count: number): [number, number, number] {
+  const step = (stop - start) / Math.max(0, count)
+  const power = Math.floor(Math.log10(step))
+  const error = step / Math.pow(10, power)
+  const factor = error >= Math.sqrt(50) ? 10 : error >= Math.sqrt(10) ? 5 : error >= Math.sqrt(2) ? 2 : 1
+
+  let indexStart: number
+  let indexStop: number
+  let increment: number
+
+  if (power < 0) {
+    increment = Math.pow(10, -power) / factor
+    indexStart = Math.round(start * increment)
+    indexStop = Math.round(stop * increment)
+    if (indexStart / increment < start) indexStart++
+    if (indexStop / increment > stop) indexStop--
+    increment = -increment
+  } else {
+    increment = Math.pow(10, power) * factor
+    indexStart = Math.round(start / increment)
+    indexStop = Math.round(stop / increment)
+    if (indexStart * increment < start) indexStart++
+    if (indexStop * increment > stop) indexStop--
+  }
+
+  if (indexStop < indexStart && 0.5 <= count && count < 2) {
+    return tickSpec(start, stop, count * 2)
+  }
+
+  return [indexStart, indexStop, increment]
+}
+
+function roundTick(value: number): number {
+  return Math.round(value * 1e12) / 1e12
+}
+
+function stripTrailingZeros(value: string): string {
+  return value.replace(/\.0+$|(\.\d*?[1-9])0+$/, '$1')
+}

--- a/src/xychart/config.ts
+++ b/src/xychart/config.ts
@@ -1,0 +1,88 @@
+import type {
+  ResolvedXYAxisRenderConfig,
+  ResolvedXYChartConfig,
+  XYAxisRenderConfig,
+  XYChartConfig,
+} from './types.ts'
+
+export const DEFAULT_XY_AXIS_CONFIG: ResolvedXYAxisRenderConfig = {
+  showLabel: true,
+  labelFontSize: 14,
+  labelPadding: 5,
+  showTitle: true,
+  titleFontSize: 16,
+  titlePadding: 5,
+  showTick: true,
+  tickLength: 5,
+  tickWidth: 2,
+  showAxisLine: true,
+  axisLineWidth: 2,
+}
+
+export const DEFAULT_XY_CHART_CONFIG: ResolvedXYChartConfig = {
+  width: 700,
+  height: 500,
+  useMaxWidth: true,
+  useWidth: undefined,
+  titleFontSize: 20,
+  titlePadding: 10,
+  chartOrientation: 'vertical',
+  plotReservedSpacePercent: 50,
+  showDataLabel: false,
+  showTitle: true,
+  xAxis: { ...DEFAULT_XY_AXIS_CONFIG },
+  yAxis: { ...DEFAULT_XY_AXIS_CONFIG },
+}
+
+export function resolveXYAxisRenderConfig(config?: XYAxisRenderConfig): ResolvedXYAxisRenderConfig {
+  return {
+    showLabel: config?.showLabel ?? DEFAULT_XY_AXIS_CONFIG.showLabel,
+    labelFontSize: getPositiveNumber(config?.labelFontSize, DEFAULT_XY_AXIS_CONFIG.labelFontSize),
+    labelPadding: getNonNegativeNumber(config?.labelPadding, DEFAULT_XY_AXIS_CONFIG.labelPadding),
+    showTitle: config?.showTitle ?? DEFAULT_XY_AXIS_CONFIG.showTitle,
+    titleFontSize: getPositiveNumber(config?.titleFontSize, DEFAULT_XY_AXIS_CONFIG.titleFontSize),
+    titlePadding: getNonNegativeNumber(config?.titlePadding, DEFAULT_XY_AXIS_CONFIG.titlePadding),
+    showTick: config?.showTick ?? DEFAULT_XY_AXIS_CONFIG.showTick,
+    tickLength: getNonNegativeNumber(config?.tickLength, DEFAULT_XY_AXIS_CONFIG.tickLength),
+    tickWidth: getPositiveNumber(config?.tickWidth, DEFAULT_XY_AXIS_CONFIG.tickWidth),
+    showAxisLine: config?.showAxisLine ?? DEFAULT_XY_AXIS_CONFIG.showAxisLine,
+    axisLineWidth: getPositiveNumber(config?.axisLineWidth, DEFAULT_XY_AXIS_CONFIG.axisLineWidth),
+  }
+}
+
+export function resolveXYChartRenderConfig(config: XYChartConfig): ResolvedXYChartConfig {
+  return {
+    width: getPositiveNumber(config.width, DEFAULT_XY_CHART_CONFIG.width),
+    height: getPositiveNumber(config.height, DEFAULT_XY_CHART_CONFIG.height),
+    useMaxWidth: config.useMaxWidth ?? DEFAULT_XY_CHART_CONFIG.useMaxWidth,
+    useWidth: getOptionalPositiveNumber(config.useWidth),
+    titleFontSize: getPositiveNumber(config.titleFontSize, DEFAULT_XY_CHART_CONFIG.titleFontSize),
+    titlePadding: getNonNegativeNumber(config.titlePadding, DEFAULT_XY_CHART_CONFIG.titlePadding),
+    chartOrientation: config.chartOrientation ?? DEFAULT_XY_CHART_CONFIG.chartOrientation,
+    plotReservedSpacePercent: clamp(
+      getPositiveNumber(config.plotReservedSpacePercent, DEFAULT_XY_CHART_CONFIG.plotReservedSpacePercent),
+      10,
+      100,
+    ),
+    showDataLabel: config.showDataLabel ?? DEFAULT_XY_CHART_CONFIG.showDataLabel,
+    showTitle: config.showTitle ?? DEFAULT_XY_CHART_CONFIG.showTitle,
+    xAxis: resolveXYAxisRenderConfig(config.xAxis),
+    yAxis: resolveXYAxisRenderConfig(config.yAxis),
+  }
+}
+
+function getPositiveNumber(value: number | undefined, fallback: number): number {
+  return typeof value === 'number' && Number.isFinite(value) && value > 0 ? value : fallback
+}
+
+function getNonNegativeNumber(value: number | undefined, fallback: number): number {
+  return typeof value === 'number' && Number.isFinite(value) && value >= 0 ? value : fallback
+}
+
+function getOptionalPositiveNumber(value: number | undefined): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value) && value > 0 ? value : undefined
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value))
+}

--- a/src/xychart/layout.ts
+++ b/src/xychart/layout.ts
@@ -1,440 +1,594 @@
 import type {
-  XYChart, PositionedXYChart, PositionedAxis, AxisTick,
-  PositionedBar, PositionedLine, GridLine, PlotArea, LegendItem,
+  AxisTick,
+  GridLine,
+  PlotArea,
+  PositionedBar,
+  PositionedLine,
+  PositionedXYChart,
+  ResolvedXYAxisRenderConfig,
+  ResolvedXYChartConfig,
+  XYChart,
 } from './types.ts'
 import type { RenderOptions } from '../types.ts'
 import { estimateTextWidth } from '../styles.ts'
+import { resolveXYChartRenderConfig } from './config.ts'
+import { formatTickValue, getCategoryLabels, getDataCount, getDataXValues, getPointSpacing, linearTicks } from './axis-utils.ts'
 
 // ============================================================================
 // XY Chart layout engine
 //
-// Computes pixel coordinates for all chart elements. No dagre needed —
-// direct coordinate-space mapping for axes, bars, lines, and grid.
+// Layout is intentionally closer to Mermaid's own xychart builder:
+// total width/height are the chart box, plot space is reserved inside that box,
+// and axis/title elements compete for the reserved margin space.
 // ============================================================================
 
-/** Layout constants — aligned with Chart.js default proportions */
-const XY = {
-  plotWidth: 600,
-  plotHeight: 340,
-  padding: 22,
-  titleFontSize: 18,
-  titleFontWeight: 600,
-  titleHeight: 42,
-  axisLabelFontSize: 14,
-  axisLabelFontWeight: 400,
-  axisTitleFontSize: 15,
-  axisTitleFontWeight: 500,
-  xLabelHeight: 38,
-  yLabelWidth: 58,
-  yLabelGap: 18,
-  axisTitlePad: 30,
-  tickLength: 4,
-  barPadRatio: 0.2,
-  barGroupGap: 0,
-  maxBarWidth: 40,
-  legendFontSize: 14,
-  legendFontWeight: 400,
-  legendHeight: 28,
-  legendSwatchW: 14,
-  legendSwatchH: 14,
-  legendGap: 6,
-  legendItemGap: 16,
-} as const
+const BAR_PADDING_PERCENT = 0.05
 
-/**
- * Lay out a parsed XY chart by computing pixel coordinates.
- */
 export function layoutXYChart(
   chart: XYChart,
-  _options: RenderOptions = {}
+  _options: RenderOptions = {},
 ): PositionedXYChart {
-  if (chart.horizontal) return layoutHorizontal(chart)
-  return layoutVertical(chart)
+  const config = resolveXYChartRenderConfig(chart.config)
+  if (chart.horizontal) return layoutHorizontal(chart, config)
+  return layoutVertical(chart, config)
 }
 
-// ============================================================================
-// Vertical layout (default)
-// ============================================================================
-
-function layoutVertical(chart: XYChart): PositionedXYChart {
-  const hasTitle = !!chart.title
-  const hasXTitle = !!chart.xAxis.title
-  const hasYTitle = !!chart.yAxis.title
-  const hasLegend = chart.series.length > 1
-
-  // Compute y-axis label width from tick labels
-  const yRange = chart.yAxis.range!
-  const yTicks = niceTickValues(yRange.min, yRange.max)
-  const maxYLabelWidth = Math.max(
-    ...yTicks.map(v => estimateTextWidth(formatTickValue(v), XY.axisLabelFontSize, XY.axisLabelFontWeight)),
-    XY.yLabelWidth
-  )
-
-  // Margins
-  const top = XY.padding + (hasTitle ? XY.titleHeight : 0) + (hasLegend ? XY.legendHeight : 0)
-  const bottom = XY.padding + XY.xLabelHeight + (hasXTitle ? XY.axisTitlePad : 0)
-  const left = XY.padding + maxYLabelWidth + XY.yLabelGap + (hasYTitle ? XY.axisTitlePad : 0)
-  const right = XY.padding
-
-  const plotW = XY.plotWidth
-  const plotH = XY.plotHeight
-  const totalW = left + plotW + right
-  const totalH = top + plotH + bottom
-
-  const plotArea: PlotArea = { x: left, y: top, width: plotW, height: plotH }
-
-  // Scales
+function layoutVertical(chart: XYChart, config: ResolvedXYChartConfig): PositionedXYChart {
+  const totalW = config.width
+  const totalH = config.height
   const dataCount = getDataCount(chart)
-  const xScale = (i: number) => left + (i + 0.5) * (plotW / dataCount)
-  const bandWidth = plotW / dataCount
-  const yScale = (v: number) => {
-    const t = (v - yRange.min) / (yRange.max - yRange.min || 1)
-    return top + plotH - t * plotH
+  const categoryLabels = getCategoryLabels(chart, dataCount)
+  const dataXValues = getDataXValues(chart, dataCount)
+  const yRange = chart.yAxis.range!
+  const yTickValues = linearTicks(yRange.min, yRange.max)
+  const yTickLabels = yTickValues.map(formatTickValue)
+  const xTickValues = chart.xAxis.range ? linearTicks(chart.xAxis.range.min, chart.xAxis.range.max) : undefined
+  const xTickLabels = xTickValues?.map(formatTickValue) ?? categoryLabels
+
+  let remainingTopBottomBudget = Math.max(0, totalH - Math.floor(totalH * config.plotReservedSpacePercent / 100))
+  let remainingLeftBudget = Math.max(0, totalW - Math.floor(totalW * config.plotReservedSpacePercent / 100))
+
+  const titleHeight = fitChartTitle(chart.title, config, remainingTopBottomBudget)
+  remainingTopBottomBudget = Math.max(0, remainingTopBottomBudget - titleHeight)
+
+  const xAxisConfig = fitHorizontalAxisConfig(config.xAxis, chart.xAxis.title, xTickLabels, remainingTopBottomBudget)
+  remainingTopBottomBudget = Math.max(0, remainingTopBottomBudget - xAxisConfig.size)
+
+  const yAxisConfig = fitVerticalAxisConfig(config.yAxis, chart.yAxis.title, yTickLabels, remainingLeftBudget)
+  remainingLeftBudget = Math.max(0, remainingLeftBudget - yAxisConfig.size)
+
+  const plotArea: PlotArea = {
+    x: yAxisConfig.size,
+    y: titleHeight,
+    width: Math.max(0, totalW - yAxisConfig.size),
+    height: Math.max(0, totalH - titleHeight - xAxisConfig.size),
   }
 
-  // X-axis ticks
-  const xTicks = buildXTicks(chart, xScale, top + plotH, bandWidth)
+  const xScaleValue = chart.xAxis.range
+    ? (value: number) => plotArea.x + ((value - chart.xAxis.range!.min) / (chart.xAxis.range!.max - chart.xAxis.range!.min || 1)) * plotArea.width
+    : undefined
+  const xPoint = (index: number) => xScaleValue ? xScaleValue(dataXValues[index]!) : plotArea.x + (index + 0.5) * (plotArea.width / dataCount)
+  const xPointSpacing = xScaleValue
+    ? getPointSpacing(dataXValues, xScaleValue, plotArea.width / Math.max(2, dataCount))
+    : plotArea.width / Math.max(1, dataCount)
+  const yScale = (value: number) => plotArea.y + plotArea.height - ((value - yRange.min) / (yRange.max - yRange.min || 1)) * plotArea.height
 
-  // Y-axis ticks
-  const yAxisTicks: AxisTick[] = yTicks.map(v => ({
-    label: formatTickValue(v),
-    x: left, y: yScale(v),
-    tx: left - XY.tickLength, ty: yScale(v),
-    labelX: left - XY.yLabelGap, labelY: yScale(v),
-    textAnchor: 'end' as const,
+  const xTicks = !xAxisConfig.config.showLabel
+    ? []
+    : chart.xAxis.range && xTickValues && xScaleValue
+      ? buildBottomAxisTicks(xTickValues, xTickLabels, xScaleValue, plotArea, xAxisConfig.config)
+      : buildBottomAxisTicks(
+        categoryLabels.map((_, index) => index),
+        categoryLabels,
+        xPoint,
+        plotArea,
+        xAxisConfig.config,
+      )
+  const yTicks = yAxisConfig.config.showLabel
+    ? buildLeftAxisTicks(
+      yTickValues,
+      yTickLabels,
+      yScale,
+      plotArea,
+      yAxisConfig.config,
+    )
+    : []
+
+  const gridLines: GridLine[] = yTickValues.map(value => ({
+    x1: plotArea.x,
+    y1: yScale(value),
+    x2: plotArea.x + plotArea.width,
+    y2: yScale(value),
   }))
 
-  // Grid lines (horizontal at each y tick)
-  const gridLines: GridLine[] = yTicks.map(v => ({
-    x1: left, y1: yScale(v), x2: left + plotW, y2: yScale(v),
-  }))
+  const colorMap = chart.series.map((_, index) => index)
+  const bars = layoutVerticalBars(chart, xPoint, xPointSpacing, yScale, yRange.min, categoryLabels, colorMap)
+  const lines = layoutVerticalLines(chart, xPoint, yScale, categoryLabels, colorMap)
 
-  // Category labels for data attributes
-  const catLabels = getCategoryLabels(chart, dataCount)
-
-  // Global color index map: each series gets a unique color index regardless of type
-  const colorMap = chart.series.map((_, i) => i)
-
-  // Bars
-  const bars = layoutBars(chart, xScale, yScale, bandWidth, yRange.min, catLabels, colorMap)
-
-  // Lines
-  const lines = layoutLines(chart, xScale, yScale, catLabels, colorMap)
-
-  // Legend
-  const legendY = XY.padding + (hasTitle ? XY.titleHeight : 0) + XY.legendHeight / 2
-  const legend = hasLegend ? buildLegendItems(chart, totalW / 2, legendY, colorMap) : []
-
-  // Axis lines
-  const xAxisLine = { x1: left, y1: top + plotH, x2: left + plotW, y2: top + plotH }
-  const yAxisLine = { x1: left, y1: top, x2: left, y2: top + plotH }
-
-  // Axis titles
-  const xAxisObj: PositionedAxis = {
-    ticks: xTicks,
-    line: xAxisLine,
-    ...(hasXTitle ? { title: { text: chart.xAxis.title!, x: left + plotW / 2, y: totalH - XY.padding } } : {}),
+  return {
+    width: totalW,
+    height: totalH,
+    accessibility: chart.accessibility,
+    title: titleHeight > 0 && chart.title
+      ? { text: chart.title, x: totalW / 2, y: config.titlePadding + config.titleFontSize }
+      : undefined,
+    xAxis: {
+      ticks: xTicks,
+      line: buildBottomAxisLine(plotArea, xAxisConfig.config),
+      title: buildBottomAxisTitle(chart.xAxis.title, plotArea, totalH, xAxisConfig.config),
+      config: xAxisConfig.config,
+    },
+    yAxis: {
+      ticks: yTicks,
+      line: buildLeftAxisLine(plotArea, yAxisConfig.config),
+      title: buildLeftAxisTitle(chart.yAxis.title, plotArea, yAxisConfig.config),
+      config: yAxisConfig.config,
+    },
+    plotArea,
+    bars,
+    lines,
+    gridLines,
+    legend: [],
+    config,
+    theme: chart.theme,
   }
-  const yAxisObj: PositionedAxis = {
-    ticks: yAxisTicks,
-    line: yAxisLine,
-    ...(hasYTitle ? { title: { text: chart.yAxis.title!, x: XY.padding + 4, y: top + plotH / 2, rotate: -90 } } : {}),
-  }
-
-  // Title
-  const titleObj = hasTitle ? { text: chart.title!, x: totalW / 2, y: XY.padding + XY.titleFontSize } : undefined
-
-  return { width: totalW, height: totalH, title: titleObj, xAxis: xAxisObj, yAxis: yAxisObj, plotArea, bars, lines, gridLines, legend }
 }
 
-// ============================================================================
-// Horizontal layout
-// ============================================================================
-
-function layoutHorizontal(chart: XYChart): PositionedXYChart {
-  const hasTitle = !!chart.title
-  const hasXTitle = !!chart.xAxis.title
-  const hasYTitle = !!chart.yAxis.title
-  const hasLegend = chart.series.length > 1
-
-  // In horizontal mode: categories go on y-axis (left side), values go on x-axis (bottom)
-  const yRange = chart.yAxis.range!
-  const valueTicks = niceTickValues(yRange.min, yRange.max)
-
-  // Compute category label widths for left margin
+function layoutHorizontal(chart: XYChart, config: ResolvedXYChartConfig): PositionedXYChart {
+  const totalW = config.width
+  const totalH = config.height
   const dataCount = getDataCount(chart)
-  const catLabels = getCategoryLabels(chart, dataCount)
-  const maxCatLabelWidth = Math.max(
-    ...catLabels.map(l => estimateTextWidth(l, XY.axisLabelFontSize, XY.axisLabelFontWeight)),
-    40
-  )
+  const categoryLabels = getCategoryLabels(chart, dataCount)
+  const yRange = chart.yAxis.range!
+  const valueTickValues = linearTicks(yRange.min, yRange.max)
+  const valueTickLabels = valueTickValues.map(formatTickValue)
 
-  const top = XY.padding + (hasTitle ? XY.titleHeight : 0) + (hasLegend ? XY.legendHeight : 0)
-  const bottom = XY.padding + XY.xLabelHeight + (hasYTitle ? XY.axisTitlePad : 0)
-  const left = XY.padding + maxCatLabelWidth + XY.yLabelGap + (hasXTitle ? XY.axisTitlePad : 0)
-  const right = XY.padding
+  let remainingTopBottomBudget = Math.max(0, totalH - Math.floor(totalH * config.plotReservedSpacePercent / 100))
+  let remainingLeftBudget = Math.max(0, totalW - Math.floor(totalW * config.plotReservedSpacePercent / 100))
 
-  const plotW = XY.plotWidth
-  const plotH = XY.plotHeight
-  const totalW = left + plotW + right
-  const totalH = top + plotH + bottom
+  const titleHeight = fitChartTitle(chart.title, config, remainingTopBottomBudget)
+  remainingTopBottomBudget = Math.max(0, remainingTopBottomBudget - titleHeight)
 
-  const plotArea: PlotArea = { x: left, y: top, width: plotW, height: plotH }
+  // Mermaid places the numeric value axis at the top in horizontal mode.
+  const topAxisConfig = fitTopAxisConfig(config.yAxis, chart.yAxis.title, valueTickLabels, remainingTopBottomBudget)
+  remainingTopBottomBudget = Math.max(0, remainingTopBottomBudget - topAxisConfig.size)
 
-  // Value scale (horizontal: left to right)
-  const valueScale = (v: number) => {
-    const t = (v - yRange.min) / (yRange.max - yRange.min || 1)
-    return left + t * plotW
+  const leftAxisConfig = fitVerticalAxisConfig(config.xAxis, chart.xAxis.title, categoryLabels, remainingLeftBudget)
+  remainingLeftBudget = Math.max(0, remainingLeftBudget - leftAxisConfig.size)
+
+  const plotArea: PlotArea = {
+    x: leftAxisConfig.size,
+    y: titleHeight + topAxisConfig.size,
+    width: Math.max(0, totalW - leftAxisConfig.size),
+    height: Math.max(0, totalH - titleHeight - topAxisConfig.size),
   }
 
-  // Category scale (vertical: top to bottom)
-  const bandHeight = plotH / dataCount
-  const catScale = (i: number) => top + (i + 0.5) * bandHeight
+  const valueScale = (value: number) => plotArea.x + ((value - yRange.min) / (yRange.max - yRange.min || 1)) * plotArea.width
+  const categoryPoint = (index: number) => plotArea.y + (index + 0.5) * (plotArea.height / dataCount)
+  const categorySpacing = plotArea.height / Math.max(1, dataCount)
 
-  // X-axis (bottom): value ticks
-  const xTicks: AxisTick[] = valueTicks.map(v => ({
-    label: formatTickValue(v),
-    x: valueScale(v), y: top + plotH,
-    tx: valueScale(v), ty: top + plotH + XY.tickLength,
-    labelX: valueScale(v), labelY: top + plotH + 18,
-    textAnchor: 'middle' as const,
+  const topTicks = topAxisConfig.config.showLabel
+    ? buildTopAxisTicks(valueTickValues, valueTickLabels, valueScale, plotArea, topAxisConfig.config)
+    : []
+  const leftTicks = leftAxisConfig.config.showLabel
+    ? buildLeftAxisTicks(
+      categoryLabels.map((_, index) => index),
+      categoryLabels,
+      categoryPoint,
+      plotArea,
+      leftAxisConfig.config,
+    )
+    : []
+
+  const gridLines: GridLine[] = valueTickValues.map(value => ({
+    x1: valueScale(value),
+    y1: plotArea.y,
+    x2: valueScale(value),
+    y2: plotArea.y + plotArea.height,
   }))
 
-  // Y-axis (left): category ticks
-  const yTicks: AxisTick[] = catLabels.map((label, i) => ({
-    label,
-    x: left, y: catScale(i),
-    tx: left - XY.tickLength, ty: catScale(i),
-    labelX: left - XY.yLabelGap, labelY: catScale(i),
-    textAnchor: 'end' as const,
-  }))
+  const colorMap = chart.series.map((_, index) => index)
+  const bars = layoutHorizontalBars(chart, categoryPoint, categorySpacing, valueScale, yRange.min, categoryLabels, colorMap)
+  const lines = layoutHorizontalLines(chart, categoryPoint, valueScale, categoryLabels, colorMap)
 
-  // Grid lines (vertical at each value tick)
-  const gridLines: GridLine[] = valueTicks.map(v => ({
-    x1: valueScale(v), y1: top, x2: valueScale(v), y2: top + plotH,
-  }))
+  return {
+    width: totalW,
+    height: totalH,
+    accessibility: chart.accessibility,
+    horizontal: true,
+    title: titleHeight > 0 && chart.title
+      ? { text: chart.title, x: totalW / 2, y: config.titlePadding + config.titleFontSize }
+      : undefined,
+    xAxis: {
+      ticks: leftTicks,
+      line: buildLeftAxisLine(plotArea, leftAxisConfig.config),
+      title: buildLeftAxisTitle(chart.xAxis.title, plotArea, leftAxisConfig.config),
+      config: leftAxisConfig.config,
+    },
+    yAxis: {
+      ticks: topTicks,
+      line: buildTopAxisLine(plotArea, topAxisConfig.config),
+      title: buildTopAxisTitle(chart.yAxis.title, plotArea, titleHeight, topAxisConfig.config),
+      config: topAxisConfig.config,
+    },
+    plotArea,
+    bars,
+    lines,
+    gridLines,
+    legend: [],
+    config,
+    theme: chart.theme,
+  }
+}
 
-  // Global color index map
-  const colorMap = chart.series.map((_, i) => i)
+function fitChartTitle(title: string | undefined, config: ResolvedXYChartConfig, budget: number): number {
+  if (!title || !config.showTitle) return 0
+  const required = config.titleFontSize + config.titlePadding * 2
+  return required <= budget ? required : 0
+}
 
-  // Bars (horizontal)
-  const barSeries = chart.series.filter(s => s.type === 'bar')
-  const barCount = barSeries.length
-  const bars: PositionedBar[] = []
-  if (barCount > 0) {
-    const usable = bandHeight * (1 - XY.barPadRatio)
-    const rawBarH = barCount > 1 ? (usable - (barCount - 1) * XY.barGroupGap) / barCount : usable
-    const singleBarH = Math.min(rawBarH, XY.maxBarWidth)
-    const groupH = barCount > 1
-      ? singleBarH * barCount + XY.barGroupGap * (barCount - 1)
-      : singleBarH
-    let bIdx = 0
-    let seriesArrayIdx = 0
-    for (const s of chart.series) {
-      if (s.type !== 'bar') { seriesArrayIdx++; continue }
-      for (let i = 0; i < s.data.length; i++) {
-        const cy = catScale(i)
-        const groupTop = cy - groupH / 2
-        const by = groupTop + bIdx * (singleBarH + XY.barGroupGap)
-        const valX = valueScale(Math.max(s.data[i]!, yRange.min))
-        const baseX = valueScale(Math.max(0, yRange.min))
-        bars.push({
-          x: Math.min(baseX, valX),
-          y: by,
-          width: Math.abs(valX - baseX),
-          height: singleBarH,
-          value: s.data[i]!,
-          label: catLabels[i]!,
-          seriesIndex: bIdx,
-          colorIndex: colorMap[seriesArrayIdx]!,
-        })
-      }
-      bIdx++
-      seriesArrayIdx++
+function fitHorizontalAxisConfig(
+  config: ResolvedXYAxisRenderConfig,
+  title: string | undefined,
+  labels: string[],
+  budget: number,
+): { config: ResolvedXYAxisRenderConfig; size: number } {
+  let remaining = budget
+  const fitted: ResolvedXYAxisRenderConfig = { ...config, showAxisLine: false, showLabel: false, showTick: false, showTitle: false }
+
+  if (config.showAxisLine && remaining > config.axisLineWidth) {
+    fitted.showAxisLine = true
+    remaining -= config.axisLineWidth
+  }
+  if (config.showLabel) {
+    const required = config.labelFontSize + config.labelPadding * 2
+    if (required <= remaining && labels.length > 0) {
+      fitted.showLabel = true
+      remaining -= required
+    }
+  }
+  if (config.showTick && remaining >= config.tickLength) {
+    fitted.showTick = true
+    remaining -= config.tickLength
+  }
+  if (config.showTitle && title) {
+    const required = config.titleFontSize + config.titlePadding * 2
+    if (required <= remaining) {
+      fitted.showTitle = true
+      remaining -= required
     }
   }
 
-  // Lines (horizontal: value on x, category index on y)
-  const lines: PositionedLine[] = []
-  let lineIdx = 0
-  let lineSeriesIdx = 0
-  for (const s of chart.series) {
-    if (s.type !== 'line') { lineSeriesIdx++; continue }
-    const points = s.data.map((v, i) => ({ x: valueScale(v), y: catScale(i), value: v, label: catLabels[i]! }))
-    lines.push({ points, seriesIndex: lineIdx, colorIndex: colorMap[lineSeriesIdx]! })
-    lineIdx++
-    lineSeriesIdx++
-  }
-
-  const xAxisLine = { x1: left, y1: top + plotH, x2: left + plotW, y2: top + plotH }
-  const yAxisLine = { x1: left, y1: top, x2: left, y2: top + plotH }
-
-  // In horizontal mode, the "y-axis" title describes values (bottom) and "x-axis" title describes categories (left)
-  const xAxisObj: PositionedAxis = {
-    ticks: xTicks,
-    line: xAxisLine,
-    ...(hasYTitle ? { title: { text: chart.yAxis.title!, x: left + plotW / 2, y: totalH - XY.padding } } : {}),
-  }
-  const yAxisObj: PositionedAxis = {
-    ticks: yTicks,
-    line: yAxisLine,
-    ...(hasXTitle ? { title: { text: chart.xAxis.title!, x: XY.padding + 4, y: top + plotH / 2, rotate: -90 } } : {}),
-  }
-
-  const titleObj = hasTitle ? { text: chart.title!, x: totalW / 2, y: XY.padding + XY.titleFontSize } : undefined
-
-  // Legend
-  const legendY = XY.padding + (hasTitle ? XY.titleHeight : 0) + XY.legendHeight / 2
-  const legend = hasLegend ? buildLegendItems(chart, totalW / 2, legendY, colorMap) : []
-
-  return { width: totalW, height: totalH, horizontal: true, title: titleObj, xAxis: xAxisObj, yAxis: yAxisObj, plotArea, bars, lines, gridLines, legend }
+  return { config: fitted, size: budget - remaining }
 }
 
-// ============================================================================
-// Helpers
-// ============================================================================
-
-function getDataCount(chart: XYChart): number {
-  if (chart.xAxis.categories) return chart.xAxis.categories.length
-  // For numeric range, use the length of the first series
-  for (const s of chart.series) {
-    if (s.data.length > 0) return s.data.length
-  }
-  return 1
+function fitTopAxisConfig(
+  config: ResolvedXYAxisRenderConfig,
+  title: string | undefined,
+  labels: string[],
+  budget: number,
+): { config: ResolvedXYAxisRenderConfig; size: number } {
+  return fitHorizontalAxisConfig(config, title, labels, budget)
 }
 
-function getCategoryLabels(chart: XYChart, count: number): string[] {
-  if (chart.xAxis.categories) return chart.xAxis.categories
-  if (chart.xAxis.range) {
-    const { min, max } = chart.xAxis.range
-    const step = count > 1 ? (max - min) / (count - 1) : 0
-    return Array.from({ length: count }, (_, i) => formatTickValue(min + step * i))
+function fitVerticalAxisConfig(
+  config: ResolvedXYAxisRenderConfig,
+  title: string | undefined,
+  labels: string[],
+  budget: number,
+): { config: ResolvedXYAxisRenderConfig; size: number } {
+  let remaining = budget
+  const fitted: ResolvedXYAxisRenderConfig = { ...config, showAxisLine: false, showLabel: false, showTick: false, showTitle: false }
+
+  if (config.showAxisLine && remaining > config.axisLineWidth) {
+    fitted.showAxisLine = true
+    remaining -= config.axisLineWidth
   }
-  return Array.from({ length: count }, (_, i) => String(i + 1))
+  if (config.showLabel && labels.length > 0) {
+    const maxLabelWidth = Math.max(...labels.map(label => estimateTextWidth(label, config.labelFontSize, 400)))
+    const required = maxLabelWidth + config.labelPadding * 2
+    if (required <= remaining) {
+      fitted.showLabel = true
+      remaining -= required
+    }
+  }
+  if (config.showTick && remaining >= config.tickLength) {
+    fitted.showTick = true
+    remaining -= config.tickLength
+  }
+  if (config.showTitle && title) {
+    const required = config.titleFontSize + config.titlePadding * 2
+    if (required <= remaining) {
+      fitted.showTitle = true
+      remaining -= required
+    }
+  }
+
+  return { config: fitted, size: budget - remaining }
 }
 
-function buildXTicks(chart: XYChart, xScale: (i: number) => number, axisY: number, _bandWidth: number): AxisTick[] {
-  const count = getDataCount(chart)
-  const labels = getCategoryLabels(chart, count)
-  return labels.map((label, i) => ({
-    label,
-    x: xScale(i), y: axisY,
-    tx: xScale(i), ty: axisY + XY.tickLength,
-    labelX: xScale(i), labelY: axisY + 18,
-    textAnchor: 'middle' as const,
+function buildBottomAxisTicks<T extends string | number>(
+  values: T[],
+  labels: string[],
+  scale: (value: T) => number,
+  plotArea: PlotArea,
+  config: ResolvedXYAxisRenderConfig,
+): AxisTick[] {
+  const lineOffset = config.showAxisLine ? config.axisLineWidth : 0
+  const tickOffset = config.showTick ? config.tickLength : 0
+  const labelY = plotArea.y + plotArea.height + lineOffset + tickOffset + config.labelPadding + config.labelFontSize
+
+  return values.map((value, index) => ({
+    label: labels[index]!,
+    x: scale(value),
+    y: plotArea.y + plotArea.height + lineOffset,
+    tx: scale(value),
+    ty: plotArea.y + plotArea.height + lineOffset + tickOffset,
+    labelX: scale(value),
+    labelY,
+    textAnchor: 'middle',
   }))
 }
 
-function layoutBars(
-  chart: XYChart, xScale: (i: number) => number, yScale: (v: number) => number,
-  bandWidth: number, yMin: number, catLabels: string[], colorMap: number[],
+function buildTopAxisTicks(
+  values: number[],
+  labels: string[],
+  scale: (value: number) => number,
+  plotArea: PlotArea,
+  config: ResolvedXYAxisRenderConfig,
+): AxisTick[] {
+  const lineOffset = config.showAxisLine ? config.axisLineWidth : 0
+  const tickOffset = config.showTick ? config.tickLength : 0
+  const labelY = plotArea.y - lineOffset - tickOffset - config.labelPadding
+
+  return values.map((value, index) => ({
+    label: labels[index]!,
+    x: scale(value),
+    y: plotArea.y - lineOffset,
+    tx: scale(value),
+    ty: plotArea.y - lineOffset - tickOffset,
+    labelX: scale(value),
+    labelY,
+    textAnchor: 'middle',
+  }))
+}
+
+function buildLeftAxisTicks<T extends string | number>(
+  values: T[],
+  labels: string[],
+  scale: (value: T) => number,
+  plotArea: PlotArea,
+  config: ResolvedXYAxisRenderConfig,
+): AxisTick[] {
+  const lineOffset = config.showAxisLine ? config.axisLineWidth : 0
+  const tickOffset = config.showTick ? config.tickLength : 0
+  const labelX = plotArea.x - lineOffset - tickOffset - config.labelPadding
+
+  return values.map((value, index) => ({
+    label: labels[index]!,
+    x: plotArea.x - lineOffset,
+    y: scale(value),
+    tx: plotArea.x - lineOffset - tickOffset,
+    ty: scale(value),
+    labelX,
+    labelY: scale(value),
+    textAnchor: 'end',
+  }))
+}
+
+function buildBottomAxisLine(plotArea: PlotArea, config: ResolvedXYAxisRenderConfig) {
+  const y = plotArea.y + plotArea.height + (config.showAxisLine ? config.axisLineWidth / 2 : 0)
+  return { x1: plotArea.x, y1: y, x2: plotArea.x + plotArea.width, y2: y }
+}
+
+function buildTopAxisLine(plotArea: PlotArea, config: ResolvedXYAxisRenderConfig) {
+  const y = plotArea.y - (config.showAxisLine ? config.axisLineWidth / 2 : 0)
+  return { x1: plotArea.x, y1: y, x2: plotArea.x + plotArea.width, y2: y }
+}
+
+function buildLeftAxisLine(plotArea: PlotArea, config: ResolvedXYAxisRenderConfig) {
+  const x = plotArea.x - (config.showAxisLine ? config.axisLineWidth / 2 : 0)
+  return { x1: x, y1: plotArea.y, x2: x, y2: plotArea.y + plotArea.height }
+}
+
+function buildBottomAxisTitle(
+  title: string | undefined,
+  plotArea: PlotArea,
+  totalHeight: number,
+  config: ResolvedXYAxisRenderConfig,
+) {
+  if (!title || !config.showTitle) return undefined
+  return {
+    text: title,
+    x: plotArea.x + plotArea.width / 2,
+    y: totalHeight - config.titlePadding,
+  }
+}
+
+function buildTopAxisTitle(
+  title: string | undefined,
+  plotArea: PlotArea,
+  titleHeight: number,
+  config: ResolvedXYAxisRenderConfig,
+) {
+  if (!title || !config.showTitle) return undefined
+  return {
+    text: title,
+    x: plotArea.x + plotArea.width / 2,
+    y: titleHeight + config.titlePadding + config.titleFontSize,
+  }
+}
+
+function buildLeftAxisTitle(
+  title: string | undefined,
+  plotArea: PlotArea,
+  config: ResolvedXYAxisRenderConfig,
+) {
+  if (!title || !config.showTitle) return undefined
+  return {
+    text: title,
+    x: config.titlePadding + config.titleFontSize * 0.8,
+    y: plotArea.y + plotArea.height / 2,
+    rotate: -90,
+  }
+}
+
+function layoutVerticalBars(
+  chart: XYChart,
+  xPoint: (index: number) => number,
+  pointSpacing: number,
+  yScale: (value: number) => number,
+  baselineValue: number,
+  labels: string[],
+  colorMap: number[],
 ): PositionedBar[] {
-  const barSeries = chart.series.filter(s => s.type === 'bar')
+  const barSeries = chart.series.filter(series => series.type === 'bar')
   const barCount = barSeries.length
   if (barCount === 0) return []
 
-  const usable = bandWidth * (1 - XY.barPadRatio)
-  const rawBarW = barCount > 1 ? (usable - (barCount - 1) * XY.barGroupGap) / barCount : usable
-  const singleBarW = Math.min(rawBarW, XY.maxBarWidth)
-  const groupW = barCount > 1
-    ? singleBarW * barCount + XY.barGroupGap * (barCount - 1)
-    : singleBarW
+  const usableWidth = pointSpacing * (1 - BAR_PADDING_PERCENT)
+  const barWidth = usableWidth / Math.max(1, barCount)
   const bars: PositionedBar[] = []
 
-  let bIdx = 0
-  let seriesArrayIdx = 0
-  for (const s of chart.series) {
-    if (s.type !== 'bar') { seriesArrayIdx++; continue }
-    for (let i = 0; i < s.data.length; i++) {
-      const cx = xScale(i)
-      const groupLeft = cx - groupW / 2
-      const bx = groupLeft + bIdx * (singleBarW + XY.barGroupGap)
-      const valY = yScale(s.data[i]!)
-      const baseY = yScale(Math.max(0, yMin))
+  let barSeriesIndex = 0
+  let seriesArrayIndex = 0
+  const baselineY = yScale(baselineValue)
+
+  for (const series of chart.series) {
+    if (series.type !== 'bar') {
+      seriesArrayIndex++
+      continue
+    }
+    for (let i = 0; i < series.data.length; i++) {
+      const x = xPoint(i) - usableWidth / 2 + barSeriesIndex * barWidth
+      const valueY = yScale(series.data[i]!)
       bars.push({
-        x: bx,
-        y: Math.min(valY, baseY),
-        width: singleBarW,
-        height: Math.abs(baseY - valY),
-        value: s.data[i]!,
-        label: catLabels[i]!,
-        seriesIndex: bIdx,
-        colorIndex: colorMap[seriesArrayIdx]!,
+        x,
+        y: Math.min(valueY, baselineY),
+        width: barWidth,
+        height: Math.abs(baselineY - valueY),
+        value: series.data[i]!,
+        label: labels[i]!,
+        seriesIndex: barSeriesIndex,
+        colorIndex: colorMap[seriesArrayIndex]!,
       })
     }
-    bIdx++
-    seriesArrayIdx++
+    barSeriesIndex++
+    seriesArrayIndex++
   }
+
   return bars
 }
 
-function layoutLines(chart: XYChart, xScale: (i: number) => number, yScale: (v: number) => number, catLabels: string[], colorMap: number[]): PositionedLine[] {
-  const lines: PositionedLine[] = []
-  let lineIdx = 0
-  let seriesArrayIdx = 0
-  for (const s of chart.series) {
-    if (s.type !== 'line') { seriesArrayIdx++; continue }
-    const points = s.data.map((v, i) => ({ x: xScale(i), y: yScale(v), value: v, label: catLabels[i]! }))
-    lines.push({ points, seriesIndex: lineIdx, colorIndex: colorMap[seriesArrayIdx]! })
-    lineIdx++
-    seriesArrayIdx++
+function layoutHorizontalBars(
+  chart: XYChart,
+  yPoint: (index: number) => number,
+  pointSpacing: number,
+  xScale: (value: number) => number,
+  baselineValue: number,
+  labels: string[],
+  colorMap: number[],
+): PositionedBar[] {
+  const barSeries = chart.series.filter(series => series.type === 'bar')
+  const barCount = barSeries.length
+  if (barCount === 0) return []
+
+  const usableHeight = pointSpacing * (1 - BAR_PADDING_PERCENT)
+  const barHeight = usableHeight / Math.max(1, barCount)
+  const bars: PositionedBar[] = []
+
+  let barSeriesIndex = 0
+  let seriesArrayIndex = 0
+  const baselineX = xScale(baselineValue)
+
+  for (const series of chart.series) {
+    if (series.type !== 'bar') {
+      seriesArrayIndex++
+      continue
+    }
+    for (let i = 0; i < series.data.length; i++) {
+      const y = yPoint(i) - usableHeight / 2 + barSeriesIndex * barHeight
+      const valueX = xScale(series.data[i]!)
+      bars.push({
+        x: Math.min(valueX, baselineX),
+        y,
+        width: Math.abs(valueX - baselineX),
+        height: barHeight,
+        value: series.data[i]!,
+        label: labels[i]!,
+        seriesIndex: barSeriesIndex,
+        colorIndex: colorMap[seriesArrayIndex]!,
+      })
+    }
+    barSeriesIndex++
+    seriesArrayIndex++
   }
+
+  return bars
+}
+
+function layoutVerticalLines(
+  chart: XYChart,
+  xPoint: (index: number) => number,
+  yScale: (value: number) => number,
+  labels: string[],
+  colorMap: number[],
+): PositionedLine[] {
+  const lines: PositionedLine[] = []
+  let lineSeriesIndex = 0
+  let seriesArrayIndex = 0
+
+  for (const series of chart.series) {
+    if (series.type !== 'line') {
+      seriesArrayIndex++
+      continue
+    }
+    lines.push({
+      points: series.data.map((value, index) => ({
+        x: xPoint(index),
+        y: yScale(value),
+        value,
+        label: labels[index]!,
+      })),
+      seriesIndex: lineSeriesIndex,
+      colorIndex: colorMap[seriesArrayIndex]!,
+    })
+    lineSeriesIndex++
+    seriesArrayIndex++
+  }
+
   return lines
 }
 
-/** Generate "nice" tick values for a numeric range */
-function niceTickValues(min: number, max: number): number[] {
-  const range = max - min
-  if (range <= 0) return [min]
+function layoutHorizontalLines(
+  chart: XYChart,
+  yPoint: (index: number) => number,
+  xScale: (value: number) => number,
+  labels: string[],
+  colorMap: number[],
+): PositionedLine[] {
+  const lines: PositionedLine[] = []
+  let lineSeriesIndex = 0
+  let seriesArrayIndex = 0
 
-  // Find nice interval
-  const rawInterval = range / 6
-  const magnitude = Math.pow(10, Math.floor(Math.log10(rawInterval)))
-  const residual = rawInterval / magnitude
-  let niceInterval: number
-  if (residual <= 1.5) niceInterval = magnitude
-  else if (residual <= 3) niceInterval = 2 * magnitude
-  else if (residual <= 7) niceInterval = 5 * magnitude
-  else niceInterval = 10 * magnitude
-
-  const start = Math.ceil(min / niceInterval) * niceInterval
-  const ticks: number[] = []
-  for (let v = start; v <= max + niceInterval * 0.001; v += niceInterval) {
-    ticks.push(Math.round(v * 1e10) / 1e10) // avoid floating-point noise
-  }
-  return ticks
-}
-
-function formatTickValue(v: number): string {
-  if (Number.isInteger(v)) return String(v)
-  // Limit decimal places
-  return v.toFixed(Math.abs(v) < 10 ? 1 : 0)
-}
-
-/** Build centered legend items for multi-series charts */
-function buildLegendItems(chart: XYChart, centerX: number, y: number, colorMap: number[]): LegendItem[] {
-  const items: LegendItem[] = []
-  let barIdx = 0, lineIdx = 0
-  for (let si = 0; si < chart.series.length; si++) {
-    const s = chart.series[si]!
-    const label = s.type === 'bar' ? `Bar ${barIdx + 1}` : `Line ${lineIdx + 1}`
-    items.push({ label, x: 0, y, type: s.type, seriesIndex: s.type === 'bar' ? barIdx : lineIdx, colorIndex: colorMap[si]! })
-    if (s.type === 'bar') barIdx++
-    else lineIdx++
+  for (const series of chart.series) {
+    if (series.type !== 'line') {
+      seriesArrayIndex++
+      continue
+    }
+    lines.push({
+      points: series.data.map((value, index) => ({
+        x: xScale(value),
+        y: yPoint(index),
+        value,
+        label: labels[index]!,
+      })),
+      seriesIndex: lineSeriesIndex,
+      colorIndex: colorMap[seriesArrayIndex]!,
+    })
+    lineSeriesIndex++
+    seriesArrayIndex++
   }
 
-  // Measure total width, then center
-  const itemWidths = items.map(item => {
-    const textW = estimateTextWidth(item.label, XY.legendFontSize, XY.legendFontWeight)
-    return XY.legendSwatchW + XY.legendGap + textW
-  })
-  const totalWidth = itemWidths.reduce((a, b) => a + b, 0) + (items.length - 1) * XY.legendItemGap
-  let x = centerX - totalWidth / 2
-
-  for (let i = 0; i < items.length; i++) {
-    items[i]!.x = x
-    x += itemWidths[i]! + XY.legendItemGap
-  }
-
-  return items
+  return lines
 }

--- a/src/xychart/parser.ts
+++ b/src/xychart/parser.ts
@@ -1,12 +1,25 @@
-import type { XYChart, XYAxis, XYChartSeries } from './types.ts'
+import {
+  getFrontmatterList,
+  getFrontmatterMap,
+  getFrontmatterScalar,
+  type MermaidFrontmatterMap,
+} from '../mermaid-source.ts'
+import type {
+  XYChart,
+  XYAxis,
+  XYAxisRenderConfig,
+  XYChartConfig,
+  XYChartSeries,
+  XYChartTheme,
+} from './types.ts'
 
 // ============================================================================
 // XY Chart parser
 //
-// Parses Mermaid xychart-beta syntax into a typed XYChart structure.
+// Parses Mermaid xychart syntax into a typed XYChart structure.
 //
 // Supported directives:
-//   xychart-beta [horizontal]
+//   xychart [horizontal]
 //   title "Chart Title"
 //   x-axis [label1, label2, ...]          — categorical
 //   x-axis min --> max                     — numeric range
@@ -18,72 +31,99 @@ import type { XYChart, XYAxis, XYChartSeries } from './types.ts'
 // ============================================================================
 
 /**
- * Parse a Mermaid xychart-beta diagram from preprocessed lines.
+ * Parse a Mermaid xychart / xychart-beta diagram from preprocessed lines.
  * Lines should already be trimmed and comment-stripped.
  */
-export function parseXYChart(lines: string[]): XYChart {
+export function parseXYChart(lines: string[], frontmatter: MermaidFrontmatterMap = {}): XYChart {
   const xAxis: XYAxis = {}
   const yAxis: XYAxis = {}
   const series: XYChartSeries[] = []
+  const config = resolveXYChartConfig(frontmatter)
+  const theme = resolveXYChartTheme(frontmatter)
+  const statements = expandXYChartStatements(lines)
   let title: string | undefined
+  let accTitle: string | undefined
+  let accDescription: string | undefined
   let horizontal = false
+  let headerOrientation: 'vertical' | 'horizontal' | undefined
 
-  for (const line of lines) {
+  for (let index = 0; index < statements.length; index++) {
+    const line = statements[index]!
+
     // Header line — detect horizontal
     if (/^xychart(-beta)?\b/i.test(line)) {
-      if (/\bhorizontal\b/i.test(line)) horizontal = true
+      if (/\bhorizontal\b/i.test(line)) {
+        horizontal = true
+        headerOrientation = 'horizontal'
+      } else if (/\bvertical\b/i.test(line)) {
+        horizontal = false
+        headerOrientation = 'vertical'
+      }
+      continue
+    }
+
+    const accTitleMatch = line.match(/^accTitle\s*:?\s*(.+)$/i)
+    if (accTitleMatch) {
+      accTitle = parseDirectiveText(accTitleMatch[1]!)
+      continue
+    }
+
+    const accDescrBlockMatch = line.match(/^accDescr\s*:?\s*\{\s*$/i)
+    if (accDescrBlockMatch) {
+      const block: string[] = []
+      for (index += 1; index < statements.length; index++) {
+        const blockLine = statements[index]!
+        if (blockLine === '}') break
+        block.push(blockLine)
+      }
+      accDescription = block.join('\n').trim() || undefined
+      continue
+    }
+
+    const accDescrMatch = line.match(/^accDescr\s*:?\s*(.+)$/i)
+    if (accDescrMatch) {
+      accDescription = parseDirectiveText(accDescrMatch[1]!)
       continue
     }
 
     // Title
-    const titleMatch = line.match(/^title\s+"([^"]+)"/)
+    const titleMatch = line.match(/^title\s+(.+)$/)
     if (titleMatch) {
-      title = titleMatch[1]
+      title = parseDirectiveText(titleMatch[1]!)
       continue
     }
 
-    // x-axis with categories: x-axis "Title" [a, b, c] or x-axis [a, b, c]
-    const xCatMatch = line.match(/^x-axis\s+(?:"([^"]*)"\s*)?\[([^\]]+)\]/)
-    if (xCatMatch) {
-      if (xCatMatch[1]) xAxis.title = xCatMatch[1]
-      xAxis.categories = xCatMatch[2]!.split(',').map(s => s.trim())
+    // x-axis: optional title with either categories or numeric range
+    const xAxisMatch = line.match(/^x-axis\s+(.+)$/)
+    if (xAxisMatch) {
+      applyAxisDirective(xAxis, xAxisMatch[1]!, 'x')
       continue
     }
 
-    // x-axis with range: x-axis "Title" min --> max or x-axis min --> max
-    const xRangeMatch = line.match(/^x-axis\s+(?:"([^"]*)"\s+)?(-?\d+(?:\.\d+)?)\s*-->\s*(-?\d+(?:\.\d+)?)/)
-    if (xRangeMatch) {
-      if (xRangeMatch[1]) xAxis.title = xRangeMatch[1]
-      xAxis.range = { min: parseFloat(xRangeMatch[2]!), max: parseFloat(xRangeMatch[3]!) }
+    // y-axis: numeric range only, optionally with a title
+    const yAxisMatch = line.match(/^y-axis\s+(.+)$/)
+    if (yAxisMatch) {
+      applyAxisDirective(yAxis, yAxisMatch[1]!, 'y')
       continue
     }
 
-    // y-axis with range: y-axis "Title" min --> max or y-axis min --> max
-    const yRangeMatch = line.match(/^y-axis\s+(?:"([^"]*)"\s+)?(-?\d+(?:\.\d+)?)\s*-->\s*(-?\d+(?:\.\d+)?)/)
-    if (yRangeMatch) {
-      if (yRangeMatch[1]) yAxis.title = yRangeMatch[1]
-      yAxis.range = { min: parseFloat(yRangeMatch[2]!), max: parseFloat(yRangeMatch[3]!) }
-      continue
-    }
-
-    // y-axis with just title (no range)
-    const yTitleOnly = line.match(/^y-axis\s+"([^"]+)"\s*$/)
-    if (yTitleOnly) {
-      yAxis.title = yTitleOnly[1]
-      continue
-    }
-
-    // bar [...]
-    const barMatch = line.match(/^bar\s+\[([^\]]+)\]/)
+    const barMatch = line.match(/^bar(?:\s+(.+?))?\s+\[([^\]]+)\]\s*$/)
     if (barMatch) {
-      series.push({ type: 'bar', data: parseNumericArray(barMatch[1]!) })
+      series.push({
+        type: 'bar',
+        label: parseOptionalSeriesLabel(barMatch[1]),
+        data: parseNumericArray(barMatch[2]!),
+      })
       continue
     }
 
-    // line [...]
-    const lineMatch = line.match(/^line\s+\[([^\]]+)\]/)
+    const lineMatch = line.match(/^line(?:\s+(.+?))?\s+\[([^\]]+)\]\s*$/)
     if (lineMatch) {
-      series.push({ type: 'line', data: parseNumericArray(lineMatch[1]!) })
+      series.push({
+        type: 'line',
+        label: parseOptionalSeriesLabel(lineMatch[1]),
+        data: parseNumericArray(lineMatch[2]!),
+      })
       continue
     }
   }
@@ -107,9 +147,348 @@ export function parseXYChart(lines: string[]): XYChart {
     yAxis.range = { min: 0, max: 100 }
   }
 
-  return { title, horizontal, xAxis, yAxis, series }
+  if (!headerOrientation && config.chartOrientation === 'horizontal') {
+    horizontal = true
+  }
+
+  return {
+    title,
+    accessibility: accTitle || accDescription ? { title: accTitle, description: accDescription } : undefined,
+    horizontal,
+    xAxis,
+    yAxis,
+    series,
+    config,
+    theme,
+  }
 }
 
 function parseNumericArray(str: string): number[] {
-  return str.split(',').map(s => parseFloat(s.trim()))
+  return splitCommaList(str).map(s => parseFloat(s))
+}
+
+const NUMBER_PATTERN = String.raw`[+-]?(?:\d+(?:\.\d+)?|\.\d+)`
+const RANGE_REGEX = new RegExp(`^(${NUMBER_PATTERN})\\s*-->\\s*(${NUMBER_PATTERN})$`)
+
+function applyAxisDirective(axis: XYAxis, rawValue: string, axisName: 'x' | 'y'): void {
+  const value = rawValue.trim()
+  if (value.length === 0) return
+
+  const categoriesMatch = value.match(/\[(.*)\]\s*$/)
+  if (categoriesMatch && axisName === 'x') {
+    const prefix = value.slice(0, categoriesMatch.index).trim()
+    if (prefix.length > 0) axis.title = parseDirectiveText(prefix)
+    axis.categories = splitCommaList(categoriesMatch[1]!)
+    return
+  }
+
+  const rangeOnly = value.match(RANGE_REGEX)
+  if (rangeOnly) {
+    axis.range = { min: parseFloat(rangeOnly[1]!), max: parseFloat(rangeOnly[2]!) }
+    return
+  }
+
+  const titledRange = parseLeadingTextToken(value)
+  if (titledRange) {
+    const rangeMatch = titledRange.rest.match(RANGE_REGEX)
+    if (rangeMatch) {
+      axis.title = parseDirectiveText(titledRange.value)
+      axis.range = { min: parseFloat(rangeMatch[1]!), max: parseFloat(rangeMatch[2]!) }
+      return
+    }
+
+    if (axisName === 'x' && titledRange.rest.length === 0) {
+      axis.title = parseDirectiveText(titledRange.value)
+    }
+  }
+}
+
+function parseLeadingTextToken(text: string): { value: string; rest: string } | undefined {
+  const trimmed = text.trim()
+  if (trimmed.length === 0) return undefined
+
+  if (trimmed.startsWith('"') || trimmed.startsWith("'")) {
+    const quote = trimmed[0]!
+    let end = 1
+    while (end < trimmed.length) {
+      if (trimmed[end] === quote && trimmed[end - 1] !== '\\') break
+      end++
+    }
+    if (end >= trimmed.length) return undefined
+    return {
+      value: trimmed.slice(1, end),
+      rest: trimmed.slice(end + 1).trim(),
+    }
+  }
+
+  const match = trimmed.match(/^([^\s]+)(?:\s+(.*))?$/)
+  if (!match) return undefined
+  return {
+    value: match[1]!,
+    rest: (match[2] ?? '').trim(),
+  }
+}
+
+function parseTextLiteral(text: string): string {
+  const token = parseLeadingTextToken(text)
+  return token ? token.value : text.trim()
+}
+
+function parseDirectiveText(text: string): string {
+  const trimmed = text.trim()
+  if (trimmed.startsWith('"') || trimmed.startsWith("'")) return parseTextLiteral(trimmed)
+  return trimmed
+}
+
+function parseOptionalSeriesLabel(value: string | undefined): string | undefined {
+  if (!value) return undefined
+  const trimmed = value.trim()
+  return trimmed ? parseDirectiveText(trimmed) : undefined
+}
+
+function splitCommaList(text: string): string[] {
+  const values: string[] = []
+  let current = ''
+  let quote: '"' | "'" | null = null
+
+  for (let i = 0; i < text.length; i++) {
+    const char = text[i]!
+    if (quote) {
+      if (char === quote && text[i - 1] !== '\\') {
+        quote = null
+      } else {
+        current += char
+      }
+      continue
+    }
+
+    if (char === '"' || char === "'") {
+      quote = char
+      continue
+    }
+
+    if (char === ',') {
+      pushValue(values, current)
+      current = ''
+      continue
+    }
+
+    current += char
+  }
+
+  pushValue(values, current)
+  return values
+}
+
+function pushValue(values: string[], rawValue: string): void {
+  const value = rawValue.trim()
+  if (value.length > 0) values.push(value)
+}
+
+function resolveXYChartConfig(frontmatter: MermaidFrontmatterMap): XYChartConfig {
+  const configRoot = getFrontmatterMap(frontmatter, ['config']) ?? frontmatter
+  const root = getFrontmatterMap(frontmatter, ['config', 'xyChart']) ?? getFrontmatterMap(frontmatter, ['xyChart']) ?? {}
+  const chartOrientation = getString(root, ['chartOrientation'])
+  return {
+    width: getPositiveNumber(root, ['width']),
+    height: getPositiveNumber(root, ['height']),
+    useMaxWidth: getBoolean(root, ['useMaxWidth']) ?? getBoolean(configRoot, ['useMaxWidth']),
+    useWidth: getPositiveNumber(root, ['useWidth']) ?? getPositiveNumber(configRoot, ['useWidth']),
+    titleFontSize: getPositiveNumber(root, ['titleFontSize']),
+    titlePadding: getNonNegativeNumber(root, ['titlePadding']),
+    chartOrientation: chartOrientation === 'horizontal' || chartOrientation === 'vertical'
+      ? chartOrientation
+      : undefined,
+    plotReservedSpacePercent: getPositiveNumber(root, ['plotReservedSpacePercent']),
+    showDataLabel: getBoolean(root, ['showDataLabel']),
+    showTitle: getBoolean(root, ['showTitle']),
+    xAxis: resolveAxisConfig(root, 'xAxis'),
+    yAxis: resolveAxisConfig(root, 'yAxis'),
+  }
+}
+
+function resolveXYChartTheme(frontmatter: MermaidFrontmatterMap): XYChartTheme {
+  const configRoot = getFrontmatterMap(frontmatter, ['config']) ?? frontmatter
+  const root = getFrontmatterMap(frontmatter, ['config', 'themeVariables', 'xyChart'])
+    ?? getFrontmatterMap(frontmatter, ['themeVariables', 'xyChart'])
+    ?? {}
+  return {
+    backgroundColor: getString(root, ['backgroundColor']),
+    themeCss: getString(configRoot, ['themeCSS']),
+    titleColor: getString(root, ['titleColor']),
+    xAxisLabelColor: getString(root, ['xAxisLabelColor']),
+    xAxisTickColor: getString(root, ['xAxisTickColor']),
+    xAxisLineColor: getString(root, ['xAxisLineColor']),
+    xAxisTitleColor: getString(root, ['xAxisTitleColor']),
+    yAxisLabelColor: getString(root, ['yAxisLabelColor']),
+    yAxisTickColor: getString(root, ['yAxisTickColor']),
+    yAxisLineColor: getString(root, ['yAxisLineColor']),
+    yAxisTitleColor: getString(root, ['yAxisTitleColor']),
+    plotColorPalette: getPalette(root, ['plotColorPalette']),
+  }
+}
+
+function resolveAxisConfig(root: MermaidFrontmatterMap, key: 'xAxis' | 'yAxis'): XYAxisRenderConfig | undefined {
+  const axisRoot = getFrontmatterMap(root, [key])
+  if (!axisRoot) return undefined
+  const showLabel = getBoolean(axisRoot, ['showLabel'])
+  const labelFontSize = getPositiveNumber(axisRoot, ['labelFontSize'])
+  const labelPadding = getNonNegativeNumber(axisRoot, ['labelPadding'])
+  const showTitle = getBoolean(axisRoot, ['showTitle'])
+  const titleFontSize = getPositiveNumber(axisRoot, ['titleFontSize'])
+  const titlePadding = getNonNegativeNumber(axisRoot, ['titlePadding'])
+  const showTick = getBoolean(axisRoot, ['showTick'])
+  const tickLength = getNonNegativeNumber(axisRoot, ['tickLength'])
+  const tickWidth = getPositiveNumber(axisRoot, ['tickWidth'])
+  const showAxisLine = getBoolean(axisRoot, ['showAxisLine'])
+  const axisLineWidth = getPositiveNumber(axisRoot, ['axisLineWidth'])
+
+  if (
+    showLabel === undefined &&
+    labelFontSize === undefined &&
+    labelPadding === undefined &&
+    showTitle === undefined &&
+    titleFontSize === undefined &&
+    titlePadding === undefined &&
+    showTick === undefined &&
+    tickLength === undefined &&
+    tickWidth === undefined &&
+    showAxisLine === undefined &&
+    axisLineWidth === undefined
+  ) {
+    return undefined
+  }
+
+  return {
+    showLabel,
+    labelFontSize,
+    labelPadding,
+    showTitle,
+    titleFontSize,
+    titlePadding,
+    showTick,
+    tickLength,
+    tickWidth,
+    showAxisLine,
+    axisLineWidth,
+  }
+}
+
+function parsePalette(value: string | undefined): string[] | undefined {
+  if (!value) return undefined
+  const items = value.split(',').map(item => item.trim()).filter(Boolean)
+  return items.length > 0 ? items : undefined
+}
+
+function getPalette(root: MermaidFrontmatterMap, path: readonly string[]): string[] | undefined {
+  const fromList = getFrontmatterList<string | number | boolean | null>(root, path)
+  if (fromList && fromList.length > 0) {
+    const items = fromList
+      .filter((value): value is string => typeof value === 'string')
+      .map(value => value.trim())
+      .filter(Boolean)
+    if (items.length > 0) return items
+  }
+
+  return parsePalette(getString(root, path))
+}
+
+function getBoolean(root: MermaidFrontmatterMap, path: readonly string[]): boolean | undefined {
+  const value = getFrontmatterScalar<boolean>(root, path)
+  return typeof value === 'boolean' ? value : undefined
+}
+
+function getPositiveNumber(root: MermaidFrontmatterMap, path: readonly string[]): number | undefined {
+  const value = getFrontmatterScalar<number>(root, path)
+  return typeof value === 'number' && Number.isFinite(value) && value > 0 ? value : undefined
+}
+
+function getNonNegativeNumber(root: MermaidFrontmatterMap, path: readonly string[]): number | undefined {
+  const value = getFrontmatterScalar<number>(root, path)
+  return typeof value === 'number' && Number.isFinite(value) && value >= 0 ? value : undefined
+}
+
+function getString(root: MermaidFrontmatterMap, path: readonly string[]): string | undefined {
+  const value = getFrontmatterScalar<string>(root, path)
+  return typeof value === 'string' && value.trim().length > 0 ? value.trim() : undefined
+}
+
+function expandXYChartStatements(lines: string[]): string[] {
+  const statements: string[] = []
+  let inAccDescrBlock = false
+
+  for (const rawLine of lines) {
+    const line = rawLine.trim()
+    if (!line) continue
+
+    if (inAccDescrBlock) {
+      statements.push(line)
+      if (line === '}') inAccDescrBlock = false
+      continue
+    }
+
+    const parts = splitSemicolonStatements(line)
+    for (const part of parts) {
+      statements.push(part)
+      if (/^accDescr\s*:?\s*\{\s*$/i.test(part)) inAccDescrBlock = true
+    }
+  }
+
+  return statements
+}
+
+function splitSemicolonStatements(text: string): string[] {
+  const statements: string[] = []
+  let current = ''
+  let quote: '"' | "'" | null = null
+  let bracketDepth = 0
+  let braceDepth = 0
+
+  for (let i = 0; i < text.length; i++) {
+    const char = text[i]!
+    if (quote) {
+      current += char
+      if (char === quote && text[i - 1] !== '\\') quote = null
+      continue
+    }
+
+    if (char === '"' || char === "'") {
+      quote = char
+      current += char
+      continue
+    }
+    if (char === '[') {
+      bracketDepth++
+      current += char
+      continue
+    }
+    if (char === ']') {
+      bracketDepth--
+      current += char
+      continue
+    }
+    if (char === '{') {
+      braceDepth++
+      current += char
+      continue
+    }
+    if (char === '}') {
+      braceDepth--
+      current += char
+      continue
+    }
+
+    if (char === ';' && bracketDepth === 0 && braceDepth === 0) {
+      const statement = current.trim()
+      if (statement) statements.push(statement)
+      current = ''
+      continue
+    }
+
+    current += char
+  }
+
+  const trailing = current.trim()
+  if (trailing) statements.push(trailing)
+  return statements
 }

--- a/src/xychart/renderer.ts
+++ b/src/xychart/renderer.ts
@@ -1,4 +1,4 @@
-import type { PositionedXYChart } from './types.ts'
+import type { PositionedBar, PositionedXYChart } from './types.ts'
 import type { DiagramColors } from '../theme.ts'
 import { svgOpenTag, buildStyleBlock } from '../theme.ts'
 import { TEXT_BASELINE_SHIFT, estimateTextWidth } from '../styles.ts'
@@ -7,38 +7,17 @@ import { getSeriesColor, CHART_ACCENT_FALLBACK } from './colors.ts'
 // ============================================================================
 // XY Chart SVG renderer
 //
-// Renders positioned XY charts to SVG strings.
-// All colors use CSS custom properties (var(--_xxx)) from the theme system.
-//
-// Visual style: clean, minimal, modern. Inspired by Apple/Craft chart design.
-//   - No axis lines or tick marks — labels float freely
-//   - Ultra-subtle solid grid lines
-//   - Bars with rounded tops, flat at baseline
-//   - Smooth curved lines, no visible dots (dots appear on hover)
-//
-// Render order (back to front):
-//   1. Grid lines
-//   2. Bars (as paths with rounded tops)
-//   3. Lines (smooth curves)
-//   4. Dots (hidden by default, visible on hover when interactive)
-//   5. Axis labels
-//   6. Axis titles
-//   7. Chart title
-//   8. Legend
+// Rendered output now tracks Mermaid's own xychart structure more closely:
+// fixed chart dimensions, explicit axis lines/ticks, simple grid lines,
+// straight line segments, and in-bar data labels for bar plots.
 // ============================================================================
 
 const CHART_FONT = {
-  titleSize: 18,
-  titleWeight: 600,
-  axisTitleSize: 15,
-  axisTitleWeight: 500,
-  labelSize: 14,
+  titleWeight: 500,
+  axisTitleWeight: 400,
   labelWeight: 400,
-  legendSize: 14,
-  legendWeight: 400,
-  dotRadius: 5,
-  lineWidth: 2.5,
-  barRadius: 8,
+  dotRadius: 4,
+  lineWidth: 3,
 } as const
 
 const TIP = {
@@ -52,9 +31,6 @@ const TIP = {
   pointerSize: 6,
 } as const
 
-/**
- * Render a positioned XY chart as an SVG string.
- */
 export function renderXYChartSvg(
   chart: PositionedXYChart,
   colors: DiagramColors,
@@ -64,256 +40,184 @@ export function renderXYChartSvg(
 ): string {
   const parts: string[] = []
 
-  // SVG root + base styles
-  // Stamp data-xychart-colors so theme-switching JS knows how many series color vars to update
-  const maxColorIdx = Math.max(0, ...chart.bars.map(b => b.colorIndex), ...chart.lines.map(l => l.colorIndex))
-  const svgTag = svgOpenTag(chart.width, chart.height, colors, transparent)
+  const maxColorIdx = Math.max(0, ...chart.bars.map(bar => bar.colorIndex), ...chart.lines.map(line => line.colorIndex))
+  const svgMeta = buildSvgMetadata(chart)
+  const svgTag = svgOpenTag(chart.width, chart.height, colors, transparent, svgMeta.openTag)
     .replace('<svg ', `<svg data-xychart-colors="${maxColorIdx}" `)
   parts.push(svgTag)
   parts.push(buildStyleBlock(font, false))
 
-  // Sparse lines (≤12 points) show dots by default
-  const maxLinePoints = Math.max(...chart.lines.map(l => l.points.length), 0)
-  const sparse = maxLinePoints > 0 && maxLinePoints <= 12
+  const { style, defs } = chartStyles(chart, interactive, colors.accent, colors.bg)
+  parts.push(style)
+  if (defs) parts.push(defs)
+  if (svgMeta.title) parts.push(svgMeta.title)
+  if (svgMeta.description) parts.push(svgMeta.description)
 
-  // Chart-specific styles + gradient defs
-  const { style: chartCss, defs: chartDefs } = chartStyles(chart, interactive, sparse, colors.accent, colors.bg)
-  parts.push(chartCss)
-  if (chartDefs) parts.push(chartDefs)
-
-  // 1. Dot grid (dense dots across plot area, aligned to tick spacing)
-  const { plotArea } = chart
-  const xTicks = chart.xAxis.ticks.map(t => t.x)
-  const yVals = chart.horizontal
-    ? chart.yAxis.ticks.map(t => t.y)
-    : chart.gridLines.map(g => g.y1)
-  const xBase = xTicks.length > 1 ? Math.abs(xTicks[1]! - xTicks[0]!) : plotArea.width / 6
-  const yBase = yVals.length > 1 ? Math.abs(yVals[1]! - yVals[0]!) : plotArea.height / 6
-  const xGap = xBase / Math.max(1, Math.round(xBase / 20))
-  const yGap = yBase / Math.max(1, Math.round(yBase / 20))
-  const xAnchor = xTicks[0] ?? plotArea.x
-  const yAnchor = yVals[0] ?? plotArea.y
-  const xStart = xAnchor - Math.ceil((xAnchor - plotArea.x) / xGap) * xGap
-  const yStart = yAnchor - Math.ceil((yAnchor - plotArea.y) / yGap) * yGap
-  for (let y = yStart; y <= plotArea.y + plotArea.height + 0.5; y += yGap) {
-    for (let x = xStart; x <= plotArea.x + plotArea.width + 0.5; x += xGap) {
-      parts.push(`<circle cx="${r(x)}" cy="${r(y)}" r="1.5" class="xychart-grid"/>`)
-    }
+  for (const gridLine of chart.gridLines) {
+    parts.push(
+      `<line x1="${r(gridLine.x1)}" y1="${r(gridLine.y1)}" x2="${r(gridLine.x2)}" y2="${r(gridLine.y2)}" class="xychart-grid"/>`
+    )
   }
 
-  // 2. Bars — always render bar paths inline (before lines for correct z-order)
-  //    Interactive: also build overlay groups with transparent hit-areas + tooltips (deferred to step 9)
+  renderAxis(parts, chart.xAxis, 'x')
+  renderAxis(parts, chart.yAxis, 'y')
+
   const barOverlay: string[] = []
   for (const bar of chart.bars) {
     const dataAttrs = ` data-value="${bar.value}"${bar.label ? ` data-label="${escapeXml(bar.label)}"` : ''}`
-    const barPath = chart.horizontal
-      ? roundedRightBarPath(bar.x, bar.y, bar.width, bar.height, CHART_FONT.barRadius)
-      : roundedTopBarPath(bar.x, bar.y, bar.width, bar.height, CHART_FONT.barRadius)
     parts.push(
-      `<path d="${barPath}" class="xychart-bar xychart-color-${bar.colorIndex}"${dataAttrs}/>`
+      `<rect x="${r(bar.x)}" y="${r(bar.y)}" width="${r(bar.width)}" height="${r(bar.height)}" ` +
+      `class="xychart-bar xychart-color-${bar.colorIndex}"${dataAttrs}/>`
     )
+
     if (interactive) {
       const tipText = formatTipValue(bar.value)
       const tipTitle = bar.label ? `${bar.label}: ${tipText}` : tipText
-      const tip = tooltipAbove(bar.x + bar.width / 2, bar.y, tipText)
+      const tipAnchorX = chart.horizontal ? bar.x + bar.width : bar.x + bar.width / 2
+      const tipAnchorY = chart.horizontal ? bar.y + bar.height / 2 : bar.y
       barOverlay.push(
         `<g class="xychart-bar-group">` +
         `<rect x="${r(bar.x)}" y="${r(bar.y)}" width="${r(bar.width)}" height="${r(bar.height)}" fill="transparent"/>` +
         `<title>${escapeXml(tipTitle)}</title>` +
-        tip +
+        tooltipAbove(tipAnchorX, tipAnchorY, tipText) +
         `</g>`
       )
     }
   }
 
-  // 3. Lines — shadow first (wider, low opacity), then crisp line on top
   for (const line of chart.lines) {
     if (line.points.length === 0) continue
-    const d = smoothCurvePath(line.points)
-    parts.push(`<path d="${d}" class="xychart-line-shadow xychart-color-${line.colorIndex}" transform="translate(0,2)"/>`)
-    parts.push(`<path d="${d}" class="xychart-line xychart-color-${line.colorIndex}"/>`)
+    parts.push(`<path d="${polylinePath(line.points)}" class="xychart-line xychart-color-${line.colorIndex}"/>`)
   }
 
-  // 4. Dots — grouped by x-position; interactive groups deferred to overlay
   const dotOverlay: string[] = []
-  if (interactive || sparse) {
-    // Build legend label lookup: line seriesIndex → "Line 1", "Line 2", etc.
-    const lineLegendLabels = new Map<number, string>()
-    for (const item of chart.legend) {
-      if (item.type === 'line') lineLegendLabels.set(item.seriesIndex, item.label)
-    }
-
-    type DotEntry = { x: number; y: number; value: number; label?: string; seriesIndex: number; colorIndex: number }
-    const columns = new Map<string, DotEntry[]>()
-
+  if (interactive) {
     for (const line of chart.lines) {
-      for (const p of line.points) {
-        const key = r(p.x)
-        if (!columns.has(key)) columns.set(key, [])
-        columns.get(key)!.push({ x: p.x, y: p.y, value: p.value, label: p.label, seriesIndex: line.seriesIndex, colorIndex: line.colorIndex })
-      }
-    }
-
-    for (const entries of columns.values()) {
-      const cx = entries[0]!.x
-      const label = entries[0]!.label || ''
-
-      if (interactive && entries.length > 1) {
-        const topY = Math.min(...entries.map(e => e.y))
-        const botY = Math.max(...entries.map(e => e.y))
-        const hitPad = CHART_FONT.dotRadius * 3
-        const hitArea = `<rect x="${r(cx - hitPad)}" y="${r(topY - hitPad)}" width="${r(hitPad * 2)}" height="${r(botY - topY + hitPad * 2)}" fill="transparent" class="xychart-hit"/>`
-        const tipEntries = entries.map(e => ({
-          text: formatTipValue(e.value),
-          legendLabel: lineLegendLabels.get(e.seriesIndex) || `Line ${e.seriesIndex + 1}`,
-        }))
-        const tip = multiTooltipAbove(cx, topY - CHART_FONT.dotRadius, label, tipEntries)
-        const valStrs = tipEntries.map(e => e.text)
-        const titleText = label ? `${label}: ${valStrs.join(' · ')}` : valStrs.join(' · ')
-
-        let group = `<g class="xychart-dot-group">${hitArea}`
-        for (const e of entries) {
-          const dataAttrs = ` data-value="${e.value}"${e.label ? ` data-label="${escapeXml(e.label)}"` : ''}`
-          group += `<circle cx="${r(e.x)}" cy="${r(e.y)}" r="${CHART_FONT.dotRadius}" class="xychart-dot xychart-color-${e.colorIndex}"${dataAttrs}/>`
-        }
-        group += `<title>${escapeXml(titleText)}</title>${tip}</g>`
-        dotOverlay.push(group)
-
-      } else if (interactive) {
-        const e = entries[0]!
-        const dataAttrs = ` data-value="${e.value}"${e.label ? ` data-label="${escapeXml(e.label)}"` : ''}`
-        const tipText = formatTipValue(e.value)
-        const tipTitle = e.label ? `${e.label}: ${tipText}` : tipText
-        const tip = tooltipAbove(cx, e.y - CHART_FONT.dotRadius, tipText)
-        const hitArea = sparse
-          ? `<circle cx="${r(cx)}" cy="${r(e.y)}" r="${CHART_FONT.dotRadius * 3}" fill="transparent" class="xychart-hit"/>`
-          : ''
+      for (const point of line.points) {
+        const dataAttrs = ` data-value="${point.value}"${point.label ? ` data-label="${escapeXml(point.label)}"` : ''}`
+        const tipText = formatTipValue(point.value)
+        const tipTitle = point.label ? `${point.label}: ${tipText}` : tipText
         dotOverlay.push(
-          `<g class="xychart-dot-group">${hitArea}` +
-          `<circle cx="${r(e.x)}" cy="${r(e.y)}" r="${CHART_FONT.dotRadius}" class="xychart-dot xychart-color-${e.colorIndex}"${dataAttrs}/>` +
-          `<title>${escapeXml(tipTitle)}</title>${tip}</g>`
+          `<g class="xychart-dot-group">` +
+          `<circle cx="${r(point.x)}" cy="${r(point.y)}" r="${CHART_FONT.dotRadius * 3}" fill="transparent" class="xychart-hit"/>` +
+          `<circle cx="${r(point.x)}" cy="${r(point.y)}" r="${CHART_FONT.dotRadius}" class="xychart-dot xychart-color-${line.colorIndex}"${dataAttrs}/>` +
+          `<title>${escapeXml(tipTitle)}</title>` +
+          tooltipAbove(point.x, point.y - CHART_FONT.dotRadius, tipText) +
+          `</g>`
         )
-
-      } else {
-        // Sparse, not interactive: static dots render inline
-        for (const e of entries) {
-          const dataAttrs = ` data-value="${e.value}"${e.label ? ` data-label="${escapeXml(e.label)}"` : ''}`
-          parts.push(
-            `<circle cx="${r(e.x)}" cy="${r(e.y)}" r="${CHART_FONT.dotRadius}" class="xychart-dot xychart-color-${e.colorIndex}"${dataAttrs}/>`
-          )
-        }
       }
     }
   }
 
-  // 5. Axis labels (no axis lines, no tick marks — just floating labels)
-  for (const tick of chart.xAxis.ticks) {
-    parts.push(
-      `<text x="${tick.labelX}" y="${tick.labelY}" text-anchor="${tick.textAnchor}" ` +
-      `font-size="${CHART_FONT.labelSize}" font-weight="${CHART_FONT.labelWeight}" ` +
-      `dy="${TEXT_BASELINE_SHIFT}" class="xychart-label">${escapeXml(tick.label)}</text>`
-    )
-  }
-  for (const tick of chart.yAxis.ticks) {
-    parts.push(
-      `<text x="${tick.labelX}" y="${tick.labelY}" text-anchor="${tick.textAnchor}" ` +
-      `font-size="${CHART_FONT.labelSize}" font-weight="${CHART_FONT.labelWeight}" ` +
-      `dy="${TEXT_BASELINE_SHIFT}" class="xychart-label">${escapeXml(tick.label)}</text>`
-    )
+  if (chart.config.showDataLabel) {
+    for (const label of buildBarDataLabels(chart.bars, chart.horizontal ?? false)) {
+      parts.push(
+        `<text x="${r(label.x)}" y="${r(label.y)}" text-anchor="${label.anchor}" ` +
+        `${label.dominantBaseline ? `dominant-baseline="${label.dominantBaseline}" ` : ''}` +
+        `font-size="${label.fontSize}" font-weight="400" class="xychart-data-label">${escapeXml(label.text)}</text>`
+      )
+    }
   }
 
-  // 6. Axis titles
+  renderAxisLabels(parts, chart.xAxis.ticks, chart.xAxis.config.labelFontSize, 'x')
+  renderAxisLabels(parts, chart.yAxis.ticks, chart.yAxis.config.labelFontSize, 'y')
+
   if (chart.xAxis.title) {
-    const t = chart.xAxis.title
-    const transform = t.rotate ? ` transform="rotate(${t.rotate},${t.x},${t.y})"` : ''
+    const title = chart.xAxis.title
+    const transform = title.rotate ? ` transform="rotate(${title.rotate},${title.x},${title.y})"` : ''
     parts.push(
-      `<text x="${t.x}" y="${t.y}" text-anchor="middle"${transform} ` +
-      `font-size="${CHART_FONT.axisTitleSize}" font-weight="${CHART_FONT.axisTitleWeight}" ` +
-      `dy="${TEXT_BASELINE_SHIFT}" class="xychart-axis-title">${escapeXml(t.text)}</text>`
-    )
-  }
-  if (chart.yAxis.title) {
-    const t = chart.yAxis.title
-    const transform = t.rotate ? ` transform="rotate(${t.rotate},${t.x},${t.y})"` : ''
-    parts.push(
-      `<text x="${t.x}" y="${t.y}" text-anchor="middle"${transform} ` +
-      `font-size="${CHART_FONT.axisTitleSize}" font-weight="${CHART_FONT.axisTitleWeight}" ` +
-      `dy="${TEXT_BASELINE_SHIFT}" class="xychart-axis-title">${escapeXml(t.text)}</text>`
+      `<text x="${title.x}" y="${title.y}" text-anchor="middle"${transform} ` +
+      `font-size="${chart.xAxis.config.titleFontSize}" font-weight="${CHART_FONT.axisTitleWeight}" ` +
+      `dy="${TEXT_BASELINE_SHIFT}" class="xychart-axis-title xychart-x-axis-title">${escapeXml(title.text)}</text>`
     )
   }
 
-  // 7. Chart title
+  if (chart.yAxis.title) {
+    const title = chart.yAxis.title
+    const transform = title.rotate ? ` transform="rotate(${title.rotate},${title.x},${title.y})"` : ''
+    parts.push(
+      `<text x="${title.x}" y="${title.y}" text-anchor="middle"${transform} ` +
+      `font-size="${chart.yAxis.config.titleFontSize}" font-weight="${CHART_FONT.axisTitleWeight}" ` +
+      `dy="${TEXT_BASELINE_SHIFT}" class="xychart-axis-title xychart-y-axis-title">${escapeXml(title.text)}</text>`
+    )
+  }
+
   if (chart.title) {
     parts.push(
       `<text x="${chart.title.x}" y="${chart.title.y}" text-anchor="middle" ` +
-      `font-size="${CHART_FONT.titleSize}" font-weight="${CHART_FONT.titleWeight}" ` +
+      `font-size="${chart.config.titleFontSize}" font-weight="${CHART_FONT.titleWeight}" ` +
       `dy="${TEXT_BASELINE_SHIFT}" class="xychart-title">${escapeXml(chart.title.text)}</text>`
     )
   }
 
-  // 8. Legend
-  for (const item of chart.legend) {
-    const swatchW = 14, swatchH = 14
-    const gap = 6
-    if (item.type === 'bar') {
-      parts.push(
-        `<rect x="${item.x}" y="${item.y - swatchH / 2}" width="${swatchW}" height="${swatchH}" rx="3" ` +
-        `class="xychart-bar xychart-color-${item.colorIndex}"/>`
-      )
-    } else {
-      const ly = item.y
-      parts.push(
-        `<line x1="${item.x}" y1="${ly}" x2="${item.x + swatchW}" y2="${ly}" ` +
-        `stroke-width="${CHART_FONT.lineWidth}" stroke-linecap="round" class="xychart-legend-line xychart-color-${item.colorIndex}"/>`
-      )
-    }
-    parts.push(
-      `<text x="${item.x + swatchW + gap}" y="${item.y}" text-anchor="start" ` +
-      `font-size="${CHART_FONT.legendSize}" font-weight="${CHART_FONT.legendWeight}" ` +
-      `dy="${TEXT_BASELINE_SHIFT}" class="xychart-label">${escapeXml(item.label)}</text>`
-    )
-  }
-
-  // 9. Interactive overlay — rendered last so tooltips are always on top
-  for (const g of barOverlay) parts.push(g)
-  for (const g of dotOverlay) parts.push(g)
+  for (const group of barOverlay) parts.push(group)
+  for (const group of dotOverlay) parts.push(group)
 
   parts.push('</svg>')
   return parts.join('\n')
 }
 
-// ============================================================================
-// Chart-specific CSS styles
-// ============================================================================
-
-function chartStyles(chart: PositionedXYChart, interactive: boolean, sparse: boolean, themeAccent?: string, bgColor?: string): { style: string; defs: string } {
-  const accentHex = themeAccent ?? CHART_ACCENT_FALLBACK
-
-  // Collect all unique global color indices from bars + lines
-  const colorIndices = new Set<number>()
-  for (const b of chart.bars) colorIndices.add(b.colorIndex)
-  for (const l of chart.lines) colorIndices.add(l.colorIndex)
-
-  // Define --xychart-color-N CSS custom properties (updatable by theme-switching JS)
-  // Also define --xychart-bar-fill-N via color-mix() so it stays dynamic on theme change
-  const colorVarDefs: string[] = []
-  for (const idx of [...colorIndices].sort((a, b) => a - b)) {
-    const value = idx === 0
-      ? `var(--accent, ${CHART_ACCENT_FALLBACK})`
-      : getSeriesColor(idx, accentHex, bgColor)
-    colorVarDefs.push(`    --xychart-color-${idx}: ${value};`)
-    colorVarDefs.push(`    --xychart-bar-fill-${idx}: color-mix(in srgb, var(--bg) 75%, var(--xychart-color-${idx}) 25%);`)
+function renderAxis(parts: string[], axis: PositionedXYChart['xAxis'], axisName: 'x' | 'y'): void {
+  if (axis.config.showAxisLine) {
+    parts.push(
+      `<line x1="${r(axis.line.x1)}" y1="${r(axis.line.y1)}" x2="${r(axis.line.x2)}" y2="${r(axis.line.y2)}" ` +
+      `class="xychart-axis-line xychart-${axisName}-axis-line" stroke-width="${axis.config.axisLineWidth}"/>`
+    )
   }
 
-  // Generate unified color rules — one per global index, referencing the CSS vars
+  if (!axis.config.showTick) return
+  for (const tick of axis.ticks) {
+    parts.push(
+      `<line x1="${r(tick.x)}" y1="${r(tick.y)}" x2="${r(tick.tx)}" y2="${r(tick.ty)}" ` +
+      `class="xychart-tick xychart-${axisName}-tick" stroke-width="${axis.config.tickWidth}"/>`
+    )
+  }
+}
+
+function renderAxisLabels(
+  parts: string[],
+  ticks: PositionedXYChart['xAxis']['ticks'],
+  fontSize: number,
+  axisName: 'x' | 'y',
+): void {
+  for (const tick of ticks) {
+    const middleBaseline = tick.textAnchor === 'end' ? ' dominant-baseline="middle"' : ''
+    const dy = tick.textAnchor === 'end' ? '' : ` dy="${TEXT_BASELINE_SHIFT}"`
+    parts.push(
+      `<text x="${tick.labelX}" y="${tick.labelY}" text-anchor="${tick.textAnchor}"${middleBaseline} ` +
+      `font-size="${fontSize}" font-weight="${CHART_FONT.labelWeight}"${dy} class="xychart-label xychart-${axisName}-label">` +
+      `${escapeXml(tick.label)}</text>`
+    )
+  }
+}
+
+function chartStyles(
+  chart: PositionedXYChart,
+  interactive: boolean,
+  themeAccent?: string,
+  bgColor?: string,
+): { style: string; defs: string } {
+  const accentHex = themeAccent ?? CHART_ACCENT_FALLBACK
+  const themeOverrides = chart.theme
+  const colorIndices = new Set<number>()
+  for (const bar of chart.bars) colorIndices.add(bar.colorIndex)
+  for (const line of chart.lines) colorIndices.add(line.colorIndex)
+
+  const colorVarDefs: string[] = []
+  const explicitPalette = themeOverrides.plotColorPalette
+  for (const index of [...colorIndices].sort((a, b) => a - b)) {
+    const value = explicitPalette && explicitPalette.length > 0
+      ? explicitPalette[index % explicitPalette.length]!
+      : (index === 0 ? `var(--accent, ${CHART_ACCENT_FALLBACK})` : getSeriesColor(index, accentHex, bgColor))
+    colorVarDefs.push(`    --xychart-color-${index}: ${value};`)
+  }
+
   const seriesRules: string[] = []
-  for (const idx of [...colorIndices].sort((a, b) => a - b)) {
-    const color = `var(--xychart-color-${idx})`
-    // Bar-specific: stroke + solid blended fill (no opacity)
-    seriesRules.push(`  .xychart-bar.xychart-color-${idx} { stroke: ${color}; fill: var(--xychart-bar-fill-${idx}); }`)
-    // Line/dot-specific: stroke for paths, fill for circles
-    seriesRules.push(`  path.xychart-color-${idx}, line.xychart-color-${idx} { stroke: ${color}; }`)
-    seriesRules.push(`  circle.xychart-color-${idx} { fill: ${color}; }`)
+  for (const index of [...colorIndices].sort((a, b) => a - b)) {
+    const color = `var(--xychart-color-${index})`
+    seriesRules.push(`  .xychart-bar.xychart-color-${index} { fill: ${color}; }`)
+    seriesRules.push(`  path.xychart-color-${index}, line.xychart-color-${index} { stroke: ${color}; }`)
+    seriesRules.push(`  circle.xychart-color-${index} { fill: ${color}; }`)
   }
 
   const tipRules = interactive ? `
@@ -324,218 +228,134 @@ function chartStyles(chart: PositionedXYChart, interactive: boolean, sparse: boo
   .xychart-bar-group:hover .xychart-tip,
   .xychart-dot-group:hover .xychart-tip { opacity: 1; }` : ''
 
+  const titleColor = themeOverrides.titleColor ?? 'var(--_text)'
+  const xAxisLabelColor = themeOverrides.xAxisLabelColor ?? 'var(--_text)'
+  const yAxisLabelColor = themeOverrides.yAxisLabelColor ?? 'var(--_text)'
+  const xAxisTickColor = themeOverrides.xAxisTickColor ?? 'var(--_text-sec)'
+  const yAxisTickColor = themeOverrides.yAxisTickColor ?? 'var(--_text-sec)'
+  const xAxisLineColor = themeOverrides.xAxisLineColor ?? 'var(--_text-sec)'
+  const yAxisLineColor = themeOverrides.yAxisLineColor ?? 'var(--_text-sec)'
+  const xAxisTitleColor = themeOverrides.xAxisTitleColor ?? 'var(--_text)'
+  const yAxisTitleColor = themeOverrides.yAxisTitleColor ?? 'var(--_text)'
   const colorVarsBlock = colorVarDefs.length > 0 ? `\n  svg {\n${colorVarDefs.join('\n')}\n  }` : ''
 
+  const extraThemeCss = chart.theme.themeCss ? `\n${chart.theme.themeCss}\n` : ''
   const style = `<style>
-  .xychart-grid { fill: var(--_inner-stroke); stroke: none; opacity: 0.65; }
-  .xychart-bar { stroke-width: 1.5; }
+  .xychart-grid { stroke: color-mix(in srgb, var(--fg) 14%, transparent); stroke-width: 1; }
+  .xychart-axis-line { fill: none; }
+  .xychart-tick { fill: none; }
+  .xychart-x-axis-line { stroke: ${xAxisLineColor}; }
+  .xychart-y-axis-line { stroke: ${yAxisLineColor}; }
+  .xychart-x-tick { stroke: ${xAxisTickColor}; }
+  .xychart-y-tick { stroke: ${yAxisTickColor}; }
+  .xychart-bar { stroke: none; }
   .xychart-line { fill: none; stroke-width: ${CHART_FONT.lineWidth}; stroke-linecap: round; stroke-linejoin: round; }
-  .xychart-line-shadow { fill: none; stroke-width: 5; stroke-linecap: round; stroke-linejoin: round; opacity: 0.12; }
   .xychart-dot { stroke: var(--bg); stroke-width: 2; }
-  .xychart-label { fill: var(--_text-muted); }
-  .xychart-axis-title { fill: var(--_text-sec); }
-  .xychart-title { fill: var(--_text); }${colorVarsBlock}
-${seriesRules.join('\n')}${tipRules}
+  .xychart-label { fill: var(--_text); }
+  .xychart-x-label { fill: ${xAxisLabelColor}; }
+  .xychart-y-label { fill: ${yAxisLabelColor}; }
+  .xychart-axis-title { fill: var(--_text); }
+  .xychart-x-axis-title { fill: ${xAxisTitleColor}; }
+  .xychart-y-axis-title { fill: ${yAxisTitleColor}; }
+  .xychart-title { fill: ${titleColor}; }
+  .xychart-data-label { fill: var(--_text); pointer-events: none; }${colorVarsBlock}
+${seriesRules.join('\n')}${tipRules}${extraThemeCss}
 </style>`
 
   return { style, defs: '' }
 }
 
-
-// ============================================================================
-// Bar path with all corners rounded
-// ============================================================================
-
-function roundedTopBarPath(x: number, y: number, w: number, h: number, radius: number): string {
-  const rr = Math.min(radius, w / 2, h / 2)
-  if (rr <= 0) {
-    return `M${r(x)},${r(y)} h${r(w)} v${r(h)} h${r(-w)} Z`
-  }
-  return [
-    `M${r(x)},${r(y + rr)}`,                                   // start below top-left
-    `Q${r(x)},${r(y)} ${r(x + rr)},${r(y)}`,                   // top-left
-    `L${r(x + w - rr)},${r(y)}`,                                // top edge
-    `Q${r(x + w)},${r(y)} ${r(x + w)},${r(y + rr)}`,           // top-right
-    `L${r(x + w)},${r(y + h - rr)}`,                            // right edge
-    `Q${r(x + w)},${r(y + h)} ${r(x + w - rr)},${r(y + h)}`,   // bottom-right
-    `L${r(x + rr)},${r(y + h)}`,                                // bottom edge
-    `Q${r(x)},${r(y + h)} ${r(x)},${r(y + h - rr)}`,           // bottom-left
-    'Z',
-  ].join(' ')
-}
-
-// ============================================================================
-// Bar path with all corners rounded (for horizontal charts)
-// ============================================================================
-
-function roundedRightBarPath(x: number, y: number, w: number, h: number, radius: number): string {
-  const rr = Math.min(radius, w / 2, h / 2)
-  if (rr <= 0) {
-    return `M${r(x)},${r(y)} h${r(w)} v${r(h)} h${r(-w)} Z`
-  }
-  return [
-    `M${r(x + rr)},${r(y)}`,                                    // start after top-left
-    `L${r(x + w - rr)},${r(y)}`,                                // top edge
-    `Q${r(x + w)},${r(y)} ${r(x + w)},${r(y + rr)}`,           // top-right
-    `L${r(x + w)},${r(y + h - rr)}`,                            // right edge
-    `Q${r(x + w)},${r(y + h)} ${r(x + w - rr)},${r(y + h)}`,   // bottom-right
-    `L${r(x + rr)},${r(y + h)}`,                                // bottom edge
-    `Q${r(x)},${r(y + h)} ${r(x)},${r(y + h - rr)}`,           // bottom-left
-    `L${r(x)},${r(y + rr)}`,                                    // left edge
-    `Q${r(x)},${r(y)} ${r(x + rr)},${r(y)}`,                   // top-left
-    'Z',
-  ].join(' ')
-}
-
-// ============================================================================
-// Smooth line interpolation — Natural cubic spline
-//
-// Computes the mathematically smoothest curve through all data points by
-// minimizing total curvature (integrated second derivative). Treats y as a
-// function of x, so the curve can never go backwards.
-//
-// Algorithm: tridiagonal system for second derivatives (Thomas algorithm),
-// then convert each cubic segment to SVG cubic Bezier commands.
-// ============================================================================
-
-function smoothCurvePath(points: Array<{ x: number; y: number }>): string {
+function polylinePath(points: Array<{ x: number; y: number }>): string {
   if (points.length === 0) return ''
-  if (points.length === 1) return `M${r(points[0]!.x)},${r(points[0]!.y)}`
-  if (points.length === 2) {
-    return `M${r(points[0]!.x)},${r(points[0]!.y)} L${r(points[1]!.x)},${r(points[1]!.y)}`
-  }
-
-  const n = points.length
-
-  // 1. Interval widths and secant slopes
-  const h: number[] = []
-  const delta: number[] = []
-  for (let i = 0; i < n - 1; i++) {
-    h.push(points[i + 1]!.x - points[i]!.x)
-    delta.push(h[i]! === 0 ? 0 : (points[i + 1]!.y - points[i]!.y) / h[i]!)
-  }
-
-  // 2. Solve tridiagonal system for second derivatives c[] (natural boundary: c[0] = c[n-1] = 0)
-  const c = new Array<number>(n).fill(0)
-  if (n > 2) {
-    // Forward elimination
-    const cp = new Array<number>(n).fill(0) // modified upper diagonal
-    const dp = new Array<number>(n).fill(0) // modified right-hand side
-    for (let i = 1; i < n - 1; i++) {
-      const diag = 2 * (h[i - 1]! + h[i]!)
-      const rhs = 3 * (delta[i]! - delta[i - 1]!)
-      if (i === 1) {
-        cp[i] = h[i]! / diag
-        dp[i] = rhs / diag
-      } else {
-        const w = diag - h[i - 1]! * cp[i - 1]!
-        cp[i] = h[i]! / w
-        dp[i] = (rhs - h[i - 1]! * dp[i - 1]!) / w
-      }
-    }
-    // Back substitution
-    for (let i = n - 2; i >= 1; i--) {
-      c[i] = dp[i]! - cp[i]! * c[i + 1]!
-    }
-  }
-
-  // 3. Compute first derivatives (slopes) at each knot
-  const slopes = new Array<number>(n).fill(0)
-  for (let i = 0; i < n - 1; i++) {
-    slopes[i] = delta[i]! - h[i]! * (2 * c[i]! + c[i + 1]!) / 3
-  }
-  // Slope at last point: derivative of last segment at its end
-  slopes[n - 1] = delta[n - 2]! + h[n - 2]! * (c[n - 2]!) / 3
-
-  // 4. Convert to cubic Bezier — control points strictly between endpoints in x
   let path = `M${r(points[0]!.x)},${r(points[0]!.y)}`
-  for (let i = 0; i < n - 1; i++) {
-    const seg = h[i]! / 3
-    const cp1x = points[i]!.x + seg
-    const cp1y = points[i]!.y + slopes[i]! * seg
-    const cp2x = points[i + 1]!.x - seg
-    const cp2y = points[i + 1]!.y - slopes[i + 1]! * seg
-    path += ` C${r(cp1x)},${r(cp1y)} ${r(cp2x)},${r(cp2y)} ${r(points[i + 1]!.x)},${r(points[i + 1]!.y)}`
+  for (let i = 1; i < points.length; i++) {
+    path += ` L${r(points[i]!.x)},${r(points[i]!.y)}`
   }
-
   return path
 }
 
-// ============================================================================
-// Tooltip rendering
-// ============================================================================
+function buildBarDataLabels(
+  bars: PositionedBar[],
+  horizontal: boolean,
+): Array<{
+  x: number
+  y: number
+  text: string
+  anchor: 'middle' | 'end'
+  fontSize: number
+  dominantBaseline?: 'middle' | 'hanging'
+}> {
+  const visibleBars = bars.filter(bar => bar.width > 0 && bar.height > 0)
+  if (visibleBars.length === 0) return []
 
-/**
- * Multi-value tooltip: category label on top, each series value below with legend text label.
- */
-function multiTooltipAbove(cx: number, topY: number, label: string, entries: Array<{ text: string; legendLabel: string }>): string {
-  const lineH = 20
-  const padY = 6
-  const labelGap = 10
-  const headingW = estimateTextWidth(label, TIP.fontSize, 600)
-  const maxRowW = Math.max(...entries.map(e => {
-    const legendW = estimateTextWidth(e.legendLabel, TIP.fontSize, TIP.fontWeight)
-    const valW = estimateTextWidth(e.text, TIP.fontSize, TIP.fontWeight)
-    return legendW + labelGap + valW
-  }))
-  const bgW = Math.max(headingW, maxRowW) + TIP.padX * 2
-  const bgH = padY + lineH + entries.length * lineH + padY
+  const texts = visibleBars.map(bar => formatTipValue(bar.value))
+  const candidates = visibleBars.map((bar, index) => {
+    const text = texts[index]!
+    if (horizontal) {
+      const widthFit = Math.max(0, (bar.width - 12) / Math.max(1, text.length * 0.62))
+      return Math.min(bar.height * 0.72, widthFit)
+    }
+    const widthFit = Math.max(0, (bar.width - 8) / Math.max(1, text.length * 0.62))
+    const heightFit = Math.max(0, bar.height - 10)
+    return Math.min(widthFit, heightFit)
+  })
 
-  const tipY = Math.max(TIP.minY, topY - TIP.offsetY - bgH - TIP.pointerSize)
-  const bgX = cx - bgW / 2
+  const rawFontSize = Math.floor(Math.min(...candidates))
+  if (!Number.isFinite(rawFontSize) || rawFontSize < 8) return []
+  const fontSize = Math.min(16, rawFontSize)
 
-  const ptrX = cx
-  const ptrY = tipY + bgH
-  const ps = TIP.pointerSize
-  const pointer = `<polygon points="${r(ptrX - ps)},${r(ptrY)} ${r(ptrX + ps)},${r(ptrY)} ${r(ptrX)},${r(ptrY + ps)}" class="xychart-tip xychart-tip-ptr"/>`
-
-  let svg = `<rect x="${r(bgX)}" y="${r(tipY)}" width="${r(bgW)}" height="${bgH}" rx="${TIP.rx}" class="xychart-tip xychart-tip-bg"/>`
-  svg += pointer
-
-  // Category label (bold, centered)
-  let textY = tipY + padY + lineH / 2
-  svg += `<text x="${r(cx)}" y="${r(textY)}" text-anchor="middle" font-weight="600" font-size="${TIP.fontSize}" dy="${TEXT_BASELINE_SHIFT}" class="xychart-tip xychart-tip-text">${escapeXml(label)}</text>`
-
-  // Value lines: legend label left-aligned, value right-aligned
-  const rowLeft = bgX + TIP.padX
-  const rowRight = bgX + bgW - TIP.padX
-  for (const entry of entries) {
-    textY += lineH
-    svg += `<text x="${r(rowLeft)}" y="${r(textY)}" text-anchor="start" font-size="${TIP.fontSize}" font-weight="${TIP.fontWeight}" dy="${TEXT_BASELINE_SHIFT}" class="xychart-tip xychart-tip-text">${escapeXml(entry.legendLabel)}</text>`
-    svg += `<text x="${r(rowRight)}" y="${r(textY)}" text-anchor="end" font-size="${TIP.fontSize}" font-weight="${TIP.fontWeight}" dy="${TEXT_BASELINE_SHIFT}" class="xychart-tip xychart-tip-text">${escapeXml(entry.text)}</text>`
-  }
-
-  return svg
+  return visibleBars.map((bar, index) => horizontal
+    ? {
+      x: bar.x + bar.width - 8,
+      y: bar.y + bar.height / 2,
+      text: texts[index]!,
+      anchor: 'end',
+      fontSize,
+      dominantBaseline: 'middle',
+    }
+    : {
+      x: bar.x + bar.width / 2,
+      y: bar.y + 8,
+      text: texts[index]!,
+      anchor: 'middle',
+      fontSize,
+      dominantBaseline: 'hanging',
+    })
 }
 
 function tooltipAbove(cx: number, topY: number, text: string): string {
   const textW = estimateTextWidth(text, TIP.fontSize, TIP.fontWeight)
   const bgW = textW + TIP.padX * 2
-  const bgH = TIP.height
-  const tipY = Math.max(TIP.minY, topY - TIP.offsetY - bgH - TIP.pointerSize)
   const bgX = cx - bgW / 2
-  const textX = cx
-  const textY = tipY + bgH / 2
+  let bgY = topY - TIP.offsetY - TIP.height
+  let ptrY = bgY + TIP.height
 
-  const ptrX = cx
-  const ptrY = tipY + bgH
-  const ps = TIP.pointerSize
-  const pointer = `<polygon points="${r(ptrX - ps)},${r(ptrY)} ${r(ptrX + ps)},${r(ptrY)} ${r(ptrX)},${r(ptrY + ps)}" class="xychart-tip xychart-tip-ptr"/>`
+  if (bgY < TIP.minY) {
+    bgY = TIP.minY
+    ptrY = bgY + TIP.height
+  }
+
+  const textX = cx
+  const textY = bgY + TIP.height / 2
+  const p = TIP.pointerSize
+  const ptrPath = `M${r(cx - p)},${r(ptrY)} L${r(cx + p)},${r(ptrY)} L${r(cx)},${r(ptrY + p)} Z`
 
   return (
-    `<rect x="${r(bgX)}" y="${r(tipY)}" width="${r(bgW)}" height="${bgH}" rx="${TIP.rx}" class="xychart-tip xychart-tip-bg"/>` +
-    pointer +
-    `<text x="${r(textX)}" y="${r(textY)}" text-anchor="middle" dy="${TEXT_BASELINE_SHIFT}" class="xychart-tip xychart-tip-text">${escapeXml(text)}</text>`
+    `<g class="xychart-tip">` +
+    `<rect x="${r(bgX)}" y="${r(bgY)}" width="${r(bgW)}" height="${TIP.height}" rx="${TIP.rx}" class="xychart-tip xychart-tip-bg"/>` +
+    `<path d="${ptrPath}" class="xychart-tip xychart-tip-ptr"/>` +
+    `<text x="${r(textX)}" y="${r(textY)}" text-anchor="middle" dy="${TEXT_BASELINE_SHIFT}" class="xychart-tip xychart-tip-text">${escapeXml(text)}</text>` +
+    `</g>`
   )
 }
 
-function formatTipValue(v: number): string {
-  if (Number.isInteger(v)) return v.toLocaleString('en-US')
-  return v.toFixed(Math.abs(v) < 10 ? 1 : 0)
+function formatTipValue(value: number): string {
+  if (Number.isInteger(value)) return String(value)
+  return value.toFixed(Math.abs(value) < 10 ? 1 : 0)
 }
 
-function r(n: number): string {
-  return String(Math.round(n * 10) / 10)
+function r(value: number): string {
+  return (Math.round(value * 100) / 100).toString()
 }
 
 function escapeXml(text: string): string {
@@ -546,4 +366,56 @@ function escapeXml(text: string): string {
     .replace(/"/g, '&quot;')
 }
 
+function buildSvgMetadata(chart: PositionedXYChart): {
+  openTag: Parameters<typeof svgOpenTag>[4]
+  title?: string
+  description?: string
+} {
+  const svgId = `mermaid-${hashChart(chart)}`
+  const accTitleId = chart.accessibility?.title ? `chart-title-${svgId}` : undefined
+  const accDescId = chart.accessibility?.description ? `chart-desc-${svgId}` : undefined
+  const responsiveWidth = chart.config.useWidth ?? chart.width
+  const width = chart.config.useMaxWidth ? '100%' : String(responsiveWidth)
+  const height = chart.config.useMaxWidth
+    ? '100%'
+    : String(Math.round(chart.height * (responsiveWidth / Math.max(1, chart.width))))
+  const style = chart.config.useMaxWidth ? `max-width:${responsiveWidth}px` : undefined
 
+  return {
+    openTag: {
+      width,
+      height,
+      style,
+      attrs: {
+        id: svgId,
+        class: 'xychart',
+        'aria-roledescription': 'xychart',
+        'aria-labelledby': accTitleId,
+        'aria-describedby': accDescId,
+      },
+    },
+    title: chart.accessibility?.title
+      ? `<title id="${accTitleId}">${escapeXml(chart.accessibility.title)}</title>`
+      : undefined,
+    description: chart.accessibility?.description
+      ? `<desc id="${accDescId}">${escapeXml(chart.accessibility.description)}</desc>`
+      : undefined,
+  }
+}
+
+function hashChart(chart: PositionedXYChart): string {
+  const text = [
+    chart.width,
+    chart.height,
+    chart.title?.text ?? '',
+    chart.accessibility?.title ?? '',
+    chart.accessibility?.description ?? '',
+    chart.bars.length,
+    chart.lines.length,
+  ].join('|')
+  let hash = 5381
+  for (let i = 0; i < text.length; i++) {
+    hash = ((hash << 5) + hash) ^ text.charCodeAt(i)
+  }
+  return Math.abs(hash >>> 0).toString(36)
+}

--- a/src/xychart/types.ts
+++ b/src/xychart/types.ts
@@ -1,7 +1,7 @@
 // ============================================================================
 // XY Chart types
 //
-// Models the parsed and positioned representations of a Mermaid xychart-beta
+// Models the parsed and positioned representations of a Mermaid xychart
 // diagram. Supports bar charts, line charts, and combinations with categorical
 // or numeric x-axes.
 // ============================================================================
@@ -10,6 +10,8 @@
 export interface XYChart {
   /** Optional chart title */
   title?: string
+  /** Optional Mermaid accessibility metadata */
+  accessibility?: XYChartAccessibility
   /** Chart orientation: vertical (default) or horizontal */
   horizontal: boolean
   /** X-axis configuration */
@@ -18,6 +20,10 @@ export interface XYChart {
   yAxis: XYAxis
   /** Data series (bar and/or line) */
   series: XYChartSeries[]
+  /** Mermaid frontmatter-driven chart options */
+  config: XYChartConfig
+  /** Mermaid frontmatter-driven chart theme overrides */
+  theme: XYChartTheme
 }
 
 /** Axis configuration — categorical (labels) or numeric (range) */
@@ -34,8 +40,123 @@ export interface XYAxis {
 export interface XYChartSeries {
   /** Series type */
   type: 'bar' | 'line'
+  /** Optional Mermaid series label */
+  label?: string
   /** Data values — one per category, or evenly spaced across numeric range */
   data: number[]
+}
+
+export interface XYChartAccessibility {
+  title?: string
+  description?: string
+}
+
+export interface XYChartConfig {
+  /** Override total chart width in SVG output */
+  width?: number
+  /** Override total chart height in SVG output */
+  height?: number
+  /** When true, emit responsive width/height output */
+  useMaxWidth?: boolean
+  /** Optional explicit rendered width override */
+  useWidth?: number
+  /** Title font size in px */
+  titleFontSize?: number
+  /** Title padding in px */
+  titlePadding?: number
+  /** Orientation from Mermaid config (`vertical` or `horizontal`) */
+  chartOrientation?: 'vertical' | 'horizontal'
+  /** Reserve this percentage of the chart box for the plot area */
+  plotReservedSpacePercent?: number
+  /** Show numeric value labels on bars */
+  showDataLabel?: boolean
+  /** Hide the chart title even when the source defines one */
+  showTitle?: boolean
+  /** Per-axis visibility controls */
+  xAxis?: XYAxisRenderConfig
+  /** Per-axis visibility controls */
+  yAxis?: XYAxisRenderConfig
+}
+
+export interface XYAxisRenderConfig {
+  /** Hide axis labels */
+  showLabel?: boolean
+  /** Axis label font size in px */
+  labelFontSize?: number
+  /** Axis label padding in px */
+  labelPadding?: number
+  /** Hide axis title */
+  showTitle?: boolean
+  /** Axis title font size in px */
+  titleFontSize?: number
+  /** Axis title padding in px */
+  titlePadding?: number
+  /** Hide tick marks */
+  showTick?: boolean
+  /** Tick length in px */
+  tickLength?: number
+  /** Tick stroke width in px */
+  tickWidth?: number
+  /** Hide the axis line */
+  showAxisLine?: boolean
+  /** Axis line stroke width in px */
+  axisLineWidth?: number
+}
+
+export interface ResolvedXYAxisRenderConfig {
+  showLabel: boolean
+  labelFontSize: number
+  labelPadding: number
+  showTitle: boolean
+  titleFontSize: number
+  titlePadding: number
+  showTick: boolean
+  tickLength: number
+  tickWidth: number
+  showAxisLine: boolean
+  axisLineWidth: number
+}
+
+export interface ResolvedXYChartConfig {
+  width: number
+  height: number
+  useMaxWidth: boolean
+  useWidth?: number
+  titleFontSize: number
+  titlePadding: number
+  chartOrientation: 'vertical' | 'horizontal'
+  plotReservedSpacePercent: number
+  showDataLabel: boolean
+  showTitle: boolean
+  xAxis: ResolvedXYAxisRenderConfig
+  yAxis: ResolvedXYAxisRenderConfig
+}
+
+export interface XYChartTheme {
+  /** Background override from Mermaid theme variables */
+  backgroundColor?: string
+  /** Raw Mermaid theme CSS appended to the SVG style block */
+  themeCss?: string
+  /** Chart title color */
+  titleColor?: string
+  /** X-axis label color */
+  xAxisLabelColor?: string
+  /** X-axis tick color */
+  xAxisTickColor?: string
+  /** X-axis line color */
+  xAxisLineColor?: string
+  /** X-axis title color */
+  xAxisTitleColor?: string
+  /** Y-axis label color */
+  yAxisLabelColor?: string
+  /** Y-axis tick color */
+  yAxisTickColor?: string
+  /** Y-axis line color */
+  yAxisLineColor?: string
+  /** Y-axis title color */
+  yAxisTitleColor?: string
+  /** Explicit per-series palette */
+  plotColorPalette?: string[]
 }
 
 // ============================================================================
@@ -45,6 +166,7 @@ export interface XYChartSeries {
 export interface PositionedXYChart {
   width: number
   height: number
+  accessibility?: XYChartAccessibility
   /** Whether this is a horizontal (rotated) chart */
   horizontal?: boolean
   /** Title text and position (if present) */
@@ -63,6 +185,10 @@ export interface PositionedXYChart {
   gridLines: GridLine[]
   /** Legend items (shown when multiple series) */
   legend: LegendItem[]
+  /** Resolved config carried through for rendering decisions */
+  config: ResolvedXYChartConfig
+  /** Mermaid theme variables carried through for rendering decisions */
+  theme: XYChartTheme
 }
 
 export interface LegendItem {
@@ -92,6 +218,8 @@ export interface PositionedAxis {
   ticks: AxisTick[]
   /** Axis line: start and end coordinates */
   line: { x1: number; y1: number; x2: number; y2: number }
+  /** Resolved axis config used for sizing and rendering */
+  config: ResolvedXYAxisRenderConfig
 }
 
 export interface AxisTick {

--- a/xychart-design.md
+++ b/xychart-design.md
@@ -1,485 +1,85 @@
-# XY Chart (xychart-beta) — Phase 2 Design Document
+# XY Chart (xychart / xychart-beta) — Design Notes
 
 ## Overview
 
-This document specifies the architecture for adding `xychart-beta` / `xychart` support to beautiful-mermaid. The implementation follows the same parse → layout → render pipeline used by all other diagram types (ER, sequence, class, flowchart).
-
-XY charts render bar charts, line charts, or combinations thereof, with categorical or numeric x-axes, numeric y-axes, optional titles, and optional horizontal orientation.
-
----
-
-## Mermaid Syntax Reference
-
-```
-xychart-beta
-    title "Sales Revenue"
-    x-axis [jan, feb, mar, apr, may, jun]
-    y-axis "Revenue (USD)" 4000 --> 11000
-    bar [5000, 6000, 7500, 8200, 9800, 10500]
-    line [5000, 6000, 7500, 8200, 9800, 10500]
-```
-
-Horizontal variant:
-```
-xychart-beta horizontal
-    title "Sales Revenue"
-    x-axis [jan, feb, mar, apr, may, jun]
-    y-axis "Revenue (USD)" 4000 --> 11000
-    bar [5000, 6000, 7500, 8200, 9800, 10500]
-```
-
-Numeric x-axis variant:
-```
-xychart-beta
-    x-axis 0 --> 100
-    y-axis 0 --> 50
-    line [10, 20, 35, 40, 45]
-```
-
----
-
-## Files to Create
-
-### 1. `src/xychart/types.ts`
-
-```typescript
-// ============================================================================
-// XY Chart types
-//
-// Models the parsed and positioned representations of a Mermaid xychart-beta
-// diagram. Supports bar charts, line charts, and combinations with categorical
-// or numeric x-axes.
-// ============================================================================
-
-/** Parsed XY chart — logical structure from mermaid text */
-export interface XYChart {
-  /** Optional chart title */
-  title?: string
-  /** Chart orientation: vertical (default) or horizontal */
-  horizontal: boolean
-  /** X-axis configuration */
-  xAxis: XYAxis
-  /** Y-axis configuration */
-  yAxis: XYAxis
-  /** Data series (bar and/or line) */
-  series: XYChartSeries[]
-}
-
-/** Axis configuration — categorical (labels) or numeric (range) */
-export interface XYAxis {
-  /** Optional axis title/label */
-  title?: string
-  /** Categorical labels (e.g., ["jan", "feb", "mar"]) — mutually exclusive with range */
-  categories?: string[]
-  /** Numeric range — mutually exclusive with categories */
-  range?: { min: number; max: number }
-}
-
-/** A single data series (bar or line) */
-export interface XYChartSeries {
-  /** Series type */
-  type: 'bar' | 'line'
-  /** Data values — one per category, or evenly spaced across numeric range */
-  data: number[]
-}
-
-// ============================================================================
-// Positioned XY chart — ready for SVG rendering
-// ============================================================================
-
-export interface PositionedXYChart {
-  width: number
-  height: number
-  /** Title text and position (if present) */
-  title?: PositionedTitle
-  /** Positioned x-axis with tick marks and labels */
-  xAxis: PositionedAxis
-  /** Positioned y-axis with tick marks and labels */
-  yAxis: PositionedAxis
-  /** The plot area bounds (inside axes) */
-  plotArea: PlotArea
-  /** Positioned bar groups */
-  bars: PositionedBar[]
-  /** Positioned line polylines */
-  lines: PositionedLine[]
-  /** Horizontal grid lines for readability */
-  gridLines: GridLine[]
-}
-
-export interface PositionedTitle {
-  text: string
-  x: number
-  y: number
-}
-
-export interface PositionedAxis {
-  /** Optional axis title text and position */
-  title?: { text: string; x: number; y: number; rotate?: number }
-  /** Tick positions along the axis */
-  ticks: AxisTick[]
-  /** Axis line: start and end coordinates */
-  line: { x1: number; y1: number; x2: number; y2: number }
-}
-
-export interface AxisTick {
-  /** Label text for this tick */
-  label: string
-  /** Position of the tick mark on the axis */
-  x: number
-  y: number
-  /** End of the tick mark (short perpendicular line) */
-  tx: number
-  ty: number
-  /** Label anchor position */
-  labelX: number
-  labelY: number
-  /** Text anchor for label ("middle", "end", "start") */
-  textAnchor: 'start' | 'middle' | 'end'
-}
-
-export interface PlotArea {
-  x: number
-  y: number
-  width: number
-  height: number
-}
-
-export interface PositionedBar {
-  /** Bar rectangle in SVG coordinates */
-  x: number
-  y: number
-  width: number
-  height: number
-  /** Original data value (for tooltips/labels if needed) */
-  value: number
-  /** Series index (for coloring multiple bar series) */
-  seriesIndex: number
-}
-
-export interface PositionedLine {
-  /** Polyline points */
-  points: Array<{ x: number; y: number }>
-  /** Series index (for coloring multiple line series) */
-  seriesIndex: number
-}
-
-export interface GridLine {
-  x1: number
-  y1: number
-  x2: number
-  y2: number
-}
-```
-
-### 2. `src/xychart/parser.ts`
-
-```typescript
-import type { XYChart, XYAxis, XYChartSeries } from './types.ts'
-
-/**
- * Parse a Mermaid xychart-beta diagram.
- * Expects the first line to be "xychart-beta" (optionally followed by "horizontal").
- *
- * Supported directives (order-independent after header):
- *   title "Chart Title"
- *   x-axis [label1, label2, ...]          — categorical
- *   x-axis min --> max                     — numeric range
- *   x-axis "Axis Title" [label1, ...]      — with title
- *   y-axis min --> max                     — numeric range
- *   y-axis "Axis Title" min --> max        — with title
- *   bar [val1, val2, ...]
- *   line [val1, val2, ...]
- */
-export function parseXYChart(lines: string[]): XYChart
-```
-
-**Parsing strategy:**
-
-1. First line: detect `horizontal` flag from `xychart-beta horizontal`
-2. Iterate remaining lines, match each directive:
-   - `title "..."` → extract quoted string
-   - `x-axis [...]` → parse as categorical labels (split by comma, trim quotes)
-   - `x-axis <num> --> <num>` → parse as numeric range
-   - `x-axis "Title" [...]` or `x-axis "Title" <num> --> <num>` → title + data
-   - `y-axis` — same patterns as x-axis
-   - `bar [...]` → parse numeric array, push `{ type: 'bar', data }`
-   - `line [...]` → parse numeric array, push `{ type: 'line', data }`
-3. If no y-axis range is specified, auto-derive from min/max of all series data (with padding)
-
-**Internal helpers:**
-- `parseNumericArray(str: string): number[]` — parse `[1, 2, 3]` to `[1, 2, 3]`
-- `parseCategoryArray(str: string): string[]` — parse `[jan, feb, "mar apr"]` with optional quoting
-- `parseRange(str: string): { min: number; max: number } | null`
-
-### 3. `src/xychart/layout.ts`
-
-```typescript
-import type { XYChart, PositionedXYChart } from './types.ts'
-import type { RenderOptions } from '../types.ts'
-
-/**
- * Lay out a parsed XY chart by computing pixel coordinates.
- * No dagre needed — direct coordinate-space mapping.
- *
- * Layout is synchronous but kept async for API consistency.
- */
-export async function layoutXYChart(
-  chart: XYChart,
-  options: RenderOptions = {}
-): Promise<PositionedXYChart>
-```
-
-**Layout algorithm:**
-
-1. **Canvas sizing:**
-   - Default plot area: 600 x 400px (tunable via constants)
-   - Padding: `options.padding ?? 40`
-   - Reserve space for title (if present): ~30px top
-   - Reserve space for axis labels: ~50px bottom (x-axis), ~60px left (y-axis)
-   - Reserve space for axis titles: ~20px each side if present
-
-2. **Scale computation:**
-   - X-scale: Maps data indices (categorical) or numeric range to `plotArea.x .. plotArea.x + plotArea.width`
-   - Y-scale: Maps `yAxis.range.min .. yAxis.range.max` to `plotArea.y + plotArea.height .. plotArea.y` (inverted for SVG)
-   - For categorical x-axis: even spacing with `bandWidth = plotArea.width / categories.length`
-
-3. **Y-axis auto-range** (when not specified):
-   - Collect all data values across all series
-   - `min = Math.min(...allValues)`, `max = Math.max(...allValues)`
-   - Add 10% padding: `min - 0.1 * range`, `max + 0.1 * range`
-   - Round to nice tick values
-
-4. **Tick generation:**
-   - X-axis categorical: one tick per category, centered in band
-   - X-axis numeric: 5-10 ticks at "nice" intervals (1, 2, 5, 10, 20, 50, ...)
-   - Y-axis: 5-8 ticks at nice intervals
-
-5. **Bar rectangles:**
-   - `barWidth = bandWidth * 0.6` (60% of band, leaving gaps)
-   - Multiple bar series: subdivide band width equally
-   - Each bar: `{ x, y: scale(value), width: barWidth, height: plotBottom - scale(value) }`
-
-6. **Line polylines:**
-   - For each line series: one point per data value at `(xCenter, scale(value))`
-
-7. **Grid lines:**
-   - Horizontal lines at each y-axis tick, spanning the plot width
-
-8. **Horizontal mode:**
-   - Swap x and y throughout: categories go on y-axis (top-to-bottom), values on x-axis (left-to-right)
-   - Bars become horizontal rectangles
-   - Line polylines have swapped coordinates
-
-**Layout constants:**
-```typescript
-const XY = {
-  padding: 40,
-  plotWidth: 600,
-  plotHeight: 400,
-  titleFontSize: 16,
-  titleHeight: 30,
-  axisLabelFontSize: 11,
-  axisTitleFontSize: 12,
-  xLabelHeight: 50,
-  yLabelWidth: 60,
-  axisTitlePad: 20,
-  tickLength: 5,
-  barPadRatio: 0.2,     // gap between bars as fraction of band
-  barGroupPadRatio: 0.1, // gap between bars within a group
-  gridDash: '3 3',
-} as const
-```
-
-**Text width estimation:**
-Uses `estimateTextWidth()` from `../styles.ts` for:
-- Chart title width (to center it)
-- Y-axis label widths (to determine left margin)
-- X-axis label widths (to check for overlap / rotation)
-
-### 4. `src/xychart/renderer.ts`
-
-```typescript
-import type { PositionedXYChart } from './types.ts'
-import type { DiagramColors } from '../theme.ts'
-
-/**
- * Render a positioned XY chart as an SVG string.
- */
-export function renderXYChartSvg(
-  chart: PositionedXYChart,
-  colors: DiagramColors,
-  font?: string,
-  transparent?: boolean
-): string
-```
-
-**SVG structure and render order:**
-
-1. `svgOpenTag()` — sets CSS variables on the root `<svg>` element
-2. `buildStyleBlock(font, false)` — no mono font needed for charts
-3. Additional `<style>` rules for chart-specific elements:
-   - `.xychart-bar { fill: var(--_accent); }` (or series-indexed colors)
-   - `.xychart-line { stroke: var(--_accent); fill: none; stroke-width: 2; }`
-   - `.xychart-grid { stroke: var(--_inner-stroke); stroke-dasharray: 3 3; }`
-   - `.xychart-axis { stroke: var(--_line); }`
-   - `.xychart-dot { fill: var(--_accent); }` (data points on lines)
-4. Grid lines (behind data, using `var(--_inner-stroke)`)
-5. Bar rectangles (using `var(--_accent)` or series color palette)
-6. Line polylines with data point circles
-7. Axis lines and tick marks (using `var(--_line)`)
-8. Axis labels (using `var(--_text-muted)`)
-9. Axis titles (using `var(--_text-sec)`)
-10. Chart title (using `var(--_text)`, centered, bold)
-
-**Theming integration:**
-
-The chart uses the same CSS custom property system as all other diagram types. Mapping to chart elements:
-
-| CSS Variable | Chart Element |
-|---|---|
-| `var(--_text)` | Chart title |
-| `var(--_text-sec)` | Axis titles |
-| `var(--_text-muted)` | Axis tick labels |
-| `var(--_line)` | Axis lines, tick marks |
-| `var(--_inner-stroke)` | Grid lines |
-| `var(--_accent)` | Bars (primary), line strokes |
-| `var(--_node-fill)` | Bar fill (alternative — lighter) |
-| `var(--_node-stroke)` | Bar stroke |
-| `var(--bg)` | Background / label backgrounds |
-
-**Multi-series coloring:**
-
-For charts with multiple series, generate palette colors using `color-mix()`:
-```css
-.xychart-series-0 { --_series: var(--_accent); }
-.xychart-series-1 { --_series: color-mix(in srgb, var(--_accent) 60%, var(--fg)); }
-.xychart-series-2 { --_series: color-mix(in srgb, var(--_accent) 40%, var(--fg)); }
-```
-
----
-
-## Files to Modify
-
-### 1. `src/index.ts`
-
-Add xychart detection in `detectDiagramType()` and import the pipeline:
-
-```typescript
-// Add to imports:
-import { parseXYChart } from './xychart/parser.ts'
-import { layoutXYChart } from './xychart/layout.ts'
-import { renderXYChartSvg } from './xychart/renderer.ts'
-
-// Update return type:
-function detectDiagramType(text: string): 'flowchart' | 'sequence' | 'class' | 'er' | 'xychart' {
-  const firstLine = text.trim().split(/[\n;]/)[0]?.trim().toLowerCase() ?? ''
-
-  if (/^xychart-beta\b/.test(firstLine)) return 'xychart'
-  if (/^xychart\b/.test(firstLine)) return 'xychart'
-  if (/^sequencediagram\s*$/.test(firstLine)) return 'sequence'
-  if (/^classdiagram\s*$/.test(firstLine)) return 'class'
-  if (/^erdiagram\s*$/.test(firstLine)) return 'er'
-
-  return 'flowchart'
-}
-
-// Add case in renderMermaid switch:
-case 'xychart': {
-  const chart = parseXYChart(lines)
-  const positioned = await layoutXYChart(chart, options)
-  return renderXYChartSvg(positioned, colors, font, transparent)
-}
-```
-
-Note: `xychart-beta` detection must use `\b` (word boundary) rather than `\s*$` because the first line may contain `horizontal` after the keyword.
-
-### 2. `samples-data.ts`
-
-Add xychart samples in a new `'XY Chart'` category section. Examples should cover:
-- Basic bar chart (categorical x-axis)
-- Basic line chart
-- Combined bar + line
-- Horizontal orientation
-- Numeric x-axis with range
-- Axis titles
-- Chart title
-- Large data sets
-- Single data point
-- Negative values
-- Theme variants
-
-### 3. `src/browser.ts`
-
-No changes needed — the browser bundle imports from `src/index.ts` which re-exports `renderMermaid`. Since xychart is handled inside `renderMermaid`, the browser bundle will automatically support xychart diagrams.
-
----
-
-## Key Patterns (from existing pipelines)
-
-### Parse → Layout → Render Pipeline
-
-Every diagram type follows the same three-stage pipeline:
-
-1. **Parser** (`parser.ts`): Takes `string[]` (preprocessed lines, comments stripped, semicolons split). Returns a typed AST (e.g., `ErDiagram`, `SequenceDiagram`). Pure function, no side effects.
-
-2. **Layout** (`layout.ts`): Takes the parsed AST + `RenderOptions`. Returns a positioned structure with pixel coordinates. Async (for API consistency even when synchronous internally). Uses `estimateTextWidth()` for sizing. ER/class/flowchart use dagre; sequence uses direct coordinate computation.
-
-3. **Renderer** (`renderer.ts`): Takes the positioned structure + `DiagramColors` + font + transparent flag. Returns an SVG string. Uses `svgOpenTag()` and `buildStyleBlock()` from `theme.ts`. All colors via CSS custom properties (`var(--_xxx)`).
-
-### Theming via CSS Custom Properties
-
-- Two required variables: `--bg`, `--fg` — set as inline styles on the `<svg>` tag
-- Five optional enrichment variables: `--line`, `--accent`, `--muted`, `--surface`, `--border`
-- Derived internal variables (`--_text`, `--_line`, `--_node-fill`, etc.) computed in `<style>` using `color-mix()` fallbacks
-- Renderers never hardcode colors — always reference `var(--_xxx)`
-
-### Text Width Estimation
-
-- `estimateTextWidth(text, fontSize, fontWeight)` — proportional fonts (Inter)
-- `estimateMonoTextWidth(text, fontSize)` — monospace fonts
-- Used in layout to size boxes, compute margins, center labels
-- Constants in `styles.ts`: `FONT_SIZES`, `FONT_WEIGHTS`, `STROKE_WIDTHS`, `TEXT_BASELINE_SHIFT`
-
-### SVG Structure Pattern
-
-```
-<svg ...style="--bg:...;--fg:...">
-  <style>
-    @import url(...)
-    text { font-family: ... }
-    svg { --_text: ...; --_line: ...; ... }
-  </style>
-  <defs>...</defs>
-  <!-- background elements (grid, relationship lines) -->
-  <!-- primary elements (bars, boxes, nodes) -->
-  <!-- foreground elements (labels, markers) -->
-</svg>
-```
-
-All SVG is generated as string concatenation (no DOM). Parts are pushed to an array and joined with `\n`.
-
-### Integration Checklist
-
-- [ ] `src/xychart/types.ts` — type definitions
-- [ ] `src/xychart/parser.ts` — parse xychart-beta text
-- [ ] `src/xychart/layout.ts` — compute positions
-- [ ] `src/xychart/renderer.ts` — render SVG
-- [ ] `src/index.ts` — add detection + routing
-- [ ] `samples-data.ts` — add xychart samples
-- [ ] Tests — parser unit tests for each syntax variant
-
----
-
-## Design Decisions
-
-### No dagre dependency
-XY charts use a fixed coordinate-space layout. Unlike ER/class/flowchart diagrams that need graph layout algorithms, charts have a predetermined structure: axes form a fixed frame, data maps linearly to pixel coordinates. Direct computation is simpler, faster, and avoids the dagre dependency.
-
-### Categorical vs numeric x-axis
-The parser detects which variant is used: `[label1, label2, ...]` → categorical, `min --> max` → numeric range. The layout handles both via a unified scale function that maps data indices or numeric values to pixel positions.
-
-### Series palette via color-mix
-Rather than hardcoding a palette, multi-series charts derive colors from the theme's `--accent` using `color-mix()`. This ensures the chart looks correct in any theme without maintaining separate palettes.
-
-### Horizontal mode as coordinate swap
-Horizontal orientation is handled by swapping x/y coordinates during layout rather than having a separate rendering path. The renderer draws the same SVG elements regardless of orientation — only the positions differ.
+The xychart implementation follows the same parse -> layout -> render pipeline used elsewhere in Beautiful Mermaid, with Mermaid's stable `xychart` syntax treated as primary and `xychart-beta` preserved for backward compatibility.
+
+Supported chart forms:
+
+- vertical and horizontal charts
+- bar, line, and mixed-series plots
+- categorical and numeric x-axes
+- semicolon-separated Mermaid statements
+- Mermaid accessibility directives (`accTitle` / `accDescr`)
+- Mermaid YAML frontmatter and `init` / `initialize` directives, including Mermaid-style loose object literals, for the current documented `xyChart` config surface
+- SVG and ASCII output routed through the public entry points
+
+## Pipeline
+
+### Source preprocessing
+
+`src/mermaid-source.ts` strips comments, parses Mermaid YAML frontmatter plus `init` / `initialize` directives, and produces trimmed diagram lines before xychart parsing begins.
+
+The preprocessing layer now intentionally lives in one shared place so future Mermaid-surface additions do not have to be reimplemented separately in SVG and ASCII entry points.
+
+### Parser
+
+`src/xychart/parser.ts` accepts:
+
+- `xychart` and `xychart-beta`
+- `horizontal` on the header
+- semicolon-separated one-line Mermaid statements
+- `accTitle` and single-line or block `accDescr`
+- quoted or unquoted titles where Mermaid allows them
+- categorical labels with quoting preserved and normalized
+- optional series labels on `bar` and `line`
+- numeric axis ranges
+- Mermaid frontmatter/directives for the current chart, responsive sizing, accessibility, and theme overrides
+
+The parser keeps unknown Mermaid config fields out of the typed result instead of trying to guess their meaning.
+
+### Layout
+
+`src/xychart/layout.ts` treats Mermaid `xyChart.width` and `height` as total chart size, then fits title and axis furniture into the remaining reserved space before computing the plot area.
+
+Key layout choices:
+
+- vertical charts use a left numeric axis and bottom categorical or numeric x-axis
+- horizontal charts place the numeric axis at the top and category axis on the left, matching Mermaid more closely
+- ticks use a simple linear tick generator for readable numeric steps
+- plot geometry stays within the declared chart box
+- legends are omitted to keep mixed charts visually quiet
+
+### Renderer
+
+`src/xychart/renderer.ts` and `src/ascii/xychart.ts` share the same parsed chart semantics, then render them in each output mode.
+
+Current SVG rendering decisions:
+
+- explicit axis lines and tick marks by default
+- subtle grid lines behind the plot area
+- straight line segments rather than spline interpolation
+- line dots only for interactive output
+- `showDataLabel` applies to bars only, matching Mermaid behavior
+- `useMaxWidth` / `useWidth` control responsive root SVG sizing
+- `themeCSS` is appended to the chart style block instead of being reinterpreted
+- series colors come from the shared theme accent unless Mermaid frontmatter provides `plotColorPalette`
+
+## Compatibility Notes
+
+Supported Mermaid compatibility surface is documented in [README.md](./README.md).
+
+Intentional gap today:
+
+- visual parity aims to stay close to Mermaid, but is not byte-for-byte identical
+
+## Verification Expectations
+
+XY chart changes should keep the following layers covered:
+
+- parser tests for stable/beta headers, quoted labels, comments, and frontmatter
+- layout tests for chart bounds, axis placement, and visibility rules
+- renderer tests for semantic classes, escaping, and theme token usage
+- integration tests for full parse -> layout -> render behavior
+- ASCII tests for unicode and ASCII-safe rendering
+- `samples-data.ts` coverage so the visual samples page exercises the feature


### PR DESCRIPTION
## What

Complete Mermaid xychart runtime parity in Beautiful Mermaid, limited to the xychart implementation itself plus the shared preprocessing/routing hooks that xychart now depends on.

## Why

The existing xychart support covered the basic syntax, but it still diverged from Mermaid runtime in a few important ways:

- one-line `xychart; ...` statements were not parsed like Mermaid
- `accTitle` / `accDescr` were not emitted as root SVG accessibility metadata
- Mermaid frontmatter and `init` / `initialize` directives still missed real-world YAML and loose-object inputs
- Mermaid responsive sizing and raw `themeCSS` were not fully routed into xychart rendering
- xychart lacked randomized property coverage for parser/layout invariants

## How

- add shared Mermaid source preprocessing for YAML frontmatter plus `init` / `initialize` directives, then route SVG and ASCII xychart entry points through it
- extend the xychart parser/config/theme model for semicolon statements, accessibility directives, responsive sizing, palette/theme CSS, and stricter Mermaid-compatible axis handling
- carry those settings through layout and SVG rendering, including root `<title>` / `<desc>` metadata and Mermaid-style `useMaxWidth` / `useWidth` sizing
- keep the documentation updates in the existing xychart docs paths: `README.md` and `xychart-design.md`
- add focused xychart parser/layout/renderer/integration/ASCII tests plus a new property-based xychart suite

This branch was rewritten on top of `main` and trimmed to xychart-related files only. It does not carry the earlier sample-page / generated-artifact churn.

## Testing

- [x] Focused xychart tests pass
- [x] Property-based xychart tests pass
- [x] Full test suite passes
- [x] Typecheck passes
- [x] Build passes

Commands run:

- `bun test src/__tests__/property-xychart.test.ts src/__tests__/xychart-parser.test.ts src/__tests__/xychart-layout.test.ts src/__tests__/xychart-renderer.test.ts src/__tests__/xychart-integration.test.ts src/__tests__/xychart-ascii.test.ts`
- `bun test src/__tests__/`
- `./node_modules/.bin/tsc --noEmit`
- `bun run build`
- `git diff --check`

Regression guards:

- parser tests lock semicolon splitting, accessibility directives, loose-object init directives, YAML lists/block scalars, and y-axis validity handling
- renderer/integration tests lock responsive sizing, themeCSS propagation, and root SVG accessibility metadata
- property tests lock quoted-category parsing, y-range containment, frontmatter propagation, and layout bounds across randomized charts

## Screenshots / Recordings

This changes generated library output rather than an app UI. I also manually exercised xychart rendering through the existing local preview tooling while keeping that preview output out of the PR diff.

## Risk

Low to moderate.

The main shared-code risk is `src/mermaid-source.ts`, because it preprocesses Mermaid source before dispatch. That risk is mitigated by the full-suite pass plus the new focused and property-based xychart coverage. The remaining known gap is visual parity: behavior is much closer to Mermaid runtime, but final layout/tick output is still not byte-for-byte identical.
