### PR TITLE
feat: add Mermaid timeline support with runtime parity

### DIFF
--- a/README.md
+++ b/README.md
@@ -359,6 +359,17 @@ timeline
   2024 : Timeline support
 ```
 
+Also works with Mermaid's official introductory timeline example:
+
+```
+timeline
+  title History of Social Media Platform
+  2002 : LinkedIn
+  2004 : Facebook : Google
+  2005 : YouTube
+  2006 : Twitter
+```
+
 ### Inline Edge Styling
 
 Use `linkStyle` to override edge colors and stroke widths — just like [Mermaid's linkStyle](https://mermaid.js.org/syntax/flowchart.html#styling-links):

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ The ASCII rendering engine is based on [mermaid-ascii](https://github.com/Alexan
 
 ## Features
 
-- **6 diagram types** — Flowcharts, State, Sequence, Class, ER, and XY Charts (bar, line, combined)
+- **7 diagram types** — Flowcharts, State, Sequence, Class, ER, Timeline, and XY Charts (bar, line, combined)
 - **Dual output** — SVG for rich UIs, ASCII/Unicode for terminals
 - **Synchronous rendering** — No async, no flash. Works with React `useMemo()`
 - **15 built-in themes** — And dead simple to add your own
@@ -343,6 +343,22 @@ erDiagram
   PRODUCT ||--o{ LINE_ITEM : "is in"
 ```
 
+### Timeline Diagrams
+
+Chronological milestones with optional section grouping — using Mermaid's `timeline` syntax.
+
+```
+timeline
+  title Beautiful Mermaid
+  section Foundation
+  2020 : First prototypes
+  2021 : Internal rollout
+  section Growth
+  2023 : Public launch
+       : Theme system
+  2024 : Timeline support
+```
+
 ### Inline Edge Styling
 
 Use `linkStyle` to override edge colors and stroke widths — just like [Mermaid's linkStyle](https://mermaid.js.org/syntax/flowchart.html#styling-links):
@@ -519,7 +535,7 @@ Render a Mermaid diagram to SVG. Synchronous. Auto-detects diagram type.
 | `thoroughness` | `number` | `3` | Crossing minimization trials (1-7, higher = better but slower) |
 | `interactive` | `boolean` | `false` | Enable hover tooltips on XY chart bars and data points |
 
-**XY Charts:** Diagrams starting with `xychart-beta` are auto-detected — no separate function needed. The `accent` color option drives the chart series color palette.
+**Timeline + XY Charts:** Diagrams starting with `timeline` or `xychart-beta` are auto-detected — no separate function needed. The `accent` color option drives the chart series color palette.
 
 ### `renderMermaidSVGAsync(text, options?): Promise<string>`
 

--- a/README.md
+++ b/README.md
@@ -545,6 +545,7 @@ Render a Mermaid diagram to SVG. Synchronous. Auto-detects diagram type.
 | `componentSpacing` | `number` | `24` | Spacing between disconnected components |
 | `thoroughness` | `number` | `3` | Crossing minimization trials (1-7, higher = better but slower) |
 | `interactive` | `boolean` | `false` | Enable hover tooltips on XY chart bars and data points |
+| `mermaidConfig` | `MermaidRuntimeConfig` | — | Optional Mermaid-style config merged with frontmatter and `%%{init}` / `%%{initialize}` directives |
 
 **Timeline + XY Charts:** Diagrams starting with `timeline` or `xychart-beta` are auto-detected — no separate function needed. The `accent` color option drives the chart series color palette.
 
@@ -566,6 +567,29 @@ Render a Mermaid diagram to ASCII/Unicode text. Synchronous.
 | `boxBorderPadding` | `number` | `1` | Inner box padding |
 | `colorMode` | `string` | `'auto'` | `'none'`, `'auto'`, `'ansi16'`, `'ansi256'`, `'truecolor'`, or `'html'` |
 | `theme` | `Partial<AsciiTheme>` | — | Override default colors for ASCII output |
+| `mermaidConfig` | `MermaidRuntimeConfig` | — | Optional Mermaid-style config merged with frontmatter and `%%{init}` / `%%{initialize}` directives |
+
+### Mermaid Config Support
+
+Both SVG and ASCII rendering accept Mermaid-style runtime config via `options.mermaidConfig`, and also honor leading frontmatter plus Mermaid init directives in the source text.
+
+```ts
+const svg = renderMermaidSVG(source, {
+  mermaidConfig: {
+    fontFamily: 'IBM Plex Sans',
+    timeline: {
+      disableMulticolor: true,
+      sectionFills: ['#224466'],
+      sectionColours: ['#ffffff'],
+    },
+    themeVariables: {
+      cScale0: '#224466',
+      cScaleLabel0: '#ffffff',
+      cScaleInv0: '#99bbdd',
+    },
+  },
+})
+```
 
 ### `parseMermaid(text): MermaidGraph`
 

--- a/examples/timeline-product-plan.svg
+++ b/examples/timeline-product-plan.svg
@@ -1,0 +1,102 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 734.664 322.2" width="734.664" height="322.2" style="--bg:#1a1b26;--fg:#a9b1d6;--line:#3d59a1;--accent:#7aa2f7;--muted:#565f89;background:var(--bg)" role="img" aria-labelledby="bm-a11y-title">
+<style>
+  @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&amp;display=swap');
+  text { font-family: 'Inter', system-ui, sans-serif; }
+  svg {
+    /* Derived from --bg and --fg (overridable via --line, --accent, etc.) */
+    --_text:          var(--fg);
+    --_text-sec:      var(--muted, color-mix(in srgb, var(--fg) 60%, var(--bg)));
+    --_text-muted:    var(--muted, color-mix(in srgb, var(--fg) 40%, var(--bg)));
+    --_text-faint:    color-mix(in srgb, var(--fg) 25%, var(--bg));
+    --_line:          var(--line, color-mix(in srgb, var(--fg) 50%, var(--bg)));
+    --_arrow:         var(--accent, color-mix(in srgb, var(--fg) 85%, var(--bg)));
+    --_node-fill:     var(--surface, color-mix(in srgb, var(--fg) 3%, var(--bg)));
+    --_node-stroke:   var(--border, color-mix(in srgb, var(--fg) 20%, var(--bg)));
+    --_group-fill:    var(--bg);
+    --_group-hdr:     color-mix(in srgb, var(--fg) 5%, var(--bg));
+    --_inner-stroke:  color-mix(in srgb, var(--fg) 12%, var(--bg));
+    --_key-badge:     color-mix(in srgb, var(--fg) 10%, var(--bg));
+  }
+</style>
+<style>
+  .timeline-title { fill: var(--_text); }
+  .timeline-rail { stroke: var(--_line); stroke-width: 1.5; stroke-linecap: round; }
+  .timeline-section-bg { fill: var(--tl-section-bg, color-mix(in srgb, var(--_node-fill) 88%, var(--bg))); stroke: var(--tl-line, var(--_node-stroke)); stroke-width: 1; }
+  .timeline-section-band { fill: var(--tl-section-band, color-mix(in srgb, var(--_arrow) 8%, var(--bg))); stroke: var(--tl-line, var(--_node-stroke)); stroke-width: 1; }
+  .timeline-section-label { fill: var(--tl-label, var(--_text-sec)); }
+  .timeline-stem { stroke: var(--tl-line, color-mix(in srgb, var(--_arrow) 32%, var(--_line))); stroke-width: 1; stroke-dasharray: 3 4; }
+  .timeline-marker-ring { fill: var(--bg); stroke: var(--tl-line, var(--_arrow)); stroke-width: 1.5; }
+  .timeline-marker-core { fill: var(--tl-accent, var(--_arrow)); }
+  .timeline-period-pill { fill: var(--tl-pill-fill, color-mix(in srgb, var(--_arrow) 7%, var(--bg))); stroke: var(--tl-pill-stroke, color-mix(in srgb, var(--_arrow) 20%, var(--bg))); stroke-width: 1; }
+  .timeline-period-text { fill: var(--tl-label, var(--_text)); }
+  .timeline-event-card { fill: var(--tl-event-fill, var(--_node-fill)); stroke: var(--tl-line, var(--_node-stroke)); stroke-width: 1; }
+  .timeline-event-accent { fill: var(--tl-event-accent, color-mix(in srgb, var(--_arrow) 18%, var(--bg))); }
+  .timeline-event-text { fill: var(--tl-label, var(--_text-muted)); }
+</style>
+<title id="bm-a11y-title">Product Delivery Plan</title>
+<g class="timeline-section" data-id="section-0" data-label="Foundation" data-family="0" style="--tl-accent:var(--_arrow);--tl-fill:var(--_arrow);--tl-label:var(--_text);--tl-line:color-mix(in srgb, var(--_arrow) 48%, var(--_line));--tl-section-bg:color-mix(in srgb, var(--_arrow) 6%, var(--bg));--tl-section-band:color-mix(in srgb, var(--_arrow) 12%, var(--bg));--tl-pill-fill:color-mix(in srgb, var(--_arrow) 11%, var(--bg));--tl-pill-stroke:color-mix(in srgb, var(--_arrow) 36%, color-mix(in srgb, var(--_arrow) 48%, var(--_line)));--tl-event-fill:color-mix(in srgb, var(--_arrow) 16%, var(--_node-fill));--tl-event-accent:color-mix(in srgb, var(--_arrow) 26%, var(--bg))">
+  <rect class="timeline-section-bg" x="32" y="75.4" width="316" height="173.2" rx="0" ry="0" />
+  <rect class="timeline-section-band" x="32" y="75.4" width="316" height="24" rx="0" ry="0" />
+  <text x="44" y="87.4" class="timeline-section-label" text-anchor="start" font-size="12" font-weight="600" dy="4.199999999999999">Foundation</text>
+</g>
+<g class="timeline-section" data-id="section-1" data-label="Launch" data-family="1" style="--tl-accent:color-mix(in srgb, var(--_arrow) 72%, var(--_line));--tl-fill:color-mix(in srgb, var(--_arrow) 72%, var(--_line));--tl-label:var(--_text);--tl-line:color-mix(in srgb, color-mix(in srgb, var(--_arrow) 72%, var(--_line)) 48%, var(--_line));--tl-section-bg:color-mix(in srgb, color-mix(in srgb, var(--_arrow) 72%, var(--_line)) 6%, var(--bg));--tl-section-band:color-mix(in srgb, color-mix(in srgb, var(--_arrow) 72%, var(--_line)) 12%, var(--bg));--tl-pill-fill:color-mix(in srgb, color-mix(in srgb, var(--_arrow) 72%, var(--_line)) 11%, var(--bg));--tl-pill-stroke:color-mix(in srgb, color-mix(in srgb, var(--_arrow) 72%, var(--_line)) 36%, color-mix(in srgb, color-mix(in srgb, var(--_arrow) 72%, var(--_line)) 48%, var(--_line)));--tl-event-fill:color-mix(in srgb, color-mix(in srgb, var(--_arrow) 72%, var(--_line)) 16%, var(--_node-fill));--tl-event-accent:color-mix(in srgb, color-mix(in srgb, var(--_arrow) 72%, var(--_line)) 26%, var(--bg))">
+  <rect class="timeline-section-bg" x="376" y="75.4" width="326.664" height="218.79999999999998" rx="0" ry="0" />
+  <rect class="timeline-section-band" x="376" y="75.4" width="326.664" height="24" rx="0" ry="0" />
+  <text x="388" y="87.4" class="timeline-section-label" text-anchor="start" font-size="12" font-weight="600" dy="4.199999999999999">Launch</text>
+</g>
+<line class="timeline-rail" x1="114" y1="167" x2="620.664" y2="167" />
+<g class="timeline-period" data-id="period-0" data-label="2022 Q4" data-section="Foundation" data-family="0" style="--tl-accent:var(--_arrow);--tl-fill:var(--_arrow);--tl-label:var(--_text);--tl-line:color-mix(in srgb, var(--_arrow) 48%, var(--_line));--tl-section-bg:color-mix(in srgb, var(--_arrow) 6%, var(--bg));--tl-section-band:color-mix(in srgb, var(--_arrow) 12%, var(--bg));--tl-pill-fill:color-mix(in srgb, var(--_arrow) 11%, var(--bg));--tl-pill-stroke:color-mix(in srgb, var(--_arrow) 36%, color-mix(in srgb, var(--_arrow) 48%, var(--_line)));--tl-event-fill:color-mix(in srgb, var(--_arrow) 16%, var(--_node-fill));--tl-event-accent:color-mix(in srgb, var(--_arrow) 26%, var(--bg))">
+  <line class="timeline-stem" x1="114" y1="175" x2="114" y2="185" />
+  <rect class="timeline-period-pill" x="77.7" y="113.4" width="72.6" height="31.6" rx="0" ry="0" />
+  <text x="114" y="129.20000000000002" class="timeline-period-text" text-anchor="middle" font-size="12" font-weight="600" dy="4.199999999999999">2022 Q4</text>
+  <circle class="timeline-marker-ring" cx="114" cy="167" r="8" />
+  <circle class="timeline-marker-core" cx="114" cy="167" r="4.5" />
+<g class="timeline-event" data-id="event-0" data-period="2022 Q4" data-section="Foundation" data-family="0">
+  <rect class="timeline-event-card" x="50" y="195" width="128" height="35.6" rx="0" ry="0" />
+  <rect class="timeline-event-accent" x="50" y="195" width="4" height="35.6" rx="0" ry="0" />
+  <text x="66" y="212.8" class="timeline-event-text" text-anchor="start" font-size="12" font-weight="400" dy="4.199999999999999">Research</text>
+</g>
+</g>
+<g class="timeline-period" data-id="period-1" data-label="2023 Q1" data-section="Foundation" data-family="0" style="--tl-accent:var(--_arrow);--tl-fill:var(--_arrow);--tl-label:var(--_text);--tl-line:color-mix(in srgb, var(--_arrow) 48%, var(--_line));--tl-section-bg:color-mix(in srgb, var(--_arrow) 6%, var(--bg));--tl-section-band:color-mix(in srgb, var(--_arrow) 12%, var(--bg));--tl-pill-fill:color-mix(in srgb, var(--_arrow) 11%, var(--bg));--tl-pill-stroke:color-mix(in srgb, var(--_arrow) 36%, color-mix(in srgb, var(--_arrow) 48%, var(--_line)));--tl-event-fill:color-mix(in srgb, var(--_arrow) 16%, var(--_node-fill));--tl-event-accent:color-mix(in srgb, var(--_arrow) 26%, var(--bg))">
+  <line class="timeline-stem" x1="266" y1="175" x2="266" y2="185" />
+  <rect class="timeline-period-pill" x="230" y="113.4" width="72" height="31.6" rx="0" ry="0" />
+  <text x="266" y="129.20000000000002" class="timeline-period-text" text-anchor="middle" font-size="12" font-weight="600" dy="4.199999999999999">2023 Q1</text>
+  <circle class="timeline-marker-ring" cx="266" cy="167" r="8" />
+  <circle class="timeline-marker-core" cx="266" cy="167" r="4.5" />
+<g class="timeline-event" data-id="event-1" data-period="2023 Q1" data-section="Foundation" data-family="0">
+  <rect class="timeline-event-card" x="202" y="195" width="128" height="35.6" rx="0" ry="0" />
+  <rect class="timeline-event-accent" x="202" y="195" width="4" height="35.6" rx="0" ry="0" />
+  <text x="218" y="212.8" class="timeline-event-text" text-anchor="start" font-size="12" font-weight="400" dy="4.199999999999999">Prototype</text>
+</g>
+</g>
+<g class="timeline-period" data-id="period-2" data-label="2023 Q3" data-section="Launch" data-family="1" style="--tl-accent:color-mix(in srgb, var(--_arrow) 72%, var(--_line));--tl-fill:color-mix(in srgb, var(--_arrow) 72%, var(--_line));--tl-label:var(--_text);--tl-line:color-mix(in srgb, color-mix(in srgb, var(--_arrow) 72%, var(--_line)) 48%, var(--_line));--tl-section-bg:color-mix(in srgb, color-mix(in srgb, var(--_arrow) 72%, var(--_line)) 6%, var(--bg));--tl-section-band:color-mix(in srgb, color-mix(in srgb, var(--_arrow) 72%, var(--_line)) 12%, var(--bg));--tl-pill-fill:color-mix(in srgb, color-mix(in srgb, var(--_arrow) 72%, var(--_line)) 11%, var(--bg));--tl-pill-stroke:color-mix(in srgb, color-mix(in srgb, var(--_arrow) 72%, var(--_line)) 36%, color-mix(in srgb, color-mix(in srgb, var(--_arrow) 72%, var(--_line)) 48%, var(--_line)));--tl-event-fill:color-mix(in srgb, color-mix(in srgb, var(--_arrow) 72%, var(--_line)) 16%, var(--_node-fill));--tl-event-accent:color-mix(in srgb, color-mix(in srgb, var(--_arrow) 72%, var(--_line)) 26%, var(--bg))">
+  <line class="timeline-stem" x1="463.332" y1="175" x2="463.332" y2="185" />
+  <rect class="timeline-period-pill" x="427.032" y="113.4" width="72.6" height="31.6" rx="0" ry="0" />
+  <text x="463.332" y="129.20000000000002" class="timeline-period-text" text-anchor="middle" font-size="12" font-weight="600" dy="4.199999999999999">2023 Q3</text>
+  <circle class="timeline-marker-ring" cx="463.332" cy="167" r="8" />
+  <circle class="timeline-marker-core" cx="463.332" cy="167" r="4.5" />
+<g class="timeline-event" data-id="event-2" data-period="2023 Q3" data-section="Launch" data-family="1">
+  <rect class="timeline-event-card" x="399.332" y="195" width="128" height="35.6" rx="0" ry="0" />
+  <rect class="timeline-event-accent" x="399.332" y="195" width="4" height="35.6" rx="0" ry="0" />
+  <text x="415.332" y="212.8" class="timeline-event-text" text-anchor="start" font-size="12" font-weight="400" dy="4.199999999999999">Private beta</text>
+</g>
+<g class="timeline-event" data-id="event-3" data-period="2023 Q3" data-section="Launch" data-family="1">
+  <rect class="timeline-event-card" x="394" y="240.6" width="138.664" height="35.6" rx="0" ry="0" />
+  <rect class="timeline-event-accent" x="394" y="240.6" width="4" height="35.6" rx="0" ry="0" />
+  <text x="410" y="258.4" class="timeline-event-text" text-anchor="start" font-size="12" font-weight="400" dy="4.199999999999999">Design system rollout</text>
+</g>
+</g>
+<g class="timeline-period" data-id="period-3" data-label="2024 Q1" data-section="Launch" data-family="1" style="--tl-accent:color-mix(in srgb, var(--_arrow) 72%, var(--_line));--tl-fill:color-mix(in srgb, var(--_arrow) 72%, var(--_line));--tl-label:var(--_text);--tl-line:color-mix(in srgb, color-mix(in srgb, var(--_arrow) 72%, var(--_line)) 48%, var(--_line));--tl-section-bg:color-mix(in srgb, color-mix(in srgb, var(--_arrow) 72%, var(--_line)) 6%, var(--bg));--tl-section-band:color-mix(in srgb, color-mix(in srgb, var(--_arrow) 72%, var(--_line)) 12%, var(--bg));--tl-pill-fill:color-mix(in srgb, color-mix(in srgb, var(--_arrow) 72%, var(--_line)) 11%, var(--bg));--tl-pill-stroke:color-mix(in srgb, color-mix(in srgb, var(--_arrow) 72%, var(--_line)) 36%, color-mix(in srgb, color-mix(in srgb, var(--_arrow) 72%, var(--_line)) 48%, var(--_line)));--tl-event-fill:color-mix(in srgb, color-mix(in srgb, var(--_arrow) 72%, var(--_line)) 16%, var(--_node-fill));--tl-event-accent:color-mix(in srgb, color-mix(in srgb, var(--_arrow) 72%, var(--_line)) 26%, var(--bg))">
+  <line class="timeline-stem" x1="620.664" y1="175" x2="620.664" y2="185" />
+  <rect class="timeline-period-pill" x="584.664" y="113.4" width="72" height="31.6" rx="0" ry="0" />
+  <text x="620.664" y="129.20000000000002" class="timeline-period-text" text-anchor="middle" font-size="12" font-weight="600" dy="4.199999999999999">2024 Q1</text>
+  <circle class="timeline-marker-ring" cx="620.664" cy="167" r="8" />
+  <circle class="timeline-marker-core" cx="620.664" cy="167" r="4.5" />
+<g class="timeline-event" data-id="event-4" data-period="2024 Q1" data-section="Launch" data-family="1">
+  <rect class="timeline-event-card" x="556.664" y="195" width="128" height="35.6" rx="0" ry="0" />
+  <rect class="timeline-event-accent" x="556.664" y="195" width="4" height="35.6" rx="0" ry="0" />
+  <text x="572.664" y="212.8" class="timeline-event-text" text-anchor="start" font-size="12" font-weight="400" dy="4.199999999999999">Public launch</text>
+</g>
+</g>
+<text x="367.332" y="39.7" class="timeline-title" text-anchor="middle" font-size="18" font-weight="600" dy="6.3">Product Delivery Plan</text>
+</svg>

--- a/examples/timeline-social.svg
+++ b/examples/timeline-social.svg
@@ -1,0 +1,92 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 648 284.2" width="648" height="284.2" style="--bg:#FFFFFF;--fg:#27272A;background:var(--bg)" role="img" aria-labelledby="bm-a11y-title">
+<style>
+  @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&amp;display=swap');
+  text { font-family: 'Inter', system-ui, sans-serif; }
+  svg {
+    /* Derived from --bg and --fg (overridable via --line, --accent, etc.) */
+    --_text:          var(--fg);
+    --_text-sec:      var(--muted, color-mix(in srgb, var(--fg) 60%, var(--bg)));
+    --_text-muted:    var(--muted, color-mix(in srgb, var(--fg) 40%, var(--bg)));
+    --_text-faint:    color-mix(in srgb, var(--fg) 25%, var(--bg));
+    --_line:          var(--line, color-mix(in srgb, var(--fg) 50%, var(--bg)));
+    --_arrow:         var(--accent, color-mix(in srgb, var(--fg) 85%, var(--bg)));
+    --_node-fill:     var(--surface, color-mix(in srgb, var(--fg) 3%, var(--bg)));
+    --_node-stroke:   var(--border, color-mix(in srgb, var(--fg) 20%, var(--bg)));
+    --_group-fill:    var(--bg);
+    --_group-hdr:     color-mix(in srgb, var(--fg) 5%, var(--bg));
+    --_inner-stroke:  color-mix(in srgb, var(--fg) 12%, var(--bg));
+    --_key-badge:     color-mix(in srgb, var(--fg) 10%, var(--bg));
+  }
+</style>
+<style>
+  .timeline-title { fill: var(--_text); }
+  .timeline-rail { stroke: var(--_line); stroke-width: 1.5; stroke-linecap: round; }
+  .timeline-section-bg { fill: var(--tl-section-bg, color-mix(in srgb, var(--_node-fill) 88%, var(--bg))); stroke: var(--tl-line, var(--_node-stroke)); stroke-width: 1; }
+  .timeline-section-band { fill: var(--tl-section-band, color-mix(in srgb, var(--_arrow) 8%, var(--bg))); stroke: var(--tl-line, var(--_node-stroke)); stroke-width: 1; }
+  .timeline-section-label { fill: var(--tl-label, var(--_text-sec)); }
+  .timeline-stem { stroke: var(--tl-line, color-mix(in srgb, var(--_arrow) 32%, var(--_line))); stroke-width: 1; stroke-dasharray: 3 4; }
+  .timeline-marker-ring { fill: var(--bg); stroke: var(--tl-line, var(--_arrow)); stroke-width: 1.5; }
+  .timeline-marker-core { fill: var(--tl-accent, var(--_arrow)); }
+  .timeline-period-pill { fill: var(--tl-pill-fill, color-mix(in srgb, var(--_arrow) 7%, var(--bg))); stroke: var(--tl-pill-stroke, color-mix(in srgb, var(--_arrow) 20%, var(--bg))); stroke-width: 1; }
+  .timeline-period-text { fill: var(--tl-label, var(--_text)); }
+  .timeline-event-card { fill: var(--tl-event-fill, var(--_node-fill)); stroke: var(--tl-line, var(--_node-stroke)); stroke-width: 1; }
+  .timeline-event-accent { fill: var(--tl-event-accent, color-mix(in srgb, var(--_arrow) 18%, var(--bg))); }
+  .timeline-event-text { fill: var(--tl-label, var(--_text-muted)); }
+</style>
+<title id="bm-a11y-title">History of Social Media Platform</title>
+<line class="timeline-rail" x1="96" y1="129" x2="552" y2="129" />
+<g class="timeline-period" data-id="period-0" data-label="2002" data-family="0" style="--tl-accent:#5B7FFF;--tl-fill:#5B7FFF;--tl-label:var(--_text);--tl-line:color-mix(in srgb, #5B7FFF 48%, var(--_line));--tl-section-bg:color-mix(in srgb, #5B7FFF 6%, var(--bg));--tl-section-band:color-mix(in srgb, #5B7FFF 12%, var(--bg));--tl-pill-fill:color-mix(in srgb, #5B7FFF 11%, var(--bg));--tl-pill-stroke:color-mix(in srgb, #5B7FFF 36%, color-mix(in srgb, #5B7FFF 48%, var(--_line)));--tl-event-fill:color-mix(in srgb, #5B7FFF 16%, var(--_node-fill));--tl-event-accent:color-mix(in srgb, #5B7FFF 26%, var(--bg))">
+  <line class="timeline-stem" x1="96" y1="137" x2="96" y2="147" />
+  <rect class="timeline-period-pill" x="60" y="75.4" width="72" height="31.6" rx="0" ry="0" />
+  <text x="96" y="91.2" class="timeline-period-text" text-anchor="middle" font-size="12" font-weight="600" dy="4.199999999999999">2002</text>
+  <circle class="timeline-marker-ring" cx="96" cy="129" r="8" />
+  <circle class="timeline-marker-core" cx="96" cy="129" r="4.5" />
+<g class="timeline-event" data-id="event-0" data-period="2002" data-family="0">
+  <rect class="timeline-event-card" x="32" y="157" width="128" height="35.6" rx="0" ry="0" />
+  <rect class="timeline-event-accent" x="32" y="157" width="4" height="35.6" rx="0" ry="0" />
+  <text x="48" y="174.8" class="timeline-event-text" text-anchor="start" font-size="12" font-weight="400" dy="4.199999999999999">LinkedIn</text>
+</g>
+</g>
+<g class="timeline-period" data-id="period-1" data-label="2004" data-family="1" style="--tl-accent:#159A72;--tl-fill:#159A72;--tl-label:var(--_text);--tl-line:color-mix(in srgb, #159A72 48%, var(--_line));--tl-section-bg:color-mix(in srgb, #159A72 6%, var(--bg));--tl-section-band:color-mix(in srgb, #159A72 12%, var(--bg));--tl-pill-fill:color-mix(in srgb, #159A72 11%, var(--bg));--tl-pill-stroke:color-mix(in srgb, #159A72 36%, color-mix(in srgb, #159A72 48%, var(--_line)));--tl-event-fill:color-mix(in srgb, #159A72 16%, var(--_node-fill));--tl-event-accent:color-mix(in srgb, #159A72 26%, var(--bg))">
+  <line class="timeline-stem" x1="248" y1="137" x2="248" y2="147" />
+  <rect class="timeline-period-pill" x="212" y="75.4" width="72" height="31.6" rx="0" ry="0" />
+  <text x="248" y="91.2" class="timeline-period-text" text-anchor="middle" font-size="12" font-weight="600" dy="4.199999999999999">2004</text>
+  <circle class="timeline-marker-ring" cx="248" cy="129" r="8" />
+  <circle class="timeline-marker-core" cx="248" cy="129" r="4.5" />
+<g class="timeline-event" data-id="event-1" data-period="2004" data-family="1">
+  <rect class="timeline-event-card" x="184" y="157" width="128" height="35.6" rx="0" ry="0" />
+  <rect class="timeline-event-accent" x="184" y="157" width="4" height="35.6" rx="0" ry="0" />
+  <text x="200" y="174.8" class="timeline-event-text" text-anchor="start" font-size="12" font-weight="400" dy="4.199999999999999">Facebook</text>
+</g>
+<g class="timeline-event" data-id="event-2" data-period="2004" data-family="1">
+  <rect class="timeline-event-card" x="184" y="202.6" width="128" height="35.6" rx="0" ry="0" />
+  <rect class="timeline-event-accent" x="184" y="202.6" width="4" height="35.6" rx="0" ry="0" />
+  <text x="200" y="220.4" class="timeline-event-text" text-anchor="start" font-size="12" font-weight="400" dy="4.199999999999999">Google</text>
+</g>
+</g>
+<g class="timeline-period" data-id="period-2" data-label="2005" data-family="2" style="--tl-accent:#D18A24;--tl-fill:#D18A24;--tl-label:var(--_text);--tl-line:color-mix(in srgb, #D18A24 48%, var(--_line));--tl-section-bg:color-mix(in srgb, #D18A24 6%, var(--bg));--tl-section-band:color-mix(in srgb, #D18A24 12%, var(--bg));--tl-pill-fill:color-mix(in srgb, #D18A24 11%, var(--bg));--tl-pill-stroke:color-mix(in srgb, #D18A24 36%, color-mix(in srgb, #D18A24 48%, var(--_line)));--tl-event-fill:color-mix(in srgb, #D18A24 16%, var(--_node-fill));--tl-event-accent:color-mix(in srgb, #D18A24 26%, var(--bg))">
+  <line class="timeline-stem" x1="400" y1="137" x2="400" y2="147" />
+  <rect class="timeline-period-pill" x="364" y="75.4" width="72" height="31.6" rx="0" ry="0" />
+  <text x="400" y="91.2" class="timeline-period-text" text-anchor="middle" font-size="12" font-weight="600" dy="4.199999999999999">2005</text>
+  <circle class="timeline-marker-ring" cx="400" cy="129" r="8" />
+  <circle class="timeline-marker-core" cx="400" cy="129" r="4.5" />
+<g class="timeline-event" data-id="event-3" data-period="2005" data-family="2">
+  <rect class="timeline-event-card" x="336" y="157" width="128" height="35.6" rx="0" ry="0" />
+  <rect class="timeline-event-accent" x="336" y="157" width="4" height="35.6" rx="0" ry="0" />
+  <text x="352" y="174.8" class="timeline-event-text" text-anchor="start" font-size="12" font-weight="400" dy="4.199999999999999">YouTube</text>
+</g>
+</g>
+<g class="timeline-period" data-id="period-3" data-label="2006" data-family="3" style="--tl-accent:#CC5A5A;--tl-fill:#CC5A5A;--tl-label:var(--_text);--tl-line:color-mix(in srgb, #CC5A5A 48%, var(--_line));--tl-section-bg:color-mix(in srgb, #CC5A5A 6%, var(--bg));--tl-section-band:color-mix(in srgb, #CC5A5A 12%, var(--bg));--tl-pill-fill:color-mix(in srgb, #CC5A5A 11%, var(--bg));--tl-pill-stroke:color-mix(in srgb, #CC5A5A 36%, color-mix(in srgb, #CC5A5A 48%, var(--_line)));--tl-event-fill:color-mix(in srgb, #CC5A5A 16%, var(--_node-fill));--tl-event-accent:color-mix(in srgb, #CC5A5A 26%, var(--bg))">
+  <line class="timeline-stem" x1="552" y1="137" x2="552" y2="147" />
+  <rect class="timeline-period-pill" x="516" y="75.4" width="72" height="31.6" rx="0" ry="0" />
+  <text x="552" y="91.2" class="timeline-period-text" text-anchor="middle" font-size="12" font-weight="600" dy="4.199999999999999">2006</text>
+  <circle class="timeline-marker-ring" cx="552" cy="129" r="8" />
+  <circle class="timeline-marker-core" cx="552" cy="129" r="4.5" />
+<g class="timeline-event" data-id="event-4" data-period="2006" data-family="3">
+  <rect class="timeline-event-card" x="488" y="157" width="128" height="35.6" rx="0" ry="0" />
+  <rect class="timeline-event-accent" x="488" y="157" width="4" height="35.6" rx="0" ry="0" />
+  <text x="504" y="174.8" class="timeline-event-text" text-anchor="start" font-size="12" font-weight="400" dy="4.199999999999999">Twitter</text>
+</g>
+</g>
+<text x="324" y="39.7" class="timeline-title" text-anchor="middle" font-size="18" font-weight="600" dy="6.3">History of Social Media Platform</text>
+</svg>

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "sequence-diagram",
     "class-diagram",
     "er-diagram",
+    "timeline-diagram",
     "xychart",
     "state-diagram",
     "visualization",

--- a/samples-data.ts
+++ b/samples-data.ts
@@ -1183,6 +1183,22 @@ export const samples: Sample[] = [
   },
 
   // ══════════════════════════════════════════════════════════════════════════
+  //  TIMELINE DIAGRAMS
+  // ══════════════════════════════════════════════════════════════════════════
+
+  {
+    title: 'Timeline: Social Media History',
+    category: 'Timeline',
+    description: 'Mirrors Mermaid’s official introductory timeline example, with each period carrying its own color family.',
+    source: `timeline
+  title History of Social Media Platform
+  2002 : LinkedIn
+  2004 : Facebook : Google
+  2005 : YouTube
+  2006 : Twitter`,
+  },
+
+  // ══════════════════════════════════════════════════════════════════════════
   //  XY CHARTS (xychart-beta)
   // ══════════════════════════════════════════════════════════════════════════
 

--- a/samples-data.ts
+++ b/samples-data.ts
@@ -1197,6 +1197,32 @@ export const samples: Sample[] = [
   2005 : YouTube
   2006 : Twitter`,
   },
+  {
+    title: 'Timeline: Product Delivery Plan',
+    category: 'Timeline',
+    description: 'Sectioned timeline with continuation events, matching the more advanced Mermaid Timeline examples.',
+    source: `timeline
+  title Product Delivery Plan
+  section Foundation
+  2022 Q4 : Research
+  2023 Q1 : Prototype
+  section Launch
+  2023 Q3 : Private beta
+          : Design system rollout
+  2024 Q1 : Public launch`,
+  },
+  {
+    title: 'Timeline: Multiline Platform Milestones',
+    category: 'Timeline',
+    description: 'Exercises <br> labels in the title, section labels, periods, and event cards.',
+    source: `timeline
+  title Platform<br>Milestones
+  section Core<br>platform
+  2024<br>Q1 : Soft<br>launch
+  2024<br>Q2 : Mobile<br>support
+  section Adoption
+  2024<br>Q4 : Team<br>rollout`,
+  },
 
   // ══════════════════════════════════════════════════════════════════════════
   //  XY CHARTS (xychart-beta)

--- a/src/__tests__/mermaid-source.test.ts
+++ b/src/__tests__/mermaid-source.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'bun:test'
+import { normalizeMermaidSource } from '../mermaid-source.ts'
+
+describe('normalizeMermaidSource', () => {
+  it('merges base config, frontmatter config, and init directives in Mermaid order', () => {
+    const normalized = normalizeMermaidSource(`---
+config:
+  themeVariables:
+    cScale0: "#112233"
+  timeline:
+    disableMulticolor: true
+---
+%%{init: {"fontFamily":"IBM Plex Sans","timeline":{"sectionFills":["#224466"]}}}%%
+%% comment
+timeline
+2024 : Launch`, {
+      timeline: {
+        disableMulticolor: false,
+        sectionColours: ['#f8f8f8'],
+      },
+    })
+
+    expect(normalized.firstLine).toBe('timeline')
+    expect(normalized.lines).toEqual(['timeline', '2024 : Launch'])
+    expect(normalized.config.fontFamily).toBe('IBM Plex Sans')
+    expect(normalized.config.themeVariables?.cScale0).toBe('#112233')
+    expect(normalized.config.timeline?.disableMulticolor).toBe(true)
+    expect(normalized.config.timeline?.sectionFills).toEqual(['#224466'])
+    expect(normalized.config.timeline?.sectionColours).toEqual(['#f8f8f8'])
+  })
+
+  it('supports initialize directives and quoted theme variable keys', () => {
+    const normalized = normalizeMermaidSource(`%%{initialize: {"themeVariables":{"cScale1":"#336699","cScaleLabel1":"#ffffff"}}}%%
+timeline
+2025 : General availability`)
+
+    expect(normalized.config.themeVariables?.cScale1).toBe('#336699')
+    expect(normalized.config.themeVariables?.cScaleLabel1).toBe('#ffffff')
+    expect(normalized.lines).toEqual(['timeline', '2025 : General availability'])
+  })
+})

--- a/src/__tests__/styles.test.ts
+++ b/src/__tests__/styles.test.ts
@@ -59,6 +59,16 @@ describe('svgOpenTag', () => {
     expect(tag).not.toContain('--accent')
     expect(tag).not.toContain('--muted')
   })
+
+  it('adds extra root attributes when requested', () => {
+    const tag = svgOpenTag(400, 300, { bg: '#fff', fg: '#000' }, false, {
+      role: 'img',
+      'aria-labelledby': 'bm-a11y-title',
+    })
+
+    expect(tag).toContain('role="img"')
+    expect(tag).toContain('aria-labelledby="bm-a11y-title"')
+  })
 })
 
 describe('buildStyleBlock', () => {

--- a/src/__tests__/timeline-ascii.test.ts
+++ b/src/__tests__/timeline-ascii.test.ts
@@ -90,5 +90,19 @@ describe('timeline ASCII', () => {
     expect(result).toContain('Private alpha')
     expect(result).toContain('○ 2023')
     expect(result).toContain('Public launch')
+    expect(result).not.toContain('○ title')
+    expect(result).not.toContain('Timeline example')
+  })
+
+  it('does not render accessibility metadata as visible timeline content', () => {
+    const result = render(`timeline
+      accTitle: Accessible roadmap
+      accDescr: Product launch plan
+      2024 : Private alpha`)
+
+    expect(result).toContain('○ 2024')
+    expect(result).toContain('Private alpha')
+    expect(result).not.toContain('Accessible roadmap')
+    expect(result).not.toContain('Product launch plan')
   })
 })

--- a/src/__tests__/timeline-ascii.test.ts
+++ b/src/__tests__/timeline-ascii.test.ts
@@ -1,0 +1,79 @@
+/**
+ * Tests for timeline ASCII rendering.
+ */
+import { describe, it, expect } from 'bun:test'
+import { renderMermaidASCII } from '../ascii/index.ts'
+
+function render(text: string, options: Parameters<typeof renderMermaidASCII>[1] = {}): string {
+  return renderMermaidASCII(text, { colorMode: 'none', ...options })
+}
+
+describe('timeline ASCII', () => {
+  it('renders a basic timeline with title, period, and event', () => {
+    const result = render(`timeline
+      title Product history
+      2024 : Timeline support`)
+
+    expect(result).toContain('Product history')
+    expect(result).toContain('○ 2024')
+    expect(result).toContain('└─ Timeline support')
+  })
+
+  it('renders section labels and multiple events', () => {
+    const result = render(`timeline
+      section Growth
+      2023 : Public launch
+           : Theme system`)
+
+    expect(result).toContain('[Growth]')
+    expect(result).toContain('○ 2023')
+    expect(result).toContain('├─ Public launch')
+    expect(result).toContain('└─ Theme system')
+  })
+
+  it('uses ASCII-safe glyphs in ASCII mode', () => {
+    const result = render(`timeline
+      2024 : Timeline support`, { useAscii: true })
+
+    expect(result).toContain('o 2024')
+    expect(result).toContain('`- Timeline support')
+    expect(result).not.toContain('○')
+    expect(result).not.toContain('└')
+  })
+
+  it('renders multiline event text on subsequent indented lines', () => {
+    const result = render(`timeline
+      2024 : Soft<br>launch`)
+
+    expect(result).toContain('Soft')
+    expect(result).toContain('launch')
+  })
+
+  it('supports themed HTML output and escapes labels safely', () => {
+    const result = render(`timeline
+      title Roadmap < 2025
+      section Phase <1>
+      2024 : Ship <alpha>`, {
+      colorMode: 'html',
+      theme: {
+        fg: '#101010',
+        border: '#202020',
+        line: '#303030',
+        arrow: '#404040',
+        junction: '#505050',
+        corner: '#606060',
+      },
+    })
+
+    expect(result).toContain('<span style="color:#101010">Roadmap</span>')
+    expect(result).toContain('<span style="color:#101010">&lt;</span>')
+    expect(result).toContain('<span style="color:#202020">[</span>')
+    expect(result).toContain('<span style="color:#101010">Phase</span>')
+    expect(result).toContain('<span style="color:#202020">]</span>')
+    expect(result).toContain('<span style="color:#505050">○</span>')
+    expect(result).toContain('<span style="color:#303030">│</span>')
+    expect(result).toContain('<span style="color:#101010">Ship</span>')
+    expect(result).toContain('<span style="color:#101010">&lt;alpha&gt;</span>')
+    expect(result).not.toContain('Ship <alpha>')
+  })
+})

--- a/src/__tests__/timeline-ascii.test.ts
+++ b/src/__tests__/timeline-ascii.test.ts
@@ -76,4 +76,19 @@ describe('timeline ASCII', () => {
     expect(result).toContain('<span style="color:#101010">&lt;alpha&gt;</span>')
     expect(result).not.toContain('Ship <alpha>')
   })
+
+  it('routes timeline ASCII correctly with frontmatter and comment lines', () => {
+    const result = render(`---
+      title: Timeline example
+      ---
+      %% comment before header
+      timeline
+      2022 : Private alpha
+      2023 : Public launch`)
+
+    expect(result).toContain('○ 2022')
+    expect(result).toContain('Private alpha')
+    expect(result).toContain('○ 2023')
+    expect(result).toContain('Public launch')
+  })
 })

--- a/src/__tests__/timeline-integration.test.ts
+++ b/src/__tests__/timeline-integration.test.ts
@@ -102,4 +102,20 @@ describe('renderMermaidSVG – timeline diagrams', () => {
     expect(svg).toContain('--fg:var(--foreground)')
     expect(svg).not.toContain('NaN')
   })
+
+  it('routes timeline diagrams correctly with frontmatter and comment lines', () => {
+    const svg = render(`---
+      title: Timeline example
+      ---
+      %% comment before header
+      timeline
+      title Product history
+      2022 : Private alpha
+      2023 : Public launch`)
+
+    expect(svg).toContain('class="timeline-rail"')
+    expect(svg).toContain('Product history')
+    expect(svg).toContain('Private alpha')
+    expect(svg).toContain('Public launch')
+  })
 })

--- a/src/__tests__/timeline-integration.test.ts
+++ b/src/__tests__/timeline-integration.test.ts
@@ -1,0 +1,79 @@
+/**
+ * Integration tests for timeline diagrams — end-to-end parse → layout → render.
+ */
+import { describe, it, expect } from 'bun:test'
+import { renderMermaidSVG } from '../index.ts'
+import type { RenderOptions } from '../types.ts'
+
+function render(text: string, options: RenderOptions = {}): string {
+  return renderMermaidSVG(text, options)
+}
+
+describe('renderMermaidSVG – timeline diagrams', () => {
+  it('renders a basic timeline to valid SVG', () => {
+    const svg = render(`timeline
+      title Product history
+      2022 : Private alpha
+      2023 : Public launch`)
+
+    expect(svg).toContain('<svg')
+    expect(svg).toContain('</svg>')
+    expect(svg).toContain('Product history')
+    expect(svg).toContain('class="timeline-rail"')
+    expect(svg).toContain('class="timeline-period"')
+    expect(svg).toContain('class="timeline-event"')
+  })
+
+  it('renders section frames and semantic data attributes', () => {
+    const svg = render(`timeline
+      title Beautiful Mermaid
+      section Foundation
+      2020 : Prototype
+      section Growth
+      2021 : Launch`)
+
+    expect(svg).toContain('class="timeline-section"')
+    expect(svg).toContain('data-label="Foundation"')
+    expect(svg).toContain('data-section="Growth"')
+    expect(svg).toContain('Prototype')
+    expect(svg).toContain('Launch')
+  })
+
+  it('renders multiple events for a single period', () => {
+    const svg = render(`timeline
+      2024 : Design refresh
+           : Timeline support
+           : Packaging polish`)
+
+    const eventCount = (svg.match(/class="timeline-event"/g) ?? []).length
+    expect(eventCount).toBe(3)
+    expect(svg).toContain('data-period="2024"')
+    expect(svg).toContain('Timeline support')
+  })
+
+  it('renders multiline labels with tspans', () => {
+    const svg = render(`timeline
+      title Product<br>history
+      section Platform<br>work
+      2024<br>Q1 : Soft<br>launch`)
+
+    expect(svg).toContain('<tspan')
+    expect(svg).toContain('Product')
+    expect(svg).toContain('history')
+    expect(svg).toContain('Soft')
+    expect(svg).toContain('launch')
+  })
+
+  it('supports dark themes and CSS variable colors without NaN output', () => {
+    const svg = render(`timeline
+      2024 : Timeline support`, {
+      bg: 'var(--background)',
+      fg: 'var(--foreground)',
+      accent: 'var(--accent)',
+    })
+
+    expect(svg).toContain('--bg:var(--background)')
+    expect(svg).toContain('--fg:var(--foreground)')
+    expect(svg).not.toContain('NaN')
+  })
+})

--- a/src/__tests__/timeline-integration.test.ts
+++ b/src/__tests__/timeline-integration.test.ts
@@ -9,6 +9,13 @@ function render(text: string, options: RenderOptions = {}): string {
   return renderMermaidSVG(text, options)
 }
 
+const MERMAID_DOCS_SOCIAL_TIMELINE = `timeline
+  title History of Social Media Platform
+  2002 : LinkedIn
+  2004 : Facebook : Google
+  2005 : YouTube
+  2006 : Twitter`
+
 describe('renderMermaidSVG – timeline diagrams', () => {
   it('renders a basic timeline to valid SVG', () => {
     const svg = render(`timeline
@@ -34,9 +41,28 @@ describe('renderMermaidSVG – timeline diagrams', () => {
 
     expect(svg).toContain('class="timeline-section"')
     expect(svg).toContain('data-label="Foundation"')
+    expect(svg).toContain('data-section="Foundation" data-family="0"')
     expect(svg).toContain('data-section="Growth"')
+    expect(svg).toContain('data-section="Growth" data-family="1"')
     expect(svg).toContain('Prototype')
     expect(svg).toContain('Launch')
+  })
+
+  it('renders Mermaid docs social media example with distinct unsectioned color families', () => {
+    const svg = render(MERMAID_DOCS_SOCIAL_TIMELINE)
+    const periodCount = (svg.match(/class="timeline-period"/g) ?? []).length
+    const eventCount = (svg.match(/class="timeline-event"/g) ?? []).length
+    const familyIds = [...svg.matchAll(/class="timeline-period"[\s\S]*?data-family="(\d+)"/g)].map(match => match[1])
+
+    expect(svg).toContain('History of Social Media Platform')
+    expect(svg).toContain('LinkedIn')
+    expect(svg).toContain('Facebook')
+    expect(svg).toContain('Google')
+    expect(svg).toContain('YouTube')
+    expect(svg).toContain('Twitter')
+    expect(periodCount).toBe(4)
+    expect(eventCount).toBe(5)
+    expect(familyIds).toEqual(['0', '1', '2', '3'])
   })
 
   it('renders multiple events for a single period', () => {

--- a/src/__tests__/timeline-integration.test.ts
+++ b/src/__tests__/timeline-integration.test.ts
@@ -118,4 +118,67 @@ describe('renderMermaidSVG – timeline diagrams', () => {
     expect(svg).toContain('Private alpha')
     expect(svg).toContain('Public launch')
   })
+
+  it('renders accessibility metadata on the root SVG instead of as timeline content', () => {
+    const svg = render(`timeline
+      accTitle: Accessible roadmap
+      accDescr: Product launch plan
+      2024 : Private alpha`)
+
+    expect(svg).toContain('role="img"')
+    expect(svg).toContain('aria-labelledby="bm-a11y-title"')
+    expect(svg).toContain('aria-describedby="bm-a11y-desc"')
+    expect(svg).toContain('<title id="bm-a11y-title">Accessible roadmap</title>')
+    expect(svg).toContain('<desc id="bm-a11y-desc">Product launch plan</desc>')
+    expect(svg).not.toContain('data-label="accTitle"')
+  })
+
+  it('applies theme variable color families from Mermaid init config', () => {
+    const svg = render(`%%{init: {"themeVariables":{"cScale0":"#224466","cScaleLabel0":"#f8f8f8","cScaleInv0":"#99bbdd"}}}%%
+      timeline
+      2024 : Private alpha`)
+
+    expect(svg).toContain('--tl-accent:#224466')
+    expect(svg).toContain('--tl-label:#f8f8f8')
+    expect(svg).toContain('--tl-line:#99bbdd')
+  })
+
+  it('supports explicit timeline color config from mermaidConfig options', () => {
+    const svg = render(`timeline
+      2024 : Private alpha`, {
+      mermaidConfig: {
+        timeline: {
+          sectionFills: ['#113355'],
+          sectionColours: ['#ffffff'],
+        },
+      },
+    })
+
+    expect(svg).toContain('--tl-accent:#113355')
+    expect(svg).toContain('--tl-label:#ffffff')
+  })
+
+  it('respects disableMulticolor for unsectioned timelines', () => {
+    const svg = render(`---
+      config:
+        timeline:
+          disableMulticolor: true
+      ---
+      timeline
+      2022 : Alpha
+      2023 : Beta
+      2024 : GA`)
+
+    const familyIds = [...svg.matchAll(/class="timeline-period"[\s\S]*?data-family="(\d+)"/g)].map(match => match[1])
+    expect(familyIds).toEqual(['0', '0', '0'])
+  })
+
+  it('wraps long labels automatically without explicit <br> tags', () => {
+    const svg = render(`timeline
+      2024 : This is a deliberately long event label that should wrap across multiple lines to match Mermaid timeline behavior more closely`)
+
+    expect(svg).toContain('<tspan')
+    expect(svg).toContain('This is a deliberately long')
+    expect(svg).toContain('match Mermaid timeline')
+  })
 })

--- a/src/__tests__/timeline-layout.test.ts
+++ b/src/__tests__/timeline-layout.test.ts
@@ -1,0 +1,68 @@
+/**
+ * Layout tests for timeline diagrams — verify spacing, bounds, and section framing.
+ */
+import { describe, it, expect } from 'bun:test'
+import { normalizeMermaidSource } from '../mermaid-source.ts'
+import { parseTimelineDiagram } from '../timeline/parser.ts'
+import { layoutTimelineDiagram } from '../timeline/layout.ts'
+
+function layout(source: string) {
+  const lines = normalizeMermaidSource(source).lines
+  return layoutTimelineDiagram(parseTimelineDiagram(lines))
+}
+
+describe('timeline layout', () => {
+  it('extends the rail beyond a single period marker and keeps the event below it', () => {
+    const diagram = layout(`timeline
+      2024 : Launch`)
+    const section = diagram.sections[0]!
+    const period = section.periods[0]!
+    const event = period.events[0]!
+
+    expect(diagram.rail.x1).toBeLessThan(period.centerX)
+    expect(diagram.rail.x2).toBeGreaterThan(period.centerX)
+    expect(period.pillX + period.pillWidth / 2).toBe(period.centerX)
+    expect(period.stemBottomY).toBeLessThan(event.y)
+    expect(event.y + event.height).toBeLessThanOrEqual(section.y + section.height)
+  })
+
+  it('keeps period columns in order without overlapping event cards', () => {
+    const diagram = layout(`timeline
+      2022 : Alpha
+      2023 : Beta release
+      2024 : General availability`)
+    const periods = diagram.sections[0]!.periods
+
+    expect(periods).toHaveLength(3)
+    expect(periods[0]!.centerX).toBeLessThan(periods[1]!.centerX)
+    expect(periods[1]!.centerX).toBeLessThan(periods[2]!.centerX)
+
+    const firstEvent = periods[0]!.events[0]!
+    const secondEvent = periods[1]!.events[0]!
+    const thirdEvent = periods[2]!.events[0]!
+
+    expect(firstEvent.x + firstEvent.width).toBeLessThan(secondEvent.x)
+    expect(secondEvent.x + secondEvent.width).toBeLessThan(thirdEvent.x)
+  })
+
+  it('adds framed section bounds and header space for named sections', () => {
+    const diagram = layout(`timeline
+      title Delivery plan
+      section Foundation
+      2023 : Prototype
+      section Launch
+      2024 : GA`)
+    const firstSection = diagram.sections[0]!
+    const secondSection = diagram.sections[1]!
+
+    expect(firstSection.framed).toBe(true)
+    expect(firstSection.headerHeight).toBeGreaterThan(0)
+    expect(secondSection.headerHeight).toBeGreaterThan(0)
+    expect(firstSection.x + firstSection.width).toBeLessThan(secondSection.x)
+    expect(firstSection.periods[0]!.centerX).toBeGreaterThan(firstSection.x)
+    expect(firstSection.periods[0]!.centerX).toBeLessThan(firstSection.x + firstSection.width)
+    expect(secondSection.periods[0]!.centerX).toBeGreaterThan(secondSection.x)
+    expect(secondSection.periods[0]!.centerX).toBeLessThan(secondSection.x + secondSection.width)
+    expect(diagram.title!.y).toBeLessThan(firstSection.y + firstSection.headerHeight)
+  })
+})

--- a/src/__tests__/timeline-layout.test.ts
+++ b/src/__tests__/timeline-layout.test.ts
@@ -65,4 +65,25 @@ describe('timeline layout', () => {
     expect(secondSection.periods[0]!.centerX).toBeLessThan(secondSection.x + secondSection.width)
     expect(diagram.title!.y).toBeLessThan(firstSection.y + firstSection.headerHeight)
   })
+
+  it('wraps long labels instead of letting a single event force unbounded width', () => {
+    const diagram = layout(`timeline
+      2024 : This is a deliberately long event label that should wrap onto multiple lines in the positioned timeline output`)
+    const period = diagram.sections[0]!.periods[0]!
+    const event = period.events[0]!
+
+    expect(period.label).toBe('2024')
+    expect(event.text).toContain('\n')
+    expect(event.width).toBeLessThan(220)
+  })
+
+  it('carries accessibility metadata through layout for the renderer', () => {
+    const diagram = layout(`timeline
+      accTitle: Accessible roadmap
+      accDescr: Public milestones
+      2024 : Launch`)
+
+    expect(diagram.accessibilityTitle).toBe('Accessible roadmap')
+    expect(diagram.accessibilityDescription).toBe('Public milestones')
+  })
 })

--- a/src/__tests__/timeline-parser.test.ts
+++ b/src/__tests__/timeline-parser.test.ts
@@ -103,9 +103,54 @@ describe('parseTimelineDiagram', () => {
     ])
   })
 
+  it('parses accessibility metadata without turning it into timeline content', () => {
+    const diagram = parse(`timeline
+      accTitle: Accessible roadmap
+      accDescr: Product launch plan
+      2024 : Private alpha`)
+
+    expect(diagram.accessibilityTitle).toBe('Accessible roadmap')
+    expect(diagram.accessibilityDescription).toBe('Product launch plan')
+    expect(diagram.sections[0]!.periods[0]!.label).toBe('2024')
+  })
+
+  it('parses multiline accDescr blocks', () => {
+    const diagram = parse(`timeline
+      accDescr {
+      First line
+      Second line
+      }
+      2024 : Launch`)
+
+    expect(diagram.accessibilityDescription).toBe('First line\nSecond line')
+  })
+
+  it('preserves colons inside event text when they are not event separators', () => {
+    const diagram = parse(`timeline
+      2024 : 10:30 launch : api:v2`)
+
+    expect(diagram.sections[0]!.periods[0]!.events.map(event => event.text)).toEqual([
+      '10:30 launch',
+      'api:v2',
+    ])
+  })
+
+  it('ignores hash-style comment lines supported by Mermaid timeline syntax', () => {
+    const diagram = parse(`timeline
+      # release milestones
+      2024 : Launch`)
+
+    expect(diagram.sections[0]!.periods[0]!.label).toBe('2024')
+  })
+
   it('throws when a continuation appears before any period', () => {
     expect(() => parse(`timeline
       : orphaned event`)).toThrow('Timeline continuation found before any period was declared')
+  })
+
+  it('throws on unsupported timeline syntax instead of silently ignoring it', () => {
+    expect(() => parse(`timeline
+      release now`)).toThrow('Unsupported timeline syntax: "release now"')
   })
 
   it('throws when the diagram has no periods', () => {

--- a/src/__tests__/timeline-parser.test.ts
+++ b/src/__tests__/timeline-parser.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Tests for the timeline diagram parser.
+ *
+ * Covers: title, sections, implicit sections, multi-event periods,
+ * continuation lines, and error cases.
+ */
+import { describe, it, expect } from 'bun:test'
+import { parseTimelineDiagram } from '../timeline/parser.ts'
+
+function parse(text: string) {
+  const lines = text.split('\n').map(l => l.trim()).filter(l => l.length > 0 && !l.startsWith('%%'))
+  return parseTimelineDiagram(lines)
+}
+
+describe('parseTimelineDiagram', () => {
+  it('parses a basic timeline with a title', () => {
+    const diagram = parse(`timeline
+      title Product history
+      2022 : Private alpha
+      2023 : Public launch`)
+
+    expect(diagram.title).toBe('Product history')
+    expect(diagram.sections).toHaveLength(1)
+    expect(diagram.sections[0]!.periods).toHaveLength(2)
+    expect(diagram.sections[0]!.periods[0]!.label).toBe('2022')
+    expect(diagram.sections[0]!.periods[0]!.events[0]!.text).toBe('Private alpha')
+  })
+
+  it('parses named sections in order', () => {
+    const diagram = parse(`timeline
+      section Foundation
+      2020 : Prototype
+      2021 : Beta
+      section Growth
+      2022 : Launch`)
+
+    expect(diagram.sections).toHaveLength(2)
+    expect(diagram.sections[0]!.label).toBe('Foundation')
+    expect(diagram.sections[1]!.label).toBe('Growth')
+    expect(diagram.sections[1]!.periods[0]!.label).toBe('2022')
+  })
+
+  it('creates an implicit section for periods before the first section', () => {
+    const diagram = parse(`timeline
+      2021 : Quiet alpha
+      section Public
+      2022 : Launch`)
+
+    expect(diagram.sections).toHaveLength(2)
+    expect(diagram.sections[0]!.label).toBeUndefined()
+    expect(diagram.sections[0]!.periods[0]!.label).toBe('2021')
+    expect(diagram.sections[1]!.label).toBe('Public')
+  })
+
+  it('parses multiple events on a single period line', () => {
+    const diagram = parse(`timeline
+      2024 : Design refresh : Timeline support`)
+
+    expect(diagram.sections[0]!.periods[0]!.events.map(event => event.text)).toEqual([
+      'Design refresh',
+      'Timeline support',
+    ])
+  })
+
+  it('parses continuation lines onto the previous period', () => {
+    const diagram = parse(`timeline
+      2024 : Design refresh
+           : Timeline support
+           : Craft polish`)
+
+    expect(diagram.sections[0]!.periods[0]!.events.map(event => event.text)).toEqual([
+      'Design refresh',
+      'Timeline support',
+      'Craft polish',
+    ])
+  })
+
+  it('normalizes <br> tags in title, section labels, periods, and events', () => {
+    const diagram = parse(`timeline
+      title Platform<br>History
+      section Product<br>Work
+      2024<br>Q1 : Soft<br>launch`)
+
+    expect(diagram.title).toBe('Platform\nHistory')
+    expect(diagram.sections[0]!.label).toBe('Product\nWork')
+    expect(diagram.sections[0]!.periods[0]!.label).toBe('2024\nQ1')
+    expect(diagram.sections[0]!.periods[0]!.events[0]!.text).toBe('Soft\nlaunch')
+  })
+
+  it('throws when a continuation appears before any period', () => {
+    expect(() => parse(`timeline
+      : orphaned event`)).toThrow('Timeline continuation found before any period was declared')
+  })
+
+  it('throws when the diagram has no periods', () => {
+    expect(() => parse(`timeline
+      title Empty`)).toThrow('Timeline diagram must include at least one period with events')
+  })
+})

--- a/src/__tests__/timeline-parser.test.ts
+++ b/src/__tests__/timeline-parser.test.ts
@@ -5,11 +5,11 @@
  * continuation lines, and error cases.
  */
 import { describe, it, expect } from 'bun:test'
+import { normalizeMermaidSource } from '../mermaid-source.ts'
 import { parseTimelineDiagram } from '../timeline/parser.ts'
 
 function parse(text: string) {
-  const lines = text.split('\n').map(l => l.trim()).filter(l => l.length > 0 && !l.startsWith('%%'))
-  return parseTimelineDiagram(lines)
+  return parseTimelineDiagram(normalizeMermaidSource(text).lines)
 }
 
 describe('parseTimelineDiagram', () => {
@@ -85,6 +85,22 @@ describe('parseTimelineDiagram', () => {
     expect(diagram.sections[0]!.label).toBe('Product\nWork')
     expect(diagram.sections[0]!.periods[0]!.label).toBe('2024\nQ1')
     expect(diagram.sections[0]!.periods[0]!.events[0]!.text).toBe('Soft\nlaunch')
+  })
+
+  it('parses timelines after frontmatter and comment lines are stripped', () => {
+    const diagram = parse(`---
+      title: Mermaid demo
+      ---
+      %% comment line
+      timeline
+      2002 : LinkedIn
+      2004 : Facebook : Google`)
+
+    expect(diagram.sections[0]!.periods).toHaveLength(2)
+    expect(diagram.sections[0]!.periods[1]!.events.map(event => event.text)).toEqual([
+      'Facebook',
+      'Google',
+    ])
   })
 
   it('throws when a continuation appears before any period', () => {

--- a/src/ascii/index.ts
+++ b/src/ascii/index.ts
@@ -31,6 +31,7 @@ import { renderXYChartAscii } from './xychart.ts'
 import { detectColorMode, DEFAULT_ASCII_THEME, diagramColorsToAsciiTheme } from './ansi.ts'
 import type { AsciiConfig, AsciiTheme, ColorMode } from './types.ts'
 import { normalizeMermaidSource } from '../mermaid-source.ts'
+import type { MermaidRuntimeConfig } from '../mermaid-source.ts'
 
 // Re-export types for external use
 export type { AsciiTheme, ColorMode }
@@ -58,6 +59,8 @@ export interface AsciiRenderOptions {
   colorMode?: ColorMode | 'auto'
   /** Theme colors for ASCII output. Uses default theme if not provided. */
   theme?: Partial<AsciiTheme>
+  /** Optional Mermaid-style runtime config (analogous to initialize/frontmatter config). */
+  mermaidConfig?: MermaidRuntimeConfig
 }
 
 /**
@@ -120,25 +123,25 @@ export function renderMermaidASCII(
 
   // Merge user theme with defaults
   const theme: AsciiTheme = { ...DEFAULT_ASCII_THEME, ...options.theme }
-  const normalizedSource = normalizeMermaidSource(text)
+  const normalizedSource = normalizeMermaidSource(text, options.mermaidConfig ?? {})
 
   const diagramType = detectDiagramType(normalizedSource.firstLine)
 
   switch (diagramType) {
     case 'xychart':
-      return renderXYChartAscii(text, config, colorMode, theme)
+      return renderXYChartAscii(normalizedSource.text, config, colorMode, theme)
 
     case 'sequence':
-      return renderSequenceAscii(text, config, colorMode, theme)
+      return renderSequenceAscii(normalizedSource.text, config, colorMode, theme)
 
     case 'class':
-      return renderClassAscii(text, config, colorMode, theme)
+      return renderClassAscii(normalizedSource.text, config, colorMode, theme)
 
     case 'er':
-      return renderErAscii(text, config, colorMode, theme)
+      return renderErAscii(normalizedSource.text, config, colorMode, theme)
 
     case 'timeline':
-      return renderTimelineAscii(text, config, colorMode, theme)
+      return renderTimelineAscii(normalizedSource.lines, config, colorMode, theme)
 
     case 'flowchart':
     default: {

--- a/src/ascii/index.ts
+++ b/src/ascii/index.ts
@@ -10,6 +10,8 @@
 //   - Sequence diagrams (sequenceDiagram) — column-based timeline layout
 //   - Class diagrams (classDiagram) — level-based UML layout
 //   - ER diagrams (erDiagram) — grid layout with crow's foot notation
+//   - Timeline diagrams (timeline) — chronological outline with grouped milestones
+//   - XY charts (xychart / xychart-beta)
 //
 // Usage:
 //   import { renderMermaidASCII } from 'beautiful-mermaid'
@@ -24,6 +26,7 @@ import { canvasToString, flipCanvasVertically, flipRoleCanvasVertically } from '
 import { renderSequenceAscii } from './sequence.ts'
 import { renderClassAscii } from './class-diagram.ts'
 import { renderErAscii } from './er-diagram.ts'
+import { renderTimelineAscii } from './timeline.ts'
 import { renderXYChartAscii } from './xychart.ts'
 import { detectColorMode, DEFAULT_ASCII_THEME, diagramColorsToAsciiTheme } from './ansi.ts'
 import type { AsciiConfig, AsciiTheme, ColorMode } from './types.ts'
@@ -60,10 +63,11 @@ export interface AsciiRenderOptions {
  * Detect the diagram type from the mermaid source text.
  * Mirrors the detection logic in src/index.ts for the SVG renderer.
  */
-function detectDiagramType(text: string): 'flowchart' | 'sequence' | 'class' | 'er' | 'xychart' {
+function detectDiagramType(text: string): 'flowchart' | 'sequence' | 'class' | 'er' | 'timeline' | 'xychart' {
   const firstLine = text.trim().split('\n')[0]?.trim().toLowerCase() ?? ''
 
   if (/^xychart(-beta)?\b/.test(firstLine)) return 'xychart'
+  if (/^timeline\s*$/.test(firstLine)) return 'timeline'
   if (/^sequencediagram\s*$/.test(firstLine)) return 'sequence'
   if (/^classdiagram\s*$/.test(firstLine)) return 'class'
   if (/^erdiagram\s*$/.test(firstLine)) return 'er'
@@ -132,6 +136,9 @@ export function renderMermaidASCII(
 
     case 'er':
       return renderErAscii(text, config, colorMode, theme)
+
+    case 'timeline':
+      return renderTimelineAscii(text, config, colorMode, theme)
 
     case 'flowchart':
     default: {

--- a/src/ascii/index.ts
+++ b/src/ascii/index.ts
@@ -30,6 +30,7 @@ import { renderTimelineAscii } from './timeline.ts'
 import { renderXYChartAscii } from './xychart.ts'
 import { detectColorMode, DEFAULT_ASCII_THEME, diagramColorsToAsciiTheme } from './ansi.ts'
 import type { AsciiConfig, AsciiTheme, ColorMode } from './types.ts'
+import { normalizeMermaidSource } from '../mermaid-source.ts'
 
 // Re-export types for external use
 export type { AsciiTheme, ColorMode }
@@ -63,9 +64,7 @@ export interface AsciiRenderOptions {
  * Detect the diagram type from the mermaid source text.
  * Mirrors the detection logic in src/index.ts for the SVG renderer.
  */
-function detectDiagramType(text: string): 'flowchart' | 'sequence' | 'class' | 'er' | 'timeline' | 'xychart' {
-  const firstLine = text.trim().split('\n')[0]?.trim().toLowerCase() ?? ''
-
+function detectDiagramType(firstLine: string): 'flowchart' | 'sequence' | 'class' | 'er' | 'timeline' | 'xychart' {
   if (/^xychart(-beta)?\b/.test(firstLine)) return 'xychart'
   if (/^timeline\s*$/.test(firstLine)) return 'timeline'
   if (/^sequencediagram\s*$/.test(firstLine)) return 'sequence'
@@ -121,8 +120,9 @@ export function renderMermaidASCII(
 
   // Merge user theme with defaults
   const theme: AsciiTheme = { ...DEFAULT_ASCII_THEME, ...options.theme }
+  const normalizedSource = normalizeMermaidSource(text)
 
-  const diagramType = detectDiagramType(text)
+  const diagramType = detectDiagramType(normalizedSource.firstLine)
 
   switch (diagramType) {
     case 'xychart':
@@ -143,7 +143,7 @@ export function renderMermaidASCII(
     case 'flowchart':
     default: {
       // Flowchart + state diagram pipeline (original)
-      const parsed = parseMermaid(text)
+      const parsed = parseMermaid(normalizedSource.text)
 
       // Normalize direction for grid layout.
       // BT is laid out as TD then flipped vertically after drawing.

--- a/src/ascii/timeline.ts
+++ b/src/ascii/timeline.ts
@@ -37,12 +37,11 @@ function renderStyledLine(
  * Render a Mermaid timeline diagram to ASCII/Unicode text.
  */
 export function renderTimelineAscii(
-  text: string,
+  lines: string[],
   config: AsciiConfig,
   colorMode: ColorMode = 'none',
   theme: AsciiTheme = DEFAULT_ASCII_THEME,
 ): string {
-  const lines = text.split('\n').map(l => l.trim()).filter(l => l.length > 0 && !l.startsWith('%%'))
   const diagram = parseTimelineDiagram(lines)
   const useAscii = config.useAscii
 

--- a/src/ascii/timeline.ts
+++ b/src/ascii/timeline.ts
@@ -1,0 +1,129 @@
+// ============================================================================
+// ASCII renderer — timeline diagrams
+//
+// Renders Mermaid timeline syntax as a chronological outline with per-period
+// markers and indented milestone lists. This keeps the ASCII variant compact
+// and readable in terminals while preserving chronology and section grouping.
+// ============================================================================
+
+import { parseTimelineDiagram } from '../timeline/parser.ts'
+import { colorizeLine, DEFAULT_ASCII_THEME } from './ansi.ts'
+import type { AsciiConfig, AsciiTheme, CharRole, ColorMode } from './types.ts'
+
+interface StyledSegment {
+  text: string
+  role: CharRole | null
+}
+
+function renderStyledLine(
+  segments: StyledSegment[],
+  colorMode: ColorMode,
+  theme: AsciiTheme,
+): string {
+  const chars: string[] = []
+  const roles: (CharRole | null)[] = []
+
+  for (const segment of segments) {
+    for (const char of segment.text) {
+      chars.push(char)
+      roles.push(segment.role)
+    }
+  }
+
+  return colorizeLine(chars, roles, theme, colorMode)
+}
+
+/**
+ * Render a Mermaid timeline diagram to ASCII/Unicode text.
+ */
+export function renderTimelineAscii(
+  text: string,
+  config: AsciiConfig,
+  colorMode: ColorMode = 'none',
+  theme: AsciiTheme = DEFAULT_ASCII_THEME,
+): string {
+  const lines = text.split('\n').map(l => l.trim()).filter(l => l.length > 0 && !l.startsWith('%%'))
+  const diagram = parseTimelineDiagram(lines)
+  const useAscii = config.useAscii
+
+  const marker = useAscii ? 'o' : '○'
+  const vertical = useAscii ? '|' : '│'
+  const branch = useAscii ? '|' : '├'
+  const lastBranch = useAscii ? '`' : '└'
+  const horizontal = useAscii ? '-' : '─'
+  const periodContinuation = '  '
+
+  const out: string[] = []
+  const pushLine = (segments: StyledSegment[] = []): void => {
+    out.push(segments.length === 0 ? '' : renderStyledLine(segments, colorMode, theme))
+  }
+
+  if (diagram.title) {
+    for (const line of diagram.title.split('\n')) {
+      pushLine([{ text: line, role: 'text' }])
+    }
+    pushLine()
+  }
+
+  for (let sectionIndex = 0; sectionIndex < diagram.sections.length; sectionIndex++) {
+    const section = diagram.sections[sectionIndex]!
+
+    if (section.label) {
+      pushLine([
+        { text: '[', role: 'border' },
+        { text: section.label.replace(/\n/g, ' / '), role: 'text' },
+        { text: ']', role: 'border' },
+      ])
+    }
+
+    for (let periodIndex = 0; periodIndex < section.periods.length; periodIndex++) {
+      const period = section.periods[periodIndex]!
+      const periodLines = period.label.split('\n')
+
+      pushLine([
+        { text: marker, role: 'junction' },
+        { text: ' ', role: null },
+        { text: periodLines[0] ?? '', role: 'text' },
+      ])
+      for (const line of periodLines.slice(1)) {
+        pushLine([
+          { text: `${periodContinuation} `, role: null },
+          { text: line, role: 'text' },
+        ])
+      }
+
+      for (let eventIndex = 0; eventIndex < period.events.length; eventIndex++) {
+        const event = period.events[eventIndex]!
+        const eventLines = event.text.split('\n')
+        const junction = eventIndex === period.events.length - 1 ? lastBranch : branch
+        pushLine([
+          { text: vertical, role: 'line' },
+          { text: '  ', role: null },
+          { text: junction, role: eventIndex === period.events.length - 1 ? 'corner' : 'junction' },
+          { text: horizontal, role: 'line' },
+          { text: ' ', role: null },
+          { text: eventLines[0] ?? '', role: 'text' },
+        ])
+
+        for (const line of eventLines.slice(1)) {
+          pushLine(eventIndex === period.events.length - 1
+            ? [
+                { text: '    ', role: null },
+                { text: line, role: 'text' },
+              ]
+            : [
+                { text: vertical, role: 'line' },
+                { text: '   ', role: null },
+                { text: line, role: 'text' },
+              ])
+        }
+      }
+
+      const morePeriods = periodIndex < section.periods.length - 1
+      const moreSections = sectionIndex < diagram.sections.length - 1
+      if (morePeriods || moreSections) pushLine()
+    }
+  }
+
+  return out.join('\n').trimEnd()
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,6 +35,7 @@ import { renderSvg } from './renderer.ts'
 import type { RenderOptions } from './types.ts'
 import type { DiagramColors } from './theme.ts'
 import { DEFAULTS } from './theme.ts'
+import { normalizeMermaidSource } from './mermaid-source.ts'
 
 import { parseSequenceDiagram } from './sequence/parser.ts'
 import { layoutSequenceDiagram } from './sequence/layout.ts'
@@ -56,9 +57,7 @@ import { renderXYChartSvg } from './xychart/renderer.ts'
  * Detect the diagram type from the mermaid source text.
  * Returns the type keyword used for routing to the correct pipeline.
  */
-function detectDiagramType(text: string): 'flowchart' | 'sequence' | 'class' | 'er' | 'timeline' | 'xychart' {
-  const firstLine = text.trim().split(/[\n;]/)[0]?.trim().toLowerCase() ?? ''
-
+function detectDiagramType(firstLine: string): 'flowchart' | 'sequence' | 'class' | 'er' | 'timeline' | 'xychart' {
   if (/^xychart(-beta)?\b/.test(firstLine)) return 'xychart'
   if (/^timeline\s*$/.test(firstLine)) return 'timeline'
   if (/^sequencediagram\s*$/.test(firstLine)) return 'sequence'
@@ -121,13 +120,13 @@ export function renderMermaidSVG(
   // Decode XML entities that may leak from markdown parsers (e.g. rehype-raw).
   // Without this, escapeXml() double-encodes them: &lt; → &amp;lt; → literal "&lt;" in SVG.
   text = decodeXML(text)
+  const normalizedSource = normalizeMermaidSource(text)
 
   const colors = buildColors(options)
   const font = options.font ?? 'Inter'
   const transparent = options.transparent ?? false
-  const diagramType = detectDiagramType(text)
-
-  const lines = text.split('\n').map(l => l.trim()).filter(l => l.length > 0 && !l.startsWith('%%'))
+  const diagramType = detectDiagramType(normalizedSource.firstLine)
+  const lines = normalizedSource.lines
 
   switch (diagramType) {
     case 'sequence': {
@@ -157,7 +156,7 @@ export function renderMermaidSVG(
     }
     case 'flowchart':
     default: {
-      const graph = parseMermaid(text)
+      const graph = parseMermaid(normalizedSource.text)
       const positioned = layoutGraphSync(graph, options)
       return renderSvg(positioned, colors, font, transparent)
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,6 +27,7 @@ export { fromShikiTheme, THEMES, DEFAULTS } from './theme.ts'
 export { parseMermaid } from './parser.ts'
 export { renderMermaidASCII, renderMermaidAscii } from './ascii/index.ts'
 export type { AsciiRenderOptions } from './ascii/index.ts'
+export type { MermaidRuntimeConfig, MermaidThemeVariables, TimelineRuntimeConfig } from './mermaid-source.ts'
 
 import { decodeXML } from 'entities'
 import { parseMermaid } from './parser.ts'
@@ -34,8 +35,9 @@ import { layoutGraphSync } from './layout.ts'
 import { renderSvg } from './renderer.ts'
 import type { RenderOptions } from './types.ts'
 import type { DiagramColors } from './theme.ts'
-import { DEFAULTS } from './theme.ts'
+import { DEFAULTS, THEMES } from './theme.ts'
 import { normalizeMermaidSource } from './mermaid-source.ts'
+import type { MermaidRuntimeConfig, MermaidThemeVariables } from './mermaid-source.ts'
 
 import { parseSequenceDiagram } from './sequence/parser.ts'
 import { layoutSequenceDiagram } from './sequence/layout.ts'
@@ -73,16 +75,32 @@ function detectDiagramType(firstLine: string): 'flowchart' | 'sequence' | 'class
  * Uses DEFAULTS for bg/fg when not provided, and passes through
  * optional enrichment colors (line, accent, muted, surface, border).
  */
-function buildColors(options: RenderOptions): DiagramColors {
+function buildColors(options: RenderOptions, config: MermaidRuntimeConfig): DiagramColors {
+  const theme = config.theme && config.theme in THEMES
+    ? THEMES[config.theme as keyof typeof THEMES]
+    : undefined
+  const vars = config.themeVariables
+
   return {
-    bg: options.bg ?? DEFAULTS.bg,
-    fg: options.fg ?? DEFAULTS.fg,
-    line: options.line,
-    accent: options.accent,
-    muted: options.muted,
-    surface: options.surface,
-    border: options.border,
+    bg: options.bg ?? readThemeValue(vars, 'background', 'mainBkg') ?? theme?.bg ?? DEFAULTS.bg,
+    fg: options.fg ?? readThemeValue(vars, 'primaryTextColor', 'textColor', 'nodeTextColor') ?? theme?.fg ?? DEFAULTS.fg,
+    line: options.line ?? readThemeValue(vars, 'lineColor', 'defaultLinkColor') ?? theme?.line,
+    accent: options.accent ?? readThemeValue(vars, 'arrowheadColor', 'primaryColor') ?? theme?.accent,
+    muted: options.muted ?? readThemeValue(vars, 'secondaryTextColor', 'tertiaryTextColor') ?? theme?.muted,
+    surface: options.surface ?? readThemeValue(vars, 'primaryColor', 'nodeBkg', 'mainBkg') ?? theme?.surface,
+    border: options.border ?? readThemeValue(vars, 'primaryBorderColor', 'secondaryBorderColor') ?? theme?.border,
   }
+}
+
+function readThemeValue(vars: MermaidThemeVariables | undefined, ...keys: string[]): string | undefined {
+  if (!vars) return undefined
+
+  for (const key of keys) {
+    const value = vars[key]
+    if (typeof value === 'string' && value.length > 0) return value
+  }
+
+  return undefined
 }
 
 /**
@@ -120,10 +138,13 @@ export function renderMermaidSVG(
   // Decode XML entities that may leak from markdown parsers (e.g. rehype-raw).
   // Without this, escapeXml() double-encodes them: &lt; → &amp;lt; → literal "&lt;" in SVG.
   text = decodeXML(text)
-  const normalizedSource = normalizeMermaidSource(text)
+  const normalizedSource = normalizeMermaidSource(text, options.mermaidConfig ?? {})
 
-  const colors = buildColors(options)
-  const font = options.font ?? 'Inter'
+  const colors = buildColors(options, normalizedSource.config)
+  const font = options.font
+    ?? normalizedSource.config.fontFamily
+    ?? readThemeValue(normalizedSource.config.themeVariables, 'fontFamily')
+    ?? 'Inter'
   const transparent = options.transparent ?? false
   const diagramType = detectDiagramType(normalizedSource.firstLine)
   const lines = normalizedSource.lines
@@ -147,7 +168,14 @@ export function renderMermaidSVG(
     case 'timeline': {
       const diagram = parseTimelineDiagram(lines)
       const positioned = layoutTimelineDiagram(diagram, options)
-      return renderTimelineSvg(positioned, colors, font, transparent)
+      return renderTimelineSvg(
+        positioned,
+        colors,
+        font,
+        transparent,
+        normalizedSource.config.timeline,
+        normalizedSource.config.themeVariables,
+      )
     }
     case 'xychart': {
       const chart = parseXYChart(lines)

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,8 @@
 //   - Sequence diagrams (sequenceDiagram)
 //   - Class diagrams (classDiagram)
 //   - ER diagrams (erDiagram)
+//   - Timeline diagrams (timeline)
+//   - XY charts (xychart / xychart-beta)
 //
 // Theming uses CSS custom properties (--bg, --fg, + optional enrichment).
 // See src/theme.ts for the full variable system.
@@ -43,6 +45,9 @@ import { renderClassSvg } from './class/renderer.ts'
 import { parseErDiagram } from './er/parser.ts'
 import { layoutErDiagramSync } from './er/layout.ts'
 import { renderErSvg } from './er/renderer.ts'
+import { parseTimelineDiagram } from './timeline/parser.ts'
+import { layoutTimelineDiagram } from './timeline/layout.ts'
+import { renderTimelineSvg } from './timeline/renderer.ts'
 import { parseXYChart } from './xychart/parser.ts'
 import { layoutXYChart } from './xychart/layout.ts'
 import { renderXYChartSvg } from './xychart/renderer.ts'
@@ -51,10 +56,11 @@ import { renderXYChartSvg } from './xychart/renderer.ts'
  * Detect the diagram type from the mermaid source text.
  * Returns the type keyword used for routing to the correct pipeline.
  */
-function detectDiagramType(text: string): 'flowchart' | 'sequence' | 'class' | 'er' | 'xychart' {
+function detectDiagramType(text: string): 'flowchart' | 'sequence' | 'class' | 'er' | 'timeline' | 'xychart' {
   const firstLine = text.trim().split(/[\n;]/)[0]?.trim().toLowerCase() ?? ''
 
   if (/^xychart(-beta)?\b/.test(firstLine)) return 'xychart'
+  if (/^timeline\s*$/.test(firstLine)) return 'timeline'
   if (/^sequencediagram\s*$/.test(firstLine)) return 'sequence'
   if (/^classdiagram\s*$/.test(firstLine)) return 'class'
   if (/^erdiagram\s*$/.test(firstLine)) return 'er'
@@ -138,6 +144,11 @@ export function renderMermaidSVG(
       const diagram = parseErDiagram(lines)
       const positioned = layoutErDiagramSync(diagram, options)
       return renderErSvg(positioned, colors, font, transparent)
+    }
+    case 'timeline': {
+      const diagram = parseTimelineDiagram(lines)
+      const positioned = layoutTimelineDiagram(diagram, options)
+      return renderTimelineSvg(positioned, colors, font, transparent)
     }
     case 'xychart': {
       const chart = parseXYChart(lines)

--- a/src/mermaid-source.ts
+++ b/src/mermaid-source.ts
@@ -1,42 +1,598 @@
 // ============================================================================
-// Mermaid source normalization
+// Mermaid source normalization + config extraction
 //
-// Strips leading frontmatter, blank lines, and Mermaid comment/directive lines
-// so the public routers can detect the real diagram header consistently.
+// Handles:
+//   - UTF-8 BOM stripping
+//   - leading YAML frontmatter
+//   - Mermaid directives / init blocks (%%{init: ...}%%)
+//   - Mermaid comment stripping (%% ...)
+//   - normalized, trimmed diagram lines for downstream parsers
 // ============================================================================
+
+export type MermaidConfigScalar = string | number | boolean
+
+export interface MermaidThemeVariables {
+  fontFamily?: string
+  [key: string]: MermaidConfigScalar | undefined
+}
+
+export interface TimelineRuntimeConfig {
+  disableMulticolor?: boolean
+  sectionFills?: string[]
+  sectionColours?: string[]
+}
+
+export interface MermaidRuntimeConfig {
+  theme?: string
+  fontFamily?: string
+  themeVariables?: MermaidThemeVariables
+  timeline?: TimelineRuntimeConfig
+}
 
 export interface NormalizedMermaidSource {
   text: string
   lines: string[]
   firstLine: string
+  config: MermaidRuntimeConfig
 }
 
-export function normalizeMermaidSource(text: string): NormalizedMermaidSource {
+export function normalizeMermaidSource(
+  text: string,
+  baseConfig: MermaidRuntimeConfig = {},
+): NormalizedMermaidSource {
   const rawLines = text.replace(/^\uFEFF/, '').split('\n')
-  let start = 0
+  let index = 0
+  let config = mergeMermaidConfigs(baseConfig)
 
-  while (start < rawLines.length && rawLines[start]!.trim().length === 0) {
-    start++
+  while (index < rawLines.length && rawLines[index]!.trim().length === 0) {
+    index++
   }
 
-  if (rawLines[start]?.trim() === '---') {
-    start++
-    while (start < rawLines.length && rawLines[start]!.trim() !== '---') {
-      start++
-    }
-    if (start < rawLines.length && rawLines[start]!.trim() === '---') {
-      start++
+  if (rawLines[index]?.trim() === '---') {
+    const frontmatter = collectFrontmatter(rawLines, index)
+    if (frontmatter) {
+      config = mergeMermaidConfigs(config, frontmatter.config)
+      index = frontmatter.nextIndex
     }
   }
 
-  const lines = rawLines
-    .slice(start)
-    .map(line => line.trim())
-    .filter(line => line.length > 0 && !line.startsWith('%%'))
+  const lines: string[] = []
+
+  while (index < rawLines.length) {
+    const rawLine = rawLines[index]!
+    const trimmed = rawLine.trim()
+
+    if (trimmed.startsWith('%%{')) {
+      const directive = collectDirective(rawLines, index)
+      config = mergeMermaidConfigs(config, directive.config)
+      index = directive.nextIndex
+      continue
+    }
+
+    if (trimmed.length > 0 && !trimmed.startsWith('%%')) {
+      lines.push(trimmed)
+    }
+
+    index++
+  }
 
   return {
     text: lines.join('\n'),
     lines,
     firstLine: lines[0]?.toLowerCase() ?? '',
+    config,
   }
+}
+
+export function mergeMermaidConfigs(...configs: MermaidRuntimeConfig[]): MermaidRuntimeConfig {
+  const merged: Record<string, unknown> = {}
+
+  for (const config of configs) {
+    mergeInto(merged, config as Record<string, unknown>)
+  }
+
+  return merged as MermaidRuntimeConfig
+}
+
+function mergeInto(target: Record<string, unknown>, source: Record<string, unknown> | undefined): void {
+  if (!source) return
+
+  for (const [key, value] of Object.entries(source)) {
+    if (value === undefined) continue
+
+    if (Array.isArray(value)) {
+      target[key] = value.slice()
+      continue
+    }
+
+    if (isPlainObject(value)) {
+      const existing = isPlainObject(target[key]) ? target[key] as Record<string, unknown> : {}
+      target[key] = existing
+      mergeInto(existing, value)
+      continue
+    }
+
+    target[key] = value
+  }
+}
+
+function collectFrontmatter(rawLines: string[], startIndex: number): { config: MermaidRuntimeConfig; nextIndex: number } | undefined {
+  const content: string[] = []
+  let index = startIndex + 1
+
+  while (index < rawLines.length && rawLines[index]!.trim() !== '---') {
+    content.push(rawLines[index]!)
+    index++
+  }
+
+  if (index >= rawLines.length) return undefined
+
+  const parsed = parseYamlDocument(content)
+  const frontmatter = isPlainObject(parsed) && isPlainObject(parsed.config)
+    ? parsed.config
+    : parsed
+
+  return {
+    config: normalizeMermaidRuntimeConfig(frontmatter),
+    nextIndex: index + 1,
+  }
+}
+
+function collectDirective(rawLines: string[], startIndex: number): { config: MermaidRuntimeConfig; nextIndex: number } {
+  const buffer: string[] = []
+  let index = startIndex
+
+  while (index < rawLines.length) {
+    buffer.push(rawLines[index]!)
+    if (rawLines[index]!.includes('}%%')) break
+    index++
+  }
+
+  const rawDirective = buffer.join('\n').trim()
+  const directiveBody = rawDirective.replace(/^%%\{/, '').replace(/\}%%$/, '').trim()
+  const wrappedBody = directiveBody.startsWith('{') ? directiveBody : `{${directiveBody}}`
+  const parsed = parseObjectLiteral(wrappedBody)
+  const directiveConfig = isPlainObject(parsed) && (isPlainObject(parsed.init) || isPlainObject(parsed.initialize))
+    ? (parsed.init ?? parsed.initialize)
+    : parsed
+
+  return {
+    config: normalizeMermaidRuntimeConfig(directiveConfig),
+    nextIndex: index + 1,
+  }
+}
+
+function normalizeMermaidRuntimeConfig(raw: unknown): MermaidRuntimeConfig {
+  if (!isPlainObject(raw)) return {}
+
+  const config: MermaidRuntimeConfig = {}
+
+  if (typeof raw.theme === 'string') config.theme = raw.theme
+  if (typeof raw.fontFamily === 'string') config.fontFamily = raw.fontFamily
+
+  if (isPlainObject(raw.themeVariables)) {
+    const themeVariables: MermaidThemeVariables = {}
+    for (const [key, value] of Object.entries(raw.themeVariables)) {
+      if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
+        themeVariables[key] = value
+      }
+    }
+    if (Object.keys(themeVariables).length > 0) config.themeVariables = themeVariables
+  }
+
+  if (isPlainObject(raw.timeline)) {
+    const timeline = normalizeTimelineRuntimeConfig(raw.timeline)
+    if (Object.keys(timeline).length > 0) config.timeline = timeline
+  }
+
+  return config
+}
+
+function normalizeTimelineRuntimeConfig(raw: Record<string, unknown>): TimelineRuntimeConfig {
+  const config: TimelineRuntimeConfig = {}
+
+  if (typeof raw.disableMulticolor === 'boolean') config.disableMulticolor = raw.disableMulticolor
+
+  const sectionFills = normalizeStringArray(raw.sectionFills)
+  if (sectionFills.length > 0) config.sectionFills = sectionFills
+
+  const sectionColours = normalizeStringArray(raw.sectionColours)
+  const sectionColors = normalizeStringArray(raw.sectionColors)
+  const sectionPalette = sectionColours.length > 0 ? sectionColours : sectionColors
+  if (sectionPalette.length > 0) config.sectionColours = sectionPalette
+
+  return config
+}
+
+function normalizeStringArray(value: unknown): string[] {
+  return Array.isArray(value) ? value.filter((entry): entry is string => typeof entry === 'string') : []
+}
+
+function parseYamlDocument(lines: string[]): unknown {
+  const prepared = dedentYamlLines(lines.map(line => line.replace(/\t/g, '    ')))
+  const { value } = parseYamlBlock(prepared, 0, 0)
+  return value
+}
+
+function dedentYamlLines(lines: string[]): string[] {
+  const indents = lines
+    .filter(line => stripYamlComment(line).trim().length > 0)
+    .map(countIndent)
+
+  const minIndent = indents.length > 0 ? Math.min(...indents) : 0
+  if (minIndent === 0) return lines
+
+  return lines.map(line => line.slice(Math.min(minIndent, line.length)))
+}
+
+function parseYamlBlock(lines: string[], startIndex: number, indent: number): { value: unknown; nextIndex: number } {
+  let index = startIndex
+
+  while (index < lines.length) {
+    const trimmed = stripYamlComment(lines[index]!).trim()
+    if (trimmed.length === 0) {
+      index++
+      continue
+    }
+    break
+  }
+
+  if (index >= lines.length) return { value: {}, nextIndex: index }
+
+  const firstIndent = countIndent(lines[index]!)
+  if (firstIndent < indent) return { value: {}, nextIndex: index }
+
+  const firstTrimmed = stripYamlComment(lines[index]!).trim()
+  if (firstTrimmed.startsWith('-')) {
+    const items: unknown[] = []
+
+    while (index < lines.length) {
+      const line = stripYamlComment(lines[index]!)
+      const trimmed = line.trim()
+      if (trimmed.length === 0) {
+        index++
+        continue
+      }
+
+      const currentIndent = countIndent(line)
+      if (currentIndent < indent) break
+      if (!trimmed.startsWith('-')) break
+
+      const rest = trimmed.slice(1).trim()
+      index++
+
+      if (rest.length === 0) {
+        const nested = parseYamlBlock(lines, index, currentIndent + 2)
+        items.push(nested.value)
+        index = nested.nextIndex
+      } else if (looksLikeYamlKeyValue(rest)) {
+        const synthetic = `${' '.repeat(currentIndent + 2)}${rest}`
+        const nestedLines = [synthetic]
+        let nestedIndex = index
+
+        while (nestedIndex < lines.length) {
+          const candidate = lines[nestedIndex]!
+          const candidateTrimmed = stripYamlComment(candidate).trim()
+          if (candidateTrimmed.length === 0) {
+            nestedLines.push(candidate)
+            nestedIndex++
+            continue
+          }
+          if (countIndent(candidate) <= currentIndent) break
+          nestedLines.push(candidate)
+          nestedIndex++
+        }
+
+        const nested = parseYamlBlock(nestedLines, 0, currentIndent + 2)
+        items.push(nested.value)
+        index = nestedIndex
+      } else {
+        items.push(parseYamlScalar(rest))
+      }
+    }
+
+    return { value: items, nextIndex: index }
+  }
+
+  const object: Record<string, unknown> = {}
+
+  while (index < lines.length) {
+    const line = stripYamlComment(lines[index]!)
+    const trimmed = line.trim()
+    if (trimmed.length === 0) {
+      index++
+      continue
+    }
+
+    const currentIndent = countIndent(line)
+    if (currentIndent < indent) break
+    if (currentIndent > indent) {
+      throw new Error(`Invalid Mermaid frontmatter indentation near "${trimmed}"`)
+    }
+
+    const match = trimmed.match(/^([^:]+):(?:\s+(.*))?$/)
+    if (!match) {
+      throw new Error(`Invalid Mermaid frontmatter entry: "${trimmed}"`)
+    }
+
+    const key = match[1]!.trim()
+    const valuePart = match[2]
+    index++
+
+    if (valuePart === undefined || valuePart.trim().length === 0) {
+      const nested = parseYamlBlock(lines, index, currentIndent + 2)
+      object[key] = nested.value
+      index = nested.nextIndex
+      continue
+    }
+
+    object[key] = parseYamlScalar(valuePart.trim())
+  }
+
+  return { value: object, nextIndex: index }
+}
+
+function stripYamlComment(line: string): string {
+  let inSingle = false
+  let inDouble = false
+
+  for (let i = 0; i < line.length; i++) {
+    const char = line[i]!
+    const prev = i > 0 ? line[i - 1]! : ''
+
+    if (char === "'" && !inDouble && prev !== '\\') inSingle = !inSingle
+    if (char === '"' && !inSingle && prev !== '\\') inDouble = !inDouble
+
+    if (char === '#' && !inSingle && !inDouble) {
+      return line.slice(0, i)
+    }
+  }
+
+  return line
+}
+
+function parseYamlScalar(value: string): unknown {
+  if (value === 'true') return true
+  if (value === 'false') return false
+  if (value === 'null') return null
+  if (/^-?\d+(?:\.\d+)?$/.test(value)) return Number(value)
+
+  if ((value.startsWith('"') && value.endsWith('"')) || (value.startsWith("'") && value.endsWith("'"))) {
+    return parseStringLiteral(value)
+  }
+
+  if (value.startsWith('[') || value.startsWith('{')) {
+    return parseObjectLiteral(value)
+  }
+
+  return value
+}
+
+function looksLikeYamlKeyValue(value: string): boolean {
+  return /^[^:[\]{}][^:]*:(?:\s+.*)?$/.test(value)
+}
+
+function countIndent(line: string): number {
+  let count = 0
+  while (count < line.length && line[count] === ' ') count++
+  return count
+}
+
+type LiteralToken =
+  | { type: 'brace-open' | 'brace-close' | 'bracket-open' | 'bracket-close' | 'colon' | 'comma' }
+  | { type: 'string'; value: string }
+  | { type: 'number'; value: number }
+  | { type: 'boolean'; value: boolean }
+  | { type: 'null'; value: null }
+  | { type: 'identifier'; value: string }
+
+function parseObjectLiteral(input: string): unknown {
+  const tokens = tokenizeLiteral(input)
+  let index = 0
+
+  const parseValue = (): unknown => {
+    const token = tokens[index]
+    if (!token) throw new Error('Unexpected end of Mermaid config')
+
+    switch (token.type) {
+      case 'string':
+      case 'number':
+      case 'boolean':
+      case 'null':
+        index++
+        return token.value
+
+      case 'brace-open':
+        return parseObject()
+
+      case 'bracket-open':
+        return parseArray()
+
+      case 'identifier':
+        index++
+        if (token.value === 'true') return true
+        if (token.value === 'false') return false
+        if (token.value === 'null') return null
+        return token.value
+
+      default:
+        throw new Error(`Unexpected Mermaid config token: ${token.type}`)
+    }
+  }
+
+  const parseObject = (): Record<string, unknown> => {
+    expectToken('brace-open')
+    const object: Record<string, unknown> = {}
+
+    while (!peekToken('brace-close')) {
+      const keyToken = tokens[index]
+      if (!keyToken || (keyToken.type !== 'identifier' && keyToken.type !== 'string')) {
+        throw new Error('Expected Mermaid config object key')
+      }
+
+      index++
+      const key = keyToken.value
+      expectToken('colon')
+      object[key] = parseValue()
+
+      if (peekToken('comma')) index++
+    }
+
+    expectToken('brace-close')
+    return object
+  }
+
+  const parseArray = (): unknown[] => {
+    expectToken('bracket-open')
+    const array: unknown[] = []
+
+    while (!peekToken('bracket-close')) {
+      array.push(parseValue())
+      if (peekToken('comma')) index++
+    }
+
+    expectToken('bracket-close')
+    return array
+  }
+
+  const expectToken = (type: LiteralToken['type']): void => {
+    const token = tokens[index]
+    if (!token || token.type !== type) {
+      throw new Error(`Expected Mermaid config token ${type}`)
+    }
+    index++
+  }
+
+  const peekToken = (type: LiteralToken['type']): boolean => tokens[index]?.type === type
+
+  const value = parseValue()
+  if (index < tokens.length) {
+    throw new Error('Unexpected trailing Mermaid config tokens')
+  }
+  return value
+}
+
+function tokenizeLiteral(input: string): LiteralToken[] {
+  const tokens: LiteralToken[] = []
+  let index = 0
+
+  while (index < input.length) {
+    const char = input[index]!
+
+    if (/\s/.test(char)) {
+      index++
+      continue
+    }
+
+    if (char === '{') {
+      tokens.push({ type: 'brace-open' })
+      index++
+      continue
+    }
+    if (char === '}') {
+      tokens.push({ type: 'brace-close' })
+      index++
+      continue
+    }
+    if (char === '[') {
+      tokens.push({ type: 'bracket-open' })
+      index++
+      continue
+    }
+    if (char === ']') {
+      tokens.push({ type: 'bracket-close' })
+      index++
+      continue
+    }
+    if (char === ':') {
+      tokens.push({ type: 'colon' })
+      index++
+      continue
+    }
+    if (char === ',') {
+      tokens.push({ type: 'comma' })
+      index++
+      continue
+    }
+
+    if (char === '"' || char === "'") {
+      const { value, nextIndex } = readStringLiteral(input, index)
+      tokens.push({ type: 'string', value })
+      index = nextIndex
+      continue
+    }
+
+    const numberMatch = input.slice(index).match(/^-?\d+(?:\.\d+)?/)
+    if (numberMatch) {
+      tokens.push({ type: 'number', value: Number(numberMatch[0]) })
+      index += numberMatch[0].length
+      continue
+    }
+
+    const identifierMatch = input.slice(index).match(/^[A-Za-z_$][\w$-]*/)
+    if (identifierMatch) {
+      const value = identifierMatch[0]
+      if (value === 'true' || value === 'false') {
+        tokens.push({ type: 'boolean', value: value === 'true' })
+      } else if (value === 'null') {
+        tokens.push({ type: 'null', value: null })
+      } else {
+        tokens.push({ type: 'identifier', value })
+      }
+      index += value.length
+      continue
+    }
+
+    throw new Error(`Unsupported Mermaid config character: "${char}"`)
+  }
+
+  return tokens
+}
+
+function readStringLiteral(input: string, startIndex: number): { value: string; nextIndex: number } {
+  const quote = input[startIndex]!
+  let value = ''
+  let index = startIndex + 1
+
+  while (index < input.length) {
+    const char = input[index]!
+
+    if (char === '\\') {
+      const next = input[index + 1]
+      if (next !== undefined) {
+        value += decodeEscape(next)
+        index += 2
+        continue
+      }
+    }
+
+    if (char === quote) {
+      return { value, nextIndex: index + 1 }
+    }
+
+    value += char
+    index++
+  }
+
+  throw new Error('Unterminated Mermaid config string literal')
+}
+
+function parseStringLiteral(value: string): string {
+  return readStringLiteral(value, 0).value
+}
+
+function decodeEscape(char: string): string {
+  switch (char) {
+    case 'n': return '\n'
+    case 'r': return '\r'
+    case 't': return '\t'
+    case '"': return '"'
+    case "'": return "'"
+    case '\\': return '\\'
+    default: return char
+  }
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
 }

--- a/src/mermaid-source.ts
+++ b/src/mermaid-source.ts
@@ -1,0 +1,42 @@
+// ============================================================================
+// Mermaid source normalization
+//
+// Strips leading frontmatter, blank lines, and Mermaid comment/directive lines
+// so the public routers can detect the real diagram header consistently.
+// ============================================================================
+
+export interface NormalizedMermaidSource {
+  text: string
+  lines: string[]
+  firstLine: string
+}
+
+export function normalizeMermaidSource(text: string): NormalizedMermaidSource {
+  const rawLines = text.replace(/^\uFEFF/, '').split('\n')
+  let start = 0
+
+  while (start < rawLines.length && rawLines[start]!.trim().length === 0) {
+    start++
+  }
+
+  if (rawLines[start]?.trim() === '---') {
+    start++
+    while (start < rawLines.length && rawLines[start]!.trim() !== '---') {
+      start++
+    }
+    if (start < rawLines.length && rawLines[start]!.trim() === '---') {
+      start++
+    }
+  }
+
+  const lines = rawLines
+    .slice(start)
+    .map(line => line.trim())
+    .filter(line => line.length > 0 && !line.startsWith('%%'))
+
+  return {
+    text: lines.join('\n'),
+    lines,
+    firstLine: lines[0]?.toLowerCase() ?? '',
+  }
+}

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -283,6 +283,7 @@ export function svgOpenTag(
   height: number,
   colors: DiagramColors,
   transparent?: boolean,
+  extraAttrs: Record<string, string> = {},
 ): string {
   // Build the style string with only the provided color variables
   const vars = [
@@ -296,9 +297,12 @@ export function svgOpenTag(
   ].filter(Boolean).join(';')
 
   const bgStyle = transparent ? '' : ';background:var(--bg)'
+  const attrs = Object.entries(extraAttrs)
+    .map(([key, value]) => ` ${key}="${value}"`)
+    .join('')
 
   return (
     `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ${width} ${height}" ` +
-    `width="${width}" height="${height}" style="${vars}${bgStyle}">`
+    `width="${width}" height="${height}" style="${vars}${bgStyle}"${attrs}>`
   )
 }

--- a/src/timeline/layout.ts
+++ b/src/timeline/layout.ts
@@ -1,0 +1,244 @@
+import type {
+  TimelineDiagram,
+  PositionedTimelineDiagram,
+  PositionedTimelineSection,
+  PositionedTimelinePeriod,
+  PositionedTimelineEvent,
+} from './types.ts'
+import type { RenderOptions } from '../types.ts'
+import { measureMultilineText } from '../text-metrics.ts'
+
+// ============================================================================
+// Timeline diagram layout engine
+//
+// Computes direct coordinates for a horizontal timeline with:
+//   - optional section frames
+//   - period pills above the rail
+//   - stacked event cards below the rail
+// ============================================================================
+
+const TL = {
+  paddingX: 32,
+  paddingY: 28,
+  titleFontSize: 18,
+  titleFontWeight: 600,
+  titleGap: 24,
+  sectionHeaderHeight: 24,
+  sectionHeaderPadX: 12,
+  sectionHeaderGap: 14,
+  sectionPadX: 18,
+  sectionPadBottom: 18,
+  sectionGap: 28,
+  columnGap: 24,
+  pillFontSize: 12,
+  pillFontWeight: 600,
+  pillPadX: 12,
+  pillPadY: 8,
+  pillMinWidth: 72,
+  railToPillGap: 22,
+  railToEventsGap: 28,
+  markerRadius: 8,
+  eventFontSize: 12,
+  eventFontWeight: 400,
+  eventPadX: 14,
+  eventPadY: 10,
+  eventMinWidth: 128,
+  eventGap: 10,
+} as const
+
+interface PeriodMetric {
+  pillWidth: number
+  pillHeight: number
+  columnWidth: number
+  stackHeight: number
+  events: Array<{ width: number; height: number }>
+}
+
+interface SectionMetric {
+  headerWidth: number
+  innerWidth: number
+  columnAreaWidth: number
+  periods: PeriodMetric[]
+  maxStackHeight: number
+}
+
+/**
+ * Lay out a parsed timeline diagram.
+ */
+export function layoutTimelineDiagram(
+  diagram: TimelineDiagram,
+  _options: RenderOptions = {}
+): PositionedTimelineDiagram {
+  const hasNamedSections = diagram.sections.some(section => !!section.label)
+  const showSectionFrames = diagram.sections.length > 1 || hasNamedSections
+  const sectionHeaderHeight = hasNamedSections ? TL.sectionHeaderHeight : 0
+  const sectionPadX = showSectionFrames ? TL.sectionPadX : 0
+
+  const titleMetrics = diagram.title
+    ? measureMultilineText(diagram.title, TL.titleFontSize, TL.titleFontWeight)
+    : undefined
+
+  const metrics: SectionMetric[] = diagram.sections.map(section => {
+    const periodMetrics: PeriodMetric[] = section.periods.map(period => {
+      const pillText = measureMultilineText(period.label, TL.pillFontSize, TL.pillFontWeight)
+      const pillWidth = Math.max(TL.pillMinWidth, pillText.width + TL.pillPadX * 2)
+      const pillHeight = pillText.height + TL.pillPadY * 2
+
+      const eventMetrics = period.events.map(event => {
+        const text = measureMultilineText(event.text, TL.eventFontSize, TL.eventFontWeight)
+        return {
+          width: Math.max(TL.eventMinWidth, text.width + TL.eventPadX * 2),
+          height: text.height + TL.eventPadY * 2,
+        }
+      })
+
+      const columnWidth = Math.max(
+        pillWidth,
+        ...eventMetrics.map(event => event.width),
+      )
+
+      const stackHeight = eventMetrics.reduce((sum, event, index) => {
+        const gap = index === 0 ? 0 : TL.eventGap
+        return sum + gap + event.height
+      }, 0)
+
+      return { pillWidth, pillHeight, columnWidth, stackHeight, events: eventMetrics }
+    })
+
+    const columnAreaWidth = periodMetrics.reduce((sum, period, index) => {
+      const gap = index === 0 ? 0 : TL.columnGap
+      return sum + gap + period.columnWidth
+    }, 0)
+
+    const headerWidth = section.label
+      ? measureMultilineText(section.label, TL.pillFontSize, TL.pillFontWeight).width + TL.sectionHeaderPadX * 2
+      : 0
+
+    const innerWidth = Math.max(columnAreaWidth, headerWidth)
+    const maxStackHeight = Math.max(0, ...periodMetrics.map(period => period.stackHeight))
+
+    return { headerWidth, innerWidth, columnAreaWidth, periods: periodMetrics, maxStackHeight }
+  })
+
+  const maxPillHeight = Math.max(
+    0,
+    ...metrics.flatMap(section => section.periods.map(period => period.pillHeight)),
+  )
+
+  let contentTop = TL.paddingY
+  if (titleMetrics) {
+    contentTop += titleMetrics.height
+    contentTop += TL.titleGap
+  }
+
+  const pillY = contentTop + sectionHeaderHeight + (hasNamedSections ? TL.sectionHeaderGap : 0)
+  const railY = pillY + maxPillHeight + TL.railToPillGap
+  const eventsTop = railY + TL.railToEventsGap
+
+  let cursorX = TL.paddingX
+  const sections: PositionedTimelineSection[] = []
+  let maxBottom = railY + TL.markerRadius
+
+  for (let sectionIndex = 0; sectionIndex < diagram.sections.length; sectionIndex++) {
+    const section = diagram.sections[sectionIndex]!
+    const metric = metrics[sectionIndex]!
+    const sectionWidth = metric.innerWidth + sectionPadX * 2
+    const columnStartX = cursorX + sectionPadX + (metric.innerWidth - metric.columnAreaWidth) / 2
+
+    let periodCursorX = columnStartX
+    const periods: PositionedTimelinePeriod[] = []
+    let sectionBottom = railY + TL.markerRadius
+
+    for (let periodIndex = 0; periodIndex < section.periods.length; periodIndex++) {
+      const period = section.periods[periodIndex]!
+      const periodMetric = metric.periods[periodIndex]!
+      const centerX = periodCursorX + periodMetric.columnWidth / 2
+
+      let eventY = eventsTop
+      const events: PositionedTimelineEvent[] = period.events.map((event, eventIndex) => {
+        const eventMetric = periodMetric.events[eventIndex]!
+        const positioned: PositionedTimelineEvent = {
+          id: event.id,
+          sectionId: section.id,
+          periodId: period.id,
+          periodLabel: period.label,
+          text: event.text,
+          x: centerX - eventMetric.width / 2,
+          y: eventY,
+          width: eventMetric.width,
+          height: eventMetric.height,
+        }
+        eventY += eventMetric.height + TL.eventGap
+        return positioned
+      })
+
+      const stemBottomY = events.length > 0 ? events[0]!.y - 10 : railY + 16
+
+      periods.push({
+        id: period.id,
+        sectionId: section.id,
+        label: period.label,
+        centerX,
+        markerY: railY,
+        pillX: centerX - periodMetric.pillWidth / 2,
+        pillY,
+        pillWidth: periodMetric.pillWidth,
+        pillHeight: periodMetric.pillHeight,
+        stemTopY: railY + TL.markerRadius,
+        stemBottomY,
+        events,
+      })
+
+      if (events.length > 0) {
+        const lastEvent = events[events.length - 1]!
+        sectionBottom = Math.max(sectionBottom, lastEvent.y + lastEvent.height)
+      }
+
+      periodCursorX += periodMetric.columnWidth + TL.columnGap
+    }
+
+    sectionBottom += TL.sectionPadBottom
+    maxBottom = Math.max(maxBottom, sectionBottom)
+
+    sections.push({
+      id: section.id,
+      label: section.label,
+      x: cursorX,
+      y: contentTop,
+      width: sectionWidth,
+      height: sectionBottom - contentTop,
+      framed: showSectionFrames,
+      headerHeight: sectionHeaderHeight,
+      periods,
+    })
+
+    cursorX += sectionWidth
+    if (sectionIndex < diagram.sections.length - 1) {
+      cursorX += showSectionFrames ? TL.sectionGap : TL.columnGap
+    }
+  }
+
+  const width = cursorX + TL.paddingX
+  const height = maxBottom + TL.paddingY
+  const allPeriods = sections.flatMap(section => section.periods)
+  const firstCenter = allPeriods[0]?.centerX ?? TL.paddingX
+  const lastCenter = allPeriods[allPeriods.length - 1]?.centerX ?? width - TL.paddingX
+
+  return {
+    width,
+    height,
+    title: diagram.title
+      ? {
+          text: diagram.title,
+          x: width / 2,
+          y: TL.paddingY + titleMetrics!.height / 2,
+        }
+      : undefined,
+    rail: {
+      x1: firstCenter === lastCenter ? firstCenter - 42 : firstCenter,
+      x2: firstCenter === lastCenter ? lastCenter + 42 : lastCenter,
+      y: railY,
+    },
+    sections,
+  }
+}

--- a/src/timeline/layout.ts
+++ b/src/timeline/layout.ts
@@ -6,7 +6,8 @@ import type {
   PositionedTimelineEvent,
 } from './types.ts'
 import type { RenderOptions } from '../types.ts'
-import { measureMultilineText } from '../text-metrics.ts'
+import { measureMultilineText, measureTextWidth } from '../text-metrics.ts'
+import { stripFormattingTags } from '../multiline-utils.ts'
 
 // ============================================================================
 // Timeline diagram layout engine
@@ -23,15 +24,20 @@ const TL = {
   titleFontSize: 18,
   titleFontWeight: 600,
   titleGap: 24,
+  titleWrapWidth: 420,
   sectionHeaderHeight: 24,
+  sectionFontSize: 12,
+  sectionFontWeight: 600,
   sectionHeaderPadX: 12,
   sectionHeaderGap: 14,
+  sectionWrapWidth: 168,
   sectionPadX: 18,
   sectionPadBottom: 18,
   sectionGap: 28,
   columnGap: 24,
   pillFontSize: 12,
   pillFontWeight: 600,
+  pillWrapWidth: 116,
   pillPadX: 12,
   pillPadY: 8,
   pillMinWidth: 72,
@@ -40,6 +46,7 @@ const TL = {
   markerRadius: 8,
   eventFontSize: 12,
   eventFontWeight: 400,
+  eventWrapWidth: 148,
   eventPadX: 14,
   eventPadY: 10,
   eventMinWidth: 128,
@@ -47,14 +54,16 @@ const TL = {
 } as const
 
 interface PeriodMetric {
+  label: string
   pillWidth: number
   pillHeight: number
   columnWidth: number
   stackHeight: number
-  events: Array<{ width: number; height: number }>
+  events: Array<{ text: string; width: number; height: number }>
 }
 
 interface SectionMetric {
+  label?: string
   headerWidth: number
   innerWidth: number
   columnAreaWidth: number
@@ -73,20 +82,29 @@ export function layoutTimelineDiagram(
   const showSectionFrames = diagram.sections.length > 1 || hasNamedSections
   const sectionHeaderHeight = hasNamedSections ? TL.sectionHeaderHeight : 0
   const sectionPadX = showSectionFrames ? TL.sectionPadX : 0
+  const titleText = diagram.title
+    ? wrapTimelineText(diagram.title, TL.titleWrapWidth, TL.titleFontSize, TL.titleFontWeight)
+    : undefined
 
-  const titleMetrics = diagram.title
-    ? measureMultilineText(diagram.title, TL.titleFontSize, TL.titleFontWeight)
+  const titleMetrics = titleText
+    ? measureMultilineText(titleText, TL.titleFontSize, TL.titleFontWeight)
     : undefined
 
   const metrics: SectionMetric[] = diagram.sections.map(section => {
+    const wrappedSectionLabel = section.label
+      ? wrapTimelineText(section.label, TL.sectionWrapWidth, TL.sectionFontSize, TL.sectionFontWeight)
+      : undefined
     const periodMetrics: PeriodMetric[] = section.periods.map(period => {
-      const pillText = measureMultilineText(period.label, TL.pillFontSize, TL.pillFontWeight)
+      const wrappedPeriodLabel = wrapTimelineText(period.label, TL.pillWrapWidth, TL.pillFontSize, TL.pillFontWeight)
+      const pillText = measureMultilineText(wrappedPeriodLabel, TL.pillFontSize, TL.pillFontWeight)
       const pillWidth = Math.max(TL.pillMinWidth, pillText.width + TL.pillPadX * 2)
       const pillHeight = pillText.height + TL.pillPadY * 2
 
       const eventMetrics = period.events.map(event => {
-        const text = measureMultilineText(event.text, TL.eventFontSize, TL.eventFontWeight)
+        const wrappedEventText = wrapTimelineText(event.text, TL.eventWrapWidth, TL.eventFontSize, TL.eventFontWeight)
+        const text = measureMultilineText(wrappedEventText, TL.eventFontSize, TL.eventFontWeight)
         return {
+          text: wrappedEventText,
           width: Math.max(TL.eventMinWidth, text.width + TL.eventPadX * 2),
           height: text.height + TL.eventPadY * 2,
         }
@@ -102,7 +120,14 @@ export function layoutTimelineDiagram(
         return sum + gap + event.height
       }, 0)
 
-      return { pillWidth, pillHeight, columnWidth, stackHeight, events: eventMetrics }
+      return {
+        label: wrappedPeriodLabel,
+        pillWidth,
+        pillHeight,
+        columnWidth,
+        stackHeight,
+        events: eventMetrics,
+      }
     })
 
     const columnAreaWidth = periodMetrics.reduce((sum, period, index) => {
@@ -110,14 +135,21 @@ export function layoutTimelineDiagram(
       return sum + gap + period.columnWidth
     }, 0)
 
-    const headerWidth = section.label
-      ? measureMultilineText(section.label, TL.pillFontSize, TL.pillFontWeight).width + TL.sectionHeaderPadX * 2
+    const headerWidth = wrappedSectionLabel
+      ? measureMultilineText(wrappedSectionLabel, TL.sectionFontSize, TL.sectionFontWeight).width + TL.sectionHeaderPadX * 2
       : 0
 
     const innerWidth = Math.max(columnAreaWidth, headerWidth)
     const maxStackHeight = Math.max(0, ...periodMetrics.map(period => period.stackHeight))
 
-    return { headerWidth, innerWidth, columnAreaWidth, periods: periodMetrics, maxStackHeight }
+    return {
+      label: wrappedSectionLabel,
+      headerWidth,
+      innerWidth,
+      columnAreaWidth,
+      periods: periodMetrics,
+      maxStackHeight,
+    }
   })
 
   const maxPillHeight = Math.max(
@@ -161,8 +193,8 @@ export function layoutTimelineDiagram(
           id: event.id,
           sectionId: section.id,
           periodId: period.id,
-          periodLabel: period.label,
-          text: event.text,
+          periodLabel: periodMetric.label,
+          text: eventMetric.text,
           x: centerX - eventMetric.width / 2,
           y: eventY,
           width: eventMetric.width,
@@ -177,7 +209,7 @@ export function layoutTimelineDiagram(
       periods.push({
         id: period.id,
         sectionId: section.id,
-        label: period.label,
+        label: periodMetric.label,
         centerX,
         markerY: railY,
         pillX: centerX - periodMetric.pillWidth / 2,
@@ -202,7 +234,7 @@ export function layoutTimelineDiagram(
 
     sections.push({
       id: section.id,
-      label: section.label,
+      label: metric.label,
       x: cursorX,
       y: contentTop,
       width: sectionWidth,
@@ -227,13 +259,15 @@ export function layoutTimelineDiagram(
   return {
     width,
     height,
-    title: diagram.title
+    title: titleText
       ? {
-          text: diagram.title,
+          text: titleText,
           x: width / 2,
           y: TL.paddingY + titleMetrics!.height / 2,
         }
       : undefined,
+    accessibilityTitle: diagram.accessibilityTitle,
+    accessibilityDescription: diagram.accessibilityDescription,
     rail: {
       x1: firstCenter === lastCenter ? firstCenter - 42 : firstCenter,
       x2: firstCenter === lastCenter ? lastCenter + 42 : lastCenter,
@@ -241,4 +275,84 @@ export function layoutTimelineDiagram(
     },
     sections,
   }
+}
+
+function wrapTimelineText(
+  text: string,
+  maxWidth: number,
+  fontSize: number,
+  fontWeight: number,
+): string {
+  return text
+    .split('\n')
+    .flatMap(line => wrapTimelineLine(line, maxWidth, fontSize, fontWeight))
+    .join('\n')
+}
+
+function wrapTimelineLine(
+  line: string,
+  maxWidth: number,
+  fontSize: number,
+  fontWeight: number,
+): string[] {
+  const plainLine = stripFormattingTags(line)
+  if (measureTextWidth(plainLine, fontSize, fontWeight) <= maxWidth) {
+    return [line]
+  }
+
+  const words = line.trim().split(/\s+/)
+  if (words.length <= 1) {
+    return breakLongToken(line, maxWidth, fontSize, fontWeight)
+  }
+
+  const wrapped: string[] = []
+  let current = ''
+
+  for (const word of words) {
+    const candidate = current ? `${current} ${word}` : word
+    const candidateWidth = measureTextWidth(stripFormattingTags(candidate), fontSize, fontWeight)
+
+    if (candidateWidth <= maxWidth) {
+      current = candidate
+      continue
+    }
+
+    if (current) {
+      wrapped.push(current)
+      current = ''
+    }
+
+    if (measureTextWidth(stripFormattingTags(word), fontSize, fontWeight) > maxWidth) {
+      wrapped.push(...breakLongToken(word, maxWidth, fontSize, fontWeight))
+    } else {
+      current = word
+    }
+  }
+
+  if (current) wrapped.push(current)
+  return wrapped
+}
+
+function breakLongToken(
+  token: string,
+  maxWidth: number,
+  fontSize: number,
+  fontWeight: number,
+): string[] {
+  const chunks: string[] = []
+  let current = ''
+
+  for (const char of token) {
+    const candidate = current + char
+    if (current && measureTextWidth(stripFormattingTags(candidate), fontSize, fontWeight) > maxWidth) {
+      chunks.push(current)
+      current = char
+      continue
+    }
+
+    current = candidate
+  }
+
+  if (current) chunks.push(current)
+  return chunks
 }

--- a/src/timeline/parser.ts
+++ b/src/timeline/parser.ts
@@ -1,0 +1,118 @@
+import type { TimelineDiagram, TimelineSection, TimelinePeriod, TimelineEvent } from './types.ts'
+import { normalizeBrTags } from '../multiline-utils.ts'
+
+// ============================================================================
+// Timeline diagram parser
+//
+// Parses Mermaid timeline syntax into a TimelineDiagram structure.
+//
+// Supported syntax:
+//   timeline
+//   title Timeline Title
+//   section Section Label
+//   2020 : Event 1
+//   2021 : Event 1 : Event 2
+//        : Continued event for the previous period
+// ============================================================================
+
+/**
+ * Parse a Mermaid timeline diagram.
+ * Expects the first line to be "timeline".
+ */
+export function parseTimelineDiagram(lines: string[]): TimelineDiagram {
+  const diagram: TimelineDiagram = { sections: [] }
+
+  let currentSection: TimelineSection | undefined
+  let currentPeriod: TimelinePeriod | undefined
+  let sectionIndex = 0
+  let periodIndex = 0
+  let eventIndex = 0
+
+  const ensureSection = (): TimelineSection => {
+    if (currentSection) return currentSection
+    currentSection = {
+      id: `section-${sectionIndex++}`,
+      periods: [],
+    }
+    diagram.sections.push(currentSection)
+    return currentSection
+  }
+
+  const pushEvents = (period: TimelinePeriod, rawEvents: string[]): void => {
+    for (const rawEvent of rawEvents) {
+      const normalized = normalizeBrTags(rawEvent.trim())
+      if (!normalized) continue
+
+      const event: TimelineEvent = {
+        id: `event-${eventIndex++}`,
+        text: normalized,
+      }
+      period.events.push(event)
+    }
+  }
+
+  for (let i = 1; i < lines.length; i++) {
+    const line = lines[i]!
+
+    if (/^timeline\b/i.test(line)) continue
+
+    const titleMatch = line.match(/^title\s+(.+)$/i)
+    if (titleMatch) {
+      diagram.title = normalizeBrTags(titleMatch[1]!.trim())
+      continue
+    }
+
+    const sectionMatch = line.match(/^section\s+(.+)$/i)
+    if (sectionMatch) {
+      currentSection = {
+        id: `section-${sectionIndex++}`,
+        label: normalizeBrTags(sectionMatch[1]!.trim()),
+        periods: [],
+      }
+      diagram.sections.push(currentSection)
+      currentPeriod = undefined
+      continue
+    }
+
+    const continuationMatch = line.match(/^:\s*(.+)$/)
+    if (continuationMatch) {
+      if (!currentPeriod) {
+        throw new Error('Timeline continuation found before any period was declared')
+      }
+      pushEvents(currentPeriod, continuationMatch[1]!.split(/\s*:\s*/))
+      continue
+    }
+
+    const parts = line.split(/\s*:\s*/)
+    if (parts.length >= 2) {
+      const periodLabel = normalizeBrTags(parts[0]!.trim())
+      const events = parts.slice(1)
+
+      if (!periodLabel) {
+        throw new Error(`Invalid timeline period: "${line}"`)
+      }
+
+      const period: TimelinePeriod = {
+        id: `period-${periodIndex++}`,
+        label: periodLabel,
+        events: [],
+      }
+
+      pushEvents(period, events)
+
+      if (period.events.length === 0) {
+        throw new Error(`Timeline period "${periodLabel}" must include at least one event`)
+      }
+
+      ensureSection().periods.push(period)
+      currentPeriod = period
+      continue
+    }
+  }
+
+  if (diagram.sections.length === 0 || diagram.sections.every(section => section.periods.length === 0)) {
+    throw new Error('Timeline diagram must include at least one period with events')
+  }
+
+  return diagram
+}

--- a/src/timeline/parser.ts
+++ b/src/timeline/parser.ts
@@ -55,6 +55,7 @@ export function parseTimelineDiagram(lines: string[]): TimelineDiagram {
     const line = lines[i]!
 
     if (/^timeline\b/i.test(line)) continue
+    if (/^#/.test(line)) continue
 
     const titleMatch = line.match(/^title\s+(.+)$/i)
     if (titleMatch) {
@@ -62,7 +63,40 @@ export function parseTimelineDiagram(lines: string[]): TimelineDiagram {
       continue
     }
 
-    const sectionMatch = line.match(/^section\s+(.+)$/i)
+    const accTitleMatch = line.match(/^accTitle\s*:\s*(.+)$/i)
+    if (accTitleMatch) {
+      diagram.accessibilityTitle = normalizeBrTags(accTitleMatch[1]!.trim())
+      continue
+    }
+
+    const accDescrMatch = line.match(/^accDescr\s*:\s*(.+)$/i)
+    if (accDescrMatch) {
+      diagram.accessibilityDescription = normalizeBrTags(accDescrMatch[1]!.trim())
+      continue
+    }
+
+    if (/^accDescr\s*\{\s*$/i.test(line)) {
+      const descriptionLines: string[] = []
+      let foundClosingBrace = false
+
+      while (++i < lines.length) {
+        const blockLine = lines[i]!
+        if (blockLine === '}') {
+          foundClosingBrace = true
+          break
+        }
+        descriptionLines.push(blockLine)
+      }
+
+      if (!foundClosingBrace) {
+        throw new Error('Timeline accDescr block was not closed with "}"')
+      }
+
+      diagram.accessibilityDescription = normalizeBrTags(descriptionLines.join('\n').trim())
+      continue
+    }
+
+    const sectionMatch = line.match(/^section\s+([^:]+)$/i)
     if (sectionMatch) {
       currentSection = {
         id: `section-${sectionIndex++}`,
@@ -74,19 +108,19 @@ export function parseTimelineDiagram(lines: string[]): TimelineDiagram {
       continue
     }
 
-    const continuationMatch = line.match(/^:\s*(.+)$/)
+    const continuationMatch = line.match(/^:\s+(.+)$/)
     if (continuationMatch) {
       if (!currentPeriod) {
         throw new Error('Timeline continuation found before any period was declared')
       }
-      pushEvents(currentPeriod, continuationMatch[1]!.split(/\s*:\s*/))
+      pushEvents(currentPeriod, splitTimelineEvents(`: ${continuationMatch[1]!}`))
       continue
     }
 
-    const parts = line.split(/\s*:\s*/)
-    if (parts.length >= 2) {
-      const periodLabel = normalizeBrTags(parts[0]!.trim())
-      const events = parts.slice(1)
+    const periodMatch = line.match(/^([^:#\n]+?)(\s*:\s+.+)$/)
+    if (periodMatch) {
+      const periodLabel = normalizeBrTags(periodMatch[1]!.trim())
+      const events = splitTimelineEvents(periodMatch[2]!)
 
       if (!periodLabel) {
         throw new Error(`Invalid timeline period: "${line}"`)
@@ -108,6 +142,8 @@ export function parseTimelineDiagram(lines: string[]): TimelineDiagram {
       currentPeriod = period
       continue
     }
+
+    throw new Error(`Unsupported timeline syntax: "${line}"`)
   }
 
   if (diagram.sections.length === 0 || diagram.sections.every(section => section.periods.length === 0)) {
@@ -115,4 +151,35 @@ export function parseTimelineDiagram(lines: string[]): TimelineDiagram {
   }
 
   return diagram
+}
+
+function splitTimelineEvents(raw: string): string[] {
+  const events: string[] = []
+  let index = 0
+
+  while (index < raw.length) {
+    while (index < raw.length && /\s/.test(raw[index]!)) index++
+    if (index >= raw.length) break
+
+    if (raw[index] !== ':') {
+      throw new Error(`Invalid timeline event list: "${raw}"`)
+    }
+
+    index++
+    if (index >= raw.length || !/\s/.test(raw[index]!)) {
+      throw new Error(`Timeline events must use ": " separators: "${raw}"`)
+    }
+
+    while (index < raw.length && /\s/.test(raw[index]!)) index++
+    const start = index
+
+    while (index < raw.length) {
+      if (raw[index] === ':' && /\s/.test(raw[index + 1] ?? '')) break
+      index++
+    }
+
+    events.push(raw.slice(start, index).trim())
+  }
+
+  return events
 }

--- a/src/timeline/renderer.ts
+++ b/src/timeline/renderer.ts
@@ -2,6 +2,7 @@ import type { PositionedTimelineDiagram, PositionedTimelineSection, PositionedTi
 import type { DiagramColors } from '../theme.ts'
 import { svgOpenTag, buildStyleBlock } from '../theme.ts'
 import { renderMultilineText, escapeXml } from '../multiline-utils.ts'
+import type { MermaidThemeVariables, TimelineRuntimeConfig } from '../mermaid-source.ts'
 
 // ============================================================================
 // Timeline diagram SVG renderer
@@ -28,6 +29,13 @@ const TL = {
   eventAccentWidth: 4,
 } as const
 
+interface TimelineFamilyPalette {
+  accent: string
+  fill: string
+  label: string
+  line: string
+}
+
 const TL_THEME_FAMILY_ACCENTS = [
   'var(--_arrow)',
   mix('var(--_arrow)', 'var(--_line)', 72),
@@ -51,21 +59,34 @@ export function renderTimelineSvg(
   diagram: PositionedTimelineDiagram,
   colors: DiagramColors,
   font: string = 'Inter',
-  transparent: boolean = false
+  transparent: boolean = false,
+  timelineConfig: TimelineRuntimeConfig = {},
+  themeVariables?: MermaidThemeVariables,
 ): string {
   const parts: string[] = []
   const useSectionFamilies = diagram.sections.some(section => Boolean(section.label))
-  const familyAccents = getTimelineFamilyAccents(colors)
+  const accessibleTitle = diagram.accessibilityTitle ?? diagram.title?.text.replace(/\n+/g, ' ')
+  const accessibleDescription = diagram.accessibilityDescription
+  const familyPalettes = getTimelineFamilyPalettes(colors, timelineConfig, themeVariables)
+  const allowMulticolor = !(timelineConfig.disableMulticolor && !useSectionFamilies)
+  const rootAttrs = buildAccessibilityAttrs(accessibleTitle, accessibleDescription)
 
-  parts.push(svgOpenTag(diagram.width, diagram.height, colors, transparent))
+  parts.push(svgOpenTag(diagram.width, diagram.height, colors, transparent, rootAttrs))
   parts.push(buildStyleBlock(font, false))
   parts.push(timelineStyles())
+
+  if (accessibleTitle) {
+    parts.push(`<title id="bm-a11y-title">${escapeXml(accessibleTitle)}</title>`)
+  }
+  if (accessibleDescription) {
+    parts.push(`<desc id="bm-a11y-desc">${escapeXml(accessibleDescription)}</desc>`)
+  }
 
   for (let sectionIndex = 0; sectionIndex < diagram.sections.length; sectionIndex++) {
     const section = diagram.sections[sectionIndex]!
     const familyIndex = useSectionFamilies ? sectionIndex : 0
     if (section.framed) {
-      parts.push(renderSectionFrame(section, familyIndex, familyAccents))
+      parts.push(renderSectionFrame(section, familyIndex, familyPalettes))
     }
   }
 
@@ -78,8 +99,8 @@ export function renderTimelineSvg(
     const section = diagram.sections[sectionIndex]!
     const sectionFamilyIndex = useSectionFamilies ? sectionIndex : undefined
     for (const period of section.periods) {
-      const familyIndex = sectionFamilyIndex ?? periodFamilyIndex++
-      parts.push(renderPeriod(period, section.label, familyIndex, familyAccents))
+      const familyIndex = sectionFamilyIndex ?? (allowMulticolor ? periodFamilyIndex++ : 0)
+      parts.push(renderPeriod(period, section.label, familyIndex, familyPalettes))
     }
   }
 
@@ -103,28 +124,28 @@ function timelineStyles(): string {
   return `<style>
   .timeline-title { fill: var(--_text); }
   .timeline-rail { stroke: var(--_line); stroke-width: 1.5; stroke-linecap: round; }
-  .timeline-section-bg { fill: var(--tl-section-bg, color-mix(in srgb, var(--_node-fill) 88%, var(--bg))); stroke: var(--tl-event-stroke, var(--_node-stroke)); stroke-width: 1; }
-  .timeline-section-band { fill: var(--tl-section-band, color-mix(in srgb, var(--_arrow) 8%, var(--bg))); stroke: var(--tl-event-stroke, var(--_node-stroke)); stroke-width: 1; }
-  .timeline-section-label { fill: var(--_text-sec); }
-  .timeline-stem { stroke: var(--tl-stem, color-mix(in srgb, var(--_arrow) 32%, var(--_line))); stroke-width: 1; stroke-dasharray: 3 4; }
-  .timeline-marker-ring { fill: var(--bg); stroke: var(--tl-marker-ring, var(--_arrow)); stroke-width: 1.5; }
-  .timeline-marker-core { fill: var(--tl-marker-core, var(--_arrow)); }
+  .timeline-section-bg { fill: var(--tl-section-bg, color-mix(in srgb, var(--_node-fill) 88%, var(--bg))); stroke: var(--tl-line, var(--_node-stroke)); stroke-width: 1; }
+  .timeline-section-band { fill: var(--tl-section-band, color-mix(in srgb, var(--_arrow) 8%, var(--bg))); stroke: var(--tl-line, var(--_node-stroke)); stroke-width: 1; }
+  .timeline-section-label { fill: var(--tl-label, var(--_text-sec)); }
+  .timeline-stem { stroke: var(--tl-line, color-mix(in srgb, var(--_arrow) 32%, var(--_line))); stroke-width: 1; stroke-dasharray: 3 4; }
+  .timeline-marker-ring { fill: var(--bg); stroke: var(--tl-line, var(--_arrow)); stroke-width: 1.5; }
+  .timeline-marker-core { fill: var(--tl-accent, var(--_arrow)); }
   .timeline-period-pill { fill: var(--tl-pill-fill, color-mix(in srgb, var(--_arrow) 7%, var(--bg))); stroke: var(--tl-pill-stroke, color-mix(in srgb, var(--_arrow) 20%, var(--bg))); stroke-width: 1; }
-  .timeline-period-text { fill: var(--_text); }
-  .timeline-event-card { fill: var(--tl-event-fill, var(--_node-fill)); stroke: var(--tl-event-stroke, var(--_node-stroke)); stroke-width: 1; }
+  .timeline-period-text { fill: var(--tl-label, var(--_text)); }
+  .timeline-event-card { fill: var(--tl-event-fill, var(--_node-fill)); stroke: var(--tl-line, var(--_node-stroke)); stroke-width: 1; }
   .timeline-event-accent { fill: var(--tl-event-accent, color-mix(in srgb, var(--_arrow) 18%, var(--bg))); }
-  .timeline-event-text { fill: var(--_text-muted); }
+  .timeline-event-text { fill: var(--tl-label, var(--_text-muted)); }
 </style>`
 }
 
 function renderSectionFrame(
   section: PositionedTimelineSection,
   familyIndex: number,
-  familyAccents: readonly string[],
+  familyPalettes: readonly TimelineFamilyPalette[],
 ): string {
   const parts: string[] = []
   const labelAttr = section.label ? ` data-label="${escapeAttr(section.label)}"` : ''
-  const familyAttr = renderFamilyAttr(familyIndex, familyAccents)
+  const familyAttr = renderFamilyAttr(familyIndex, familyPalettes)
   parts.push(`<g class="timeline-section" data-id="${escapeAttr(section.id)}"${labelAttr}${familyAttr}>`)
   parts.push(
     `  <rect class="timeline-section-bg" x="${section.x}" y="${section.y}" width="${section.width}" height="${section.height}" rx="0" ry="0" />`
@@ -155,11 +176,11 @@ function renderPeriod(
   period: PositionedTimelinePeriod,
   sectionLabel: string | undefined,
   familyIndex: number,
-  familyAccents: readonly string[],
+  familyPalettes: readonly TimelineFamilyPalette[],
 ): string {
   const parts: string[] = []
   const sectionAttr = sectionLabel ? ` data-section="${escapeAttr(sectionLabel)}"` : ''
-  const familyAttr = renderFamilyAttr(familyIndex, familyAccents)
+  const familyAttr = renderFamilyAttr(familyIndex, familyPalettes)
 
   parts.push(
     `<g class="timeline-period" data-id="${escapeAttr(period.id)}" data-label="${escapeAttr(period.label)}"${sectionAttr}${familyAttr}>`
@@ -187,7 +208,7 @@ function renderPeriod(
   )
 
   for (const event of period.events) {
-    parts.push(renderEvent(event, sectionLabel, familyIndex, familyAccents.length))
+    parts.push(renderEvent(event, sectionLabel, familyIndex, familyPalettes))
   }
 
   parts.push('</g>')
@@ -198,10 +219,10 @@ function renderEvent(
   event: PositionedTimelineEvent,
   sectionLabel: string | undefined,
   familyIndex: number,
-  familyCount: number,
+  familyPalettes: readonly TimelineFamilyPalette[],
 ): string {
   const sectionAttr = sectionLabel ? ` data-section="${escapeAttr(sectionLabel)}"` : ''
-  const familyAttr = ` data-family="${familyIndex % familyCount}"`
+  const familyAttr = ` data-family="${familyIndex % familyPalettes.length}"`
 
   return [
     `<g class="timeline-event" data-id="${escapeAttr(event.id)}" data-period="${escapeAttr(event.periodLabel)}"${sectionAttr}${familyAttr}>`,
@@ -218,27 +239,32 @@ function renderEvent(
 ].join('\n')
 }
 
-function renderFamilyAttr(familyIndex: number, familyAccents: readonly string[]): string {
-  const family = familyIndex % familyAccents.length
-  const accent = familyAccents[family]!
+function renderFamilyAttr(familyIndex: number, familyPalettes: readonly TimelineFamilyPalette[]): string {
+  const family = familyIndex % familyPalettes.length
+  const palette = familyPalettes[family]!
   const style = [
-    `--tl-accent:${accent}`,
-    `--tl-section-bg:${mix(accent, 'var(--bg)', 4)}`,
-    `--tl-section-band:${mix(accent, 'var(--bg)', 9)}`,
-    `--tl-stem:${mix(accent, 'var(--_line)', 36)}`,
-    `--tl-pill-fill:${mix(accent, 'var(--bg)', 8)}`,
-    `--tl-pill-stroke:${mix(accent, 'var(--bg)', 24)}`,
-    `--tl-marker-ring:${accent}`,
-    `--tl-marker-core:${accent}`,
-    `--tl-event-fill:${mix(accent, 'var(--_node-fill)', 10)}`,
-    `--tl-event-stroke:${mix(accent, 'var(--_node-stroke)', 24)}`,
-    `--tl-event-accent:${mix(accent, 'var(--bg)', 18)}`,
+    `--tl-accent:${palette.accent}`,
+    `--tl-fill:${palette.fill}`,
+    `--tl-label:${palette.label}`,
+    `--tl-line:${palette.line}`,
+    `--tl-section-bg:${mix(palette.fill, 'var(--bg)', 6)}`,
+    `--tl-section-band:${mix(palette.fill, 'var(--bg)', 12)}`,
+    `--tl-pill-fill:${mix(palette.fill, 'var(--bg)', 11)}`,
+    `--tl-pill-stroke:${mix(palette.fill, palette.line, 36)}`,
+    `--tl-event-fill:${mix(palette.fill, 'var(--_node-fill)', 16)}`,
+    `--tl-event-accent:${mix(palette.fill, 'var(--bg)', 26)}`,
   ].join(';')
 
   return ` data-family="${family}" style="${escapeAttr(style)}"`
 }
 
-function getTimelineFamilyAccents(colors: DiagramColors): readonly string[] {
+function getTimelineFamilyPalettes(
+  colors: DiagramColors,
+  timelineConfig: TimelineRuntimeConfig,
+  themeVariables?: MermaidThemeVariables,
+): readonly TimelineFamilyPalette[] {
+  const customFills = timelineConfig.sectionFills ?? []
+  const customLabels = timelineConfig.sectionColours ?? []
   const hasThemeEnrichment = Boolean(
     colors.accent ||
     colors.line ||
@@ -247,11 +273,47 @@ function getTimelineFamilyAccents(colors: DiagramColors): readonly string[] {
     colors.border
   )
 
-  return hasThemeEnrichment ? TL_THEME_FAMILY_ACCENTS : TL_DEFAULT_FAMILY_ACCENTS
+  return Array.from({ length: 12 }, (_, index) => {
+    const defaultFill = hasThemeEnrichment
+      ? TL_THEME_FAMILY_ACCENTS[index % TL_THEME_FAMILY_ACCENTS.length]!
+      : TL_DEFAULT_FAMILY_ACCENTS[index % TL_DEFAULT_FAMILY_ACCENTS.length]!
+    const fill = customFills[index % Math.max(customFills.length, 1)]
+      ?? readTimelineScale(themeVariables, 'cScale', index)
+      ?? defaultFill
+    const label = customLabels[index % Math.max(customLabels.length, 1)]
+      ?? readTimelineScale(themeVariables, 'cScaleLabel', index)
+      ?? 'var(--_text)'
+    const line = readTimelineScale(themeVariables, 'cScaleInv', index)
+      ?? mix(fill, 'var(--_line)', 48)
+
+    return { accent: fill, fill, label, line }
+  })
 }
 
 function mix(primary: string, secondary: string, amount: number): string {
   return `color-mix(in srgb, ${primary} ${amount}%, ${secondary})`
+}
+
+function readTimelineScale(
+  themeVariables: MermaidThemeVariables | undefined,
+  prefix: 'cScale' | 'cScaleLabel' | 'cScaleInv',
+  index: number,
+): string | undefined {
+  if (!themeVariables) return undefined
+  const value = themeVariables[`${prefix}${index}`]
+  return typeof value === 'string' && value.length > 0 ? value : undefined
+}
+
+function buildAccessibilityAttrs(
+  title: string | undefined,
+  description: string | undefined,
+): Record<string, string> {
+  if (!title && !description) return {}
+
+  const attrs: Record<string, string> = { role: 'img' }
+  if (title) attrs['aria-labelledby'] = 'bm-a11y-title'
+  if (description) attrs['aria-describedby'] = 'bm-a11y-desc'
+  return attrs
 }
 
 function escapeAttr(text: string): string {

--- a/src/timeline/renderer.ts
+++ b/src/timeline/renderer.ts
@@ -11,6 +11,7 @@ import { renderMultilineText, escapeXml } from '../multiline-utils.ts'
 //   - a single horizontal rail
 //   - period pills above the rail
 //   - stacked event cards below with a subtle accent strip
+//   - color families grouped by section (or by period when unsectioned)
 // ============================================================================
 
 const TL = {
@@ -27,6 +28,22 @@ const TL = {
   eventAccentWidth: 4,
 } as const
 
+const TL_THEME_FAMILY_ACCENTS = [
+  'var(--_arrow)',
+  mix('var(--_arrow)', 'var(--_line)', 72),
+  mix('var(--_arrow)', 'var(--_text-sec)', 60),
+  mix('var(--_line)', 'var(--_text)', 56),
+  mix('var(--_arrow)', 'var(--_node-stroke)', 46),
+] as const
+
+const TL_DEFAULT_FAMILY_ACCENTS = [
+  '#5B7FFF',
+  '#159A72',
+  '#D18A24',
+  '#CC5A5A',
+  '#6B7280',
+] as const
+
 /**
  * Render a positioned timeline diagram as an SVG string.
  */
@@ -37,14 +54,18 @@ export function renderTimelineSvg(
   transparent: boolean = false
 ): string {
   const parts: string[] = []
+  const useSectionFamilies = diagram.sections.some(section => Boolean(section.label))
+  const familyAccents = getTimelineFamilyAccents(colors)
 
   parts.push(svgOpenTag(diagram.width, diagram.height, colors, transparent))
   parts.push(buildStyleBlock(font, false))
   parts.push(timelineStyles())
 
-  for (const section of diagram.sections) {
+  for (let sectionIndex = 0; sectionIndex < diagram.sections.length; sectionIndex++) {
+    const section = diagram.sections[sectionIndex]!
+    const familyIndex = useSectionFamilies ? sectionIndex : 0
     if (section.framed) {
-      parts.push(renderSectionFrame(section))
+      parts.push(renderSectionFrame(section, familyIndex, familyAccents))
     }
   }
 
@@ -52,9 +73,13 @@ export function renderTimelineSvg(
     `<line class="timeline-rail" x1="${diagram.rail.x1}" y1="${diagram.rail.y}" x2="${diagram.rail.x2}" y2="${diagram.rail.y}" />`
   )
 
-  for (const section of diagram.sections) {
+  let periodFamilyIndex = 0
+  for (let sectionIndex = 0; sectionIndex < diagram.sections.length; sectionIndex++) {
+    const section = diagram.sections[sectionIndex]!
+    const sectionFamilyIndex = useSectionFamilies ? sectionIndex : undefined
     for (const period of section.periods) {
-      parts.push(renderPeriod(period, section.label))
+      const familyIndex = sectionFamilyIndex ?? periodFamilyIndex++
+      parts.push(renderPeriod(period, section.label, familyIndex, familyAccents))
     }
   }
 
@@ -78,25 +103,29 @@ function timelineStyles(): string {
   return `<style>
   .timeline-title { fill: var(--_text); }
   .timeline-rail { stroke: var(--_line); stroke-width: 1.5; stroke-linecap: round; }
-  .timeline-section-bg { fill: color-mix(in srgb, var(--_node-fill) 88%, var(--bg)); stroke: var(--_node-stroke); stroke-width: 1; }
-  .timeline-section-band { fill: color-mix(in srgb, var(--_arrow) 8%, var(--bg)); stroke: var(--_node-stroke); stroke-width: 1; }
+  .timeline-section-bg { fill: var(--tl-section-bg, color-mix(in srgb, var(--_node-fill) 88%, var(--bg))); stroke: var(--tl-event-stroke, var(--_node-stroke)); stroke-width: 1; }
+  .timeline-section-band { fill: var(--tl-section-band, color-mix(in srgb, var(--_arrow) 8%, var(--bg))); stroke: var(--tl-event-stroke, var(--_node-stroke)); stroke-width: 1; }
   .timeline-section-label { fill: var(--_text-sec); }
-  .timeline-stem { stroke: color-mix(in srgb, var(--_arrow) 32%, var(--_line)); stroke-width: 1; stroke-dasharray: 3 4; }
-  .timeline-marker-ring { fill: var(--bg); stroke: var(--_arrow); stroke-width: 1.5; }
-  .timeline-marker-core { fill: var(--_arrow); }
-  .timeline-period-pill { fill: color-mix(in srgb, var(--_arrow) 7%, var(--bg)); stroke: color-mix(in srgb, var(--_arrow) 20%, var(--bg)); stroke-width: 1; }
+  .timeline-stem { stroke: var(--tl-stem, color-mix(in srgb, var(--_arrow) 32%, var(--_line))); stroke-width: 1; stroke-dasharray: 3 4; }
+  .timeline-marker-ring { fill: var(--bg); stroke: var(--tl-marker-ring, var(--_arrow)); stroke-width: 1.5; }
+  .timeline-marker-core { fill: var(--tl-marker-core, var(--_arrow)); }
+  .timeline-period-pill { fill: var(--tl-pill-fill, color-mix(in srgb, var(--_arrow) 7%, var(--bg))); stroke: var(--tl-pill-stroke, color-mix(in srgb, var(--_arrow) 20%, var(--bg))); stroke-width: 1; }
   .timeline-period-text { fill: var(--_text); }
-  .timeline-event-card { fill: var(--_node-fill); stroke: var(--_node-stroke); stroke-width: 1; }
-  .timeline-event-accent { fill: color-mix(in srgb, var(--_arrow) 18%, var(--bg)); }
+  .timeline-event-card { fill: var(--tl-event-fill, var(--_node-fill)); stroke: var(--tl-event-stroke, var(--_node-stroke)); stroke-width: 1; }
+  .timeline-event-accent { fill: var(--tl-event-accent, color-mix(in srgb, var(--_arrow) 18%, var(--bg))); }
   .timeline-event-text { fill: var(--_text-muted); }
 </style>`
 }
 
-function renderSectionFrame(section: PositionedTimelineSection): string {
+function renderSectionFrame(
+  section: PositionedTimelineSection,
+  familyIndex: number,
+  familyAccents: readonly string[],
+): string {
   const parts: string[] = []
-
   const labelAttr = section.label ? ` data-label="${escapeAttr(section.label)}"` : ''
-  parts.push(`<g class="timeline-section" data-id="${escapeAttr(section.id)}"${labelAttr}>`)
+  const familyAttr = renderFamilyAttr(familyIndex, familyAccents)
+  parts.push(`<g class="timeline-section" data-id="${escapeAttr(section.id)}"${labelAttr}${familyAttr}>`)
   parts.push(
     `  <rect class="timeline-section-bg" x="${section.x}" y="${section.y}" width="${section.width}" height="${section.height}" rx="0" ry="0" />`
   )
@@ -122,12 +151,18 @@ function renderSectionFrame(section: PositionedTimelineSection): string {
   return parts.join('\n')
 }
 
-function renderPeriod(period: PositionedTimelinePeriod, sectionLabel?: string): string {
+function renderPeriod(
+  period: PositionedTimelinePeriod,
+  sectionLabel: string | undefined,
+  familyIndex: number,
+  familyAccents: readonly string[],
+): string {
   const parts: string[] = []
   const sectionAttr = sectionLabel ? ` data-section="${escapeAttr(sectionLabel)}"` : ''
+  const familyAttr = renderFamilyAttr(familyIndex, familyAccents)
 
   parts.push(
-    `<g class="timeline-period" data-id="${escapeAttr(period.id)}" data-label="${escapeAttr(period.label)}"${sectionAttr}>`
+    `<g class="timeline-period" data-id="${escapeAttr(period.id)}" data-label="${escapeAttr(period.label)}"${sectionAttr}${familyAttr}>`
   )
   parts.push(
     `  <line class="timeline-stem" x1="${period.centerX}" y1="${period.stemTopY}" x2="${period.centerX}" y2="${period.stemBottomY}" />`
@@ -152,18 +187,24 @@ function renderPeriod(period: PositionedTimelinePeriod, sectionLabel?: string): 
   )
 
   for (const event of period.events) {
-    parts.push(renderEvent(event, sectionLabel))
+    parts.push(renderEvent(event, sectionLabel, familyIndex, familyAccents.length))
   }
 
   parts.push('</g>')
   return parts.join('\n')
 }
 
-function renderEvent(event: PositionedTimelineEvent, sectionLabel?: string): string {
+function renderEvent(
+  event: PositionedTimelineEvent,
+  sectionLabel: string | undefined,
+  familyIndex: number,
+  familyCount: number,
+): string {
   const sectionAttr = sectionLabel ? ` data-section="${escapeAttr(sectionLabel)}"` : ''
+  const familyAttr = ` data-family="${familyIndex % familyCount}"`
 
   return [
-    `<g class="timeline-event" data-id="${escapeAttr(event.id)}" data-period="${escapeAttr(event.periodLabel)}"${sectionAttr}>`,
+    `<g class="timeline-event" data-id="${escapeAttr(event.id)}" data-period="${escapeAttr(event.periodLabel)}"${sectionAttr}${familyAttr}>`,
     `  <rect class="timeline-event-card" x="${event.x}" y="${event.y}" width="${event.width}" height="${event.height}" rx="0" ry="0" />`,
     `  <rect class="timeline-event-accent" x="${event.x}" y="${event.y}" width="${TL.eventAccentWidth}" height="${event.height}" rx="0" ry="0" />`,
     '  ' + renderMultilineText(
@@ -174,7 +215,43 @@ function renderEvent(event: PositionedTimelineEvent, sectionLabel?: string): str
       `class="timeline-event-text" text-anchor="start" font-size="${TL.eventFontSize}" font-weight="${TL.eventFontWeight}"`,
     ),
     '</g>',
-  ].join('\n')
+].join('\n')
+}
+
+function renderFamilyAttr(familyIndex: number, familyAccents: readonly string[]): string {
+  const family = familyIndex % familyAccents.length
+  const accent = familyAccents[family]!
+  const style = [
+    `--tl-accent:${accent}`,
+    `--tl-section-bg:${mix(accent, 'var(--bg)', 4)}`,
+    `--tl-section-band:${mix(accent, 'var(--bg)', 9)}`,
+    `--tl-stem:${mix(accent, 'var(--_line)', 36)}`,
+    `--tl-pill-fill:${mix(accent, 'var(--bg)', 8)}`,
+    `--tl-pill-stroke:${mix(accent, 'var(--bg)', 24)}`,
+    `--tl-marker-ring:${accent}`,
+    `--tl-marker-core:${accent}`,
+    `--tl-event-fill:${mix(accent, 'var(--_node-fill)', 10)}`,
+    `--tl-event-stroke:${mix(accent, 'var(--_node-stroke)', 24)}`,
+    `--tl-event-accent:${mix(accent, 'var(--bg)', 18)}`,
+  ].join(';')
+
+  return ` data-family="${family}" style="${escapeAttr(style)}"`
+}
+
+function getTimelineFamilyAccents(colors: DiagramColors): readonly string[] {
+  const hasThemeEnrichment = Boolean(
+    colors.accent ||
+    colors.line ||
+    colors.muted ||
+    colors.surface ||
+    colors.border
+  )
+
+  return hasThemeEnrichment ? TL_THEME_FAMILY_ACCENTS : TL_DEFAULT_FAMILY_ACCENTS
+}
+
+function mix(primary: string, secondary: string, amount: number): string {
+  return `color-mix(in srgb, ${primary} ${amount}%, ${secondary})`
 }
 
 function escapeAttr(text: string): string {

--- a/src/timeline/renderer.ts
+++ b/src/timeline/renderer.ts
@@ -1,0 +1,182 @@
+import type { PositionedTimelineDiagram, PositionedTimelineSection, PositionedTimelinePeriod, PositionedTimelineEvent } from './types.ts'
+import type { DiagramColors } from '../theme.ts'
+import { svgOpenTag, buildStyleBlock } from '../theme.ts'
+import { renderMultilineText, escapeXml } from '../multiline-utils.ts'
+
+// ============================================================================
+// Timeline diagram SVG renderer
+//
+// Visual language:
+//   - crisp section frames aligned with the rest of beautiful-mermaid
+//   - a single horizontal rail
+//   - period pills above the rail
+//   - stacked event cards below with a subtle accent strip
+// ============================================================================
+
+const TL = {
+  titleFontSize: 18,
+  titleFontWeight: 600,
+  sectionFontSize: 12,
+  sectionFontWeight: 600,
+  pillFontSize: 12,
+  pillFontWeight: 600,
+  eventFontSize: 12,
+  eventFontWeight: 400,
+  markerOuterRadius: 8,
+  markerInnerRadius: 4.5,
+  eventAccentWidth: 4,
+} as const
+
+/**
+ * Render a positioned timeline diagram as an SVG string.
+ */
+export function renderTimelineSvg(
+  diagram: PositionedTimelineDiagram,
+  colors: DiagramColors,
+  font: string = 'Inter',
+  transparent: boolean = false
+): string {
+  const parts: string[] = []
+
+  parts.push(svgOpenTag(diagram.width, diagram.height, colors, transparent))
+  parts.push(buildStyleBlock(font, false))
+  parts.push(timelineStyles())
+
+  for (const section of diagram.sections) {
+    if (section.framed) {
+      parts.push(renderSectionFrame(section))
+    }
+  }
+
+  parts.push(
+    `<line class="timeline-rail" x1="${diagram.rail.x1}" y1="${diagram.rail.y}" x2="${diagram.rail.x2}" y2="${diagram.rail.y}" />`
+  )
+
+  for (const section of diagram.sections) {
+    for (const period of section.periods) {
+      parts.push(renderPeriod(period, section.label))
+    }
+  }
+
+  if (diagram.title) {
+    parts.push(
+      renderMultilineText(
+        diagram.title.text,
+        diagram.title.x,
+        diagram.title.y,
+        TL.titleFontSize,
+        `class="timeline-title" text-anchor="middle" font-size="${TL.titleFontSize}" font-weight="${TL.titleFontWeight}"`,
+      )
+    )
+  }
+
+  parts.push('</svg>')
+  return parts.join('\n')
+}
+
+function timelineStyles(): string {
+  return `<style>
+  .timeline-title { fill: var(--_text); }
+  .timeline-rail { stroke: var(--_line); stroke-width: 1.5; stroke-linecap: round; }
+  .timeline-section-bg { fill: color-mix(in srgb, var(--_node-fill) 88%, var(--bg)); stroke: var(--_node-stroke); stroke-width: 1; }
+  .timeline-section-band { fill: color-mix(in srgb, var(--_arrow) 8%, var(--bg)); stroke: var(--_node-stroke); stroke-width: 1; }
+  .timeline-section-label { fill: var(--_text-sec); }
+  .timeline-stem { stroke: color-mix(in srgb, var(--_arrow) 32%, var(--_line)); stroke-width: 1; stroke-dasharray: 3 4; }
+  .timeline-marker-ring { fill: var(--bg); stroke: var(--_arrow); stroke-width: 1.5; }
+  .timeline-marker-core { fill: var(--_arrow); }
+  .timeline-period-pill { fill: color-mix(in srgb, var(--_arrow) 7%, var(--bg)); stroke: color-mix(in srgb, var(--_arrow) 20%, var(--bg)); stroke-width: 1; }
+  .timeline-period-text { fill: var(--_text); }
+  .timeline-event-card { fill: var(--_node-fill); stroke: var(--_node-stroke); stroke-width: 1; }
+  .timeline-event-accent { fill: color-mix(in srgb, var(--_arrow) 18%, var(--bg)); }
+  .timeline-event-text { fill: var(--_text-muted); }
+</style>`
+}
+
+function renderSectionFrame(section: PositionedTimelineSection): string {
+  const parts: string[] = []
+
+  const labelAttr = section.label ? ` data-label="${escapeAttr(section.label)}"` : ''
+  parts.push(`<g class="timeline-section" data-id="${escapeAttr(section.id)}"${labelAttr}>`)
+  parts.push(
+    `  <rect class="timeline-section-bg" x="${section.x}" y="${section.y}" width="${section.width}" height="${section.height}" rx="0" ry="0" />`
+  )
+
+  if (section.headerHeight > 0) {
+    parts.push(
+      `  <rect class="timeline-section-band" x="${section.x}" y="${section.y}" width="${section.width}" height="${section.headerHeight}" rx="0" ry="0" />`
+    )
+    if (section.label) {
+      parts.push(
+        '  ' + renderMultilineText(
+          section.label,
+          section.x + 12,
+          section.y + section.headerHeight / 2,
+          TL.sectionFontSize,
+          `class="timeline-section-label" text-anchor="start" font-size="${TL.sectionFontSize}" font-weight="${TL.sectionFontWeight}"`,
+        )
+      )
+    }
+  }
+
+  parts.push('</g>')
+  return parts.join('\n')
+}
+
+function renderPeriod(period: PositionedTimelinePeriod, sectionLabel?: string): string {
+  const parts: string[] = []
+  const sectionAttr = sectionLabel ? ` data-section="${escapeAttr(sectionLabel)}"` : ''
+
+  parts.push(
+    `<g class="timeline-period" data-id="${escapeAttr(period.id)}" data-label="${escapeAttr(period.label)}"${sectionAttr}>`
+  )
+  parts.push(
+    `  <line class="timeline-stem" x1="${period.centerX}" y1="${period.stemTopY}" x2="${period.centerX}" y2="${period.stemBottomY}" />`
+  )
+  parts.push(
+    `  <rect class="timeline-period-pill" x="${period.pillX}" y="${period.pillY}" width="${period.pillWidth}" height="${period.pillHeight}" rx="0" ry="0" />`
+  )
+  parts.push(
+    '  ' + renderMultilineText(
+      period.label,
+      period.centerX,
+      period.pillY + period.pillHeight / 2,
+      TL.pillFontSize,
+      `class="timeline-period-text" text-anchor="middle" font-size="${TL.pillFontSize}" font-weight="${TL.pillFontWeight}"`,
+    )
+  )
+  parts.push(
+    `  <circle class="timeline-marker-ring" cx="${period.centerX}" cy="${period.markerY}" r="${TL.markerOuterRadius}" />`
+  )
+  parts.push(
+    `  <circle class="timeline-marker-core" cx="${period.centerX}" cy="${period.markerY}" r="${TL.markerInnerRadius}" />`
+  )
+
+  for (const event of period.events) {
+    parts.push(renderEvent(event, sectionLabel))
+  }
+
+  parts.push('</g>')
+  return parts.join('\n')
+}
+
+function renderEvent(event: PositionedTimelineEvent, sectionLabel?: string): string {
+  const sectionAttr = sectionLabel ? ` data-section="${escapeAttr(sectionLabel)}"` : ''
+
+  return [
+    `<g class="timeline-event" data-id="${escapeAttr(event.id)}" data-period="${escapeAttr(event.periodLabel)}"${sectionAttr}>`,
+    `  <rect class="timeline-event-card" x="${event.x}" y="${event.y}" width="${event.width}" height="${event.height}" rx="0" ry="0" />`,
+    `  <rect class="timeline-event-accent" x="${event.x}" y="${event.y}" width="${TL.eventAccentWidth}" height="${event.height}" rx="0" ry="0" />`,
+    '  ' + renderMultilineText(
+      event.text,
+      event.x + TL.eventAccentWidth + 12,
+      event.y + event.height / 2,
+      TL.eventFontSize,
+      `class="timeline-event-text" text-anchor="start" font-size="${TL.eventFontSize}" font-weight="${TL.eventFontWeight}"`,
+    ),
+    '</g>',
+  ].join('\n')
+}
+
+function escapeAttr(text: string): string {
+  return escapeXml(text)
+}

--- a/src/timeline/types.ts
+++ b/src/timeline/types.ts
@@ -1,0 +1,97 @@
+// ============================================================================
+// Timeline diagram types
+//
+// Models Mermaid timeline diagrams in parsed and positioned form.
+// Timeline diagrams show chronological milestones grouped into optional sections.
+// ============================================================================
+
+/** Parsed timeline diagram — logical structure from Mermaid text */
+export interface TimelineDiagram {
+  /** Optional timeline title */
+  title?: string
+  /** Ordered sections in input order */
+  sections: TimelineSection[]
+}
+
+export interface TimelineSection {
+  id: string
+  /** Optional section label. Undefined means "ungrouped" / implicit section. */
+  label?: string
+  periods: TimelinePeriod[]
+}
+
+export interface TimelinePeriod {
+  id: string
+  label: string
+  events: TimelineEvent[]
+}
+
+export interface TimelineEvent {
+  id: string
+  text: string
+}
+
+// ============================================================================
+// Positioned timeline diagram — ready for SVG rendering
+// ============================================================================
+
+export interface PositionedTimelineDiagram {
+  width: number
+  height: number
+  title?: PositionedTimelineTitle
+  rail: TimelineRail
+  sections: PositionedTimelineSection[]
+}
+
+export interface PositionedTimelineTitle {
+  text: string
+  x: number
+  y: number
+}
+
+export interface TimelineRail {
+  x1: number
+  x2: number
+  y: number
+}
+
+export interface PositionedTimelineSection {
+  id: string
+  label?: string
+  x: number
+  y: number
+  width: number
+  height: number
+  /** Whether to render a framed background for this section. */
+  framed: boolean
+  /** Height of the section header band. 0 when there is no visible header row. */
+  headerHeight: number
+  periods: PositionedTimelinePeriod[]
+}
+
+export interface PositionedTimelinePeriod {
+  id: string
+  sectionId: string
+  label: string
+  centerX: number
+  markerY: number
+  pillX: number
+  pillY: number
+  pillWidth: number
+  pillHeight: number
+  stemTopY: number
+  stemBottomY: number
+  events: PositionedTimelineEvent[]
+}
+
+export interface PositionedTimelineEvent {
+  id: string
+  sectionId: string
+  periodId: string
+  periodLabel: string
+  text: string
+  x: number
+  y: number
+  width: number
+  height: number
+}

--- a/src/timeline/types.ts
+++ b/src/timeline/types.ts
@@ -9,6 +9,10 @@
 export interface TimelineDiagram {
   /** Optional timeline title */
   title?: string
+  /** Optional accessibility title (Mermaid accTitle) */
+  accessibilityTitle?: string
+  /** Optional accessibility description (Mermaid accDescr) */
+  accessibilityDescription?: string
   /** Ordered sections in input order */
   sections: TimelineSection[]
 }
@@ -39,6 +43,8 @@ export interface PositionedTimelineDiagram {
   width: number
   height: number
   title?: PositionedTimelineTitle
+  accessibilityTitle?: string
+  accessibilityDescription?: string
   rail: TimelineRail
   sections: PositionedTimelineSection[]
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,5 @@
+import type { MermaidRuntimeConfig } from './mermaid-source.ts'
+
 // ============================================================================
 // Parsed graph — logical structure extracted from Mermaid text
 // ============================================================================
@@ -161,4 +163,6 @@ export interface RenderOptions {
   transparent?: boolean
   /** Enable hover tooltips on chart data points (xychart only). Default: false */
   interactive?: boolean
+  /** Optional Mermaid-style runtime config (analogous to initialize/frontmatter config). */
+  mermaidConfig?: MermaidRuntimeConfig
 }


### PR DESCRIPTION
## What

Add Mermaid `timeline` support across SVG and ASCII output, then close the main Mermaid-runtime parity gaps for Timeline.

This PR now covers:

- Timeline parser, layout, SVG renderer, ASCII renderer, routing, docs, and samples
- Mermaid-style config extraction from frontmatter and `%%{init: ...}%%` / `%%{initialize: ...}%%`
- Timeline accessibility metadata (`accTitle`, `accDescr`, multiline `accDescr { ... }`)
- stricter Timeline parsing so unsupported syntax fails instead of being silently ignored
- automatic wrapping for long Timeline labels so output behaves much closer to Mermaid’s runtime
- Timeline color-family behavior driven by Mermaid config/theme variables, including `disableMulticolor`, `cScale*`, `cScaleLabel*`, and `cScaleInv*`

## Why

`beautiful-mermaid` was missing `timeline`, and the first implementation still had a few important parity gaps once we evaluated it against Mermaid’s actual runtime behavior. The biggest ones were:

The repository has GitHub issues disabled, so this PR is intentionally self-contained rather than linked to an issue.

- Timeline ASCII could still leak frontmatter into visible output
- Mermaid config/directive data was stripped for routing but not actually applied
- `accTitle` / `accDescr` could be misparsed as diagram content
- long labels only respected explicit `<br>` instead of wrapping automatically
- unsupported Timeline syntax was too permissive

This update closes those gaps while staying within Beautiful Mermaid’s existing architecture and visual language.

## How

- add Mermaid source normalization that:
  - strips BOM/frontmatter/comments/directives for routing
  - parses and merges frontmatter config plus `init` / `initialize` directive config
  - threads merged config into rendering
- extend public SVG and ASCII render options with optional Mermaid-style runtime config
- update Timeline parsing to support:
  - `title`
  - `section`
  - multi-event period lines
  - continuation lines
  - `<br>` multiline labels
  - `accTitle`
  - `accDescr: ...`
  - `accDescr { ... }`
  - Mermaid-style hash comment lines
- make unsupported Timeline lines throw explicit syntax errors
- wrap long Timeline labels during layout instead of expanding indefinitely
- carry accessibility metadata through layout and render it as SVG `<title>` / `<desc>` plus root `role="img"` / `aria-*` attributes
- drive Timeline family styling from Mermaid config/theme variables:
  - `timeline.disableMulticolor`
  - `timeline.sectionFills`
  - `timeline.sectionColours`
  - `themeVariables.cScale0..11`
  - `themeVariables.cScaleLabel0..11`
  - `themeVariables.cScaleInv0..11`
- fix Timeline ASCII so it renders from normalized lines and no longer shows frontmatter/config metadata as fake periods
- add focused regression tests for each of the parity gaps above

## Testing

- [x] New/modified tests pass
- [x] Full test suite passes
- [x] Build passes
- [x] Sample generation passes
- [x] Benchmark pass completed

Commands run:

- `bun test src/__tests__/mermaid-source.test.ts src/__tests__/timeline-parser.test.ts src/__tests__/timeline-layout.test.ts src/__tests__/timeline-integration.test.ts src/__tests__/timeline-ascii.test.ts src/__tests__/styles.test.ts`
- `bun test src/__tests__/`
- `npm run build`
- `bun run samples`
- `bun run bench`

Key regression coverage added:

- frontmatter/directive config extraction and merge order
- frontmatter-safe Timeline SVG routing
- frontmatter-safe Timeline ASCII routing
- `accTitle` / `accDescr` parsing and rendering
- multiline `accDescr { ... }`
- strict failure on unsupported Timeline syntax
- automatic label wrapping
- `disableMulticolor`
- Mermaid theme-variable-driven family colors

## Screenshots / Recordings

This change affects generated library output rather than an app UI. Representative renders are checked into `examples/` and embedded here for review.

Docs-aligned Timeline example:

![Timeline social media example](https://raw.githubusercontent.com/adewale/beautiful-mermaid/codex/timeline-diagram-pr/examples/timeline-social.svg)

Sectioned Timeline example:

![Timeline product delivery plan example](https://raw.githubusercontent.com/adewale/beautiful-mermaid/codex/timeline-diagram-pr/examples/timeline-product-plan.svg)

## Risk

Moderate. This is still a new diagram family, but the follow-up work materially reduces the real parity risk by adding config plumbing, accessibility support, stricter parsing, wrapping behavior, and regression coverage around the exact failure modes we identified.
