### PR TITLE
test: add property-based invariant coverage

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -10,6 +10,7 @@
       },
       "devDependencies": {
         "@types/bun": "^1.3.9",
+        "fast-check": "^4.6.0",
         "shiki": "^3.19.0",
         "tsup": "^8.5.1",
         "typescript": "^5.9.3",
@@ -193,6 +194,8 @@
 
     "esbuild": ["esbuild@0.27.3", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.3", "@esbuild/android-arm": "0.27.3", "@esbuild/android-arm64": "0.27.3", "@esbuild/android-x64": "0.27.3", "@esbuild/darwin-arm64": "0.27.3", "@esbuild/darwin-x64": "0.27.3", "@esbuild/freebsd-arm64": "0.27.3", "@esbuild/freebsd-x64": "0.27.3", "@esbuild/linux-arm": "0.27.3", "@esbuild/linux-arm64": "0.27.3", "@esbuild/linux-ia32": "0.27.3", "@esbuild/linux-loong64": "0.27.3", "@esbuild/linux-mips64el": "0.27.3", "@esbuild/linux-ppc64": "0.27.3", "@esbuild/linux-riscv64": "0.27.3", "@esbuild/linux-s390x": "0.27.3", "@esbuild/linux-x64": "0.27.3", "@esbuild/netbsd-arm64": "0.27.3", "@esbuild/netbsd-x64": "0.27.3", "@esbuild/openbsd-arm64": "0.27.3", "@esbuild/openbsd-x64": "0.27.3", "@esbuild/openharmony-arm64": "0.27.3", "@esbuild/sunos-x64": "0.27.3", "@esbuild/win32-arm64": "0.27.3", "@esbuild/win32-ia32": "0.27.3", "@esbuild/win32-x64": "0.27.3" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg=="],
 
+    "fast-check": ["fast-check@4.6.0", "", { "dependencies": { "pure-rand": "^8.0.0" } }, "sha512-h7H6Dm0Fy+H4ciQYFxFjXnXkzR2kr9Fb22c0UBpHnm59K2zpr2t13aPTHlltFiNT6zuxp6HMPAVVvgur4BLdpA=="],
+
     "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
 
     "fix-dts-default-cjs-exports": ["fix-dts-default-cjs-exports@1.0.1", "", { "dependencies": { "magic-string": "^0.30.17", "mlly": "^1.7.4", "rollup": "^4.34.8" } }, "sha512-pVIECanWFC61Hzl2+oOCtoJ3F17kglZC/6N94eRWycFgBH35hHx0Li604ZIzhseh97mf2p0cv7vVrOZGoqhlEg=="],
@@ -252,6 +255,8 @@
     "postcss-load-config": ["postcss-load-config@6.0.1", "", { "dependencies": { "lilconfig": "^3.1.1" }, "peerDependencies": { "jiti": ">=1.21.0", "postcss": ">=8.0.9", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["jiti", "postcss", "tsx", "yaml"] }, "sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g=="],
 
     "property-information": ["property-information@7.1.0", "", {}, "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ=="],
+
+    "pure-rand": ["pure-rand@8.0.0", "", {}, "sha512-7rgWlxG2gAvFPIQfUreo1XYlNvrQ9VnQPFWdncPkdl3icucLK0InOxsaafbvxGTnI6Bk/Rxmslg0lQlRCuzOXw=="],
 
     "readdirp": ["readdirp@4.1.2", "", {}, "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg=="],
 

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
   },
   "devDependencies": {
     "@types/bun": "^1.3.9",
+    "fast-check": "^4.6.0",
     "shiki": "^3.19.0",
     "tsup": "^8.5.1",
     "typescript": "^5.9.3"

--- a/src/__tests__/property-ascii-routing.test.ts
+++ b/src/__tests__/property-ascii-routing.test.ts
@@ -1,0 +1,354 @@
+import { describe, expect, it } from 'bun:test'
+import fc from 'fast-check'
+
+import { renderMermaidASCII } from '../ascii/index.ts'
+import { convertToAsciiGraph } from '../ascii/converter.ts'
+import { determineLabelLine } from '../ascii/edge-routing.ts'
+import { getPath, mergePath } from '../ascii/pathfinder.ts'
+import {
+  EMPTY_STYLE,
+  type AsciiConfig,
+  type AsciiEdge,
+  type AsciiGraph,
+  type AsciiNode,
+  gridKey,
+} from '../ascii/types.ts'
+import { assertNoDiagonals } from '../ascii/validate.ts'
+import type { MermaidGraph, MermaidNode } from '../types.ts'
+
+const PROPERTY_RUNS = 50
+const LABEL_CHARS = [...'abcdefghijklmnopqrstuvwxyz']
+const ID_HEAD = [...'ABCDEFGHIJKLMNOPQRSTUVWXYZ']
+const ID_TAIL = [...'abcdefghijklmnopqrstuvwxyz0123456789']
+
+const labelArb = fc
+  .array(fc.constantFrom(...LABEL_CHARS), { minLength: 1, maxLength: 10 })
+  .map(chars => chars.join(''))
+
+const idArb = fc
+  .tuple(
+    fc.constantFrom(...ID_HEAD),
+    fc.array(fc.constantFrom(...ID_TAIL), { maxLength: 4 }),
+  )
+  .map(([head, tail]) => `${head}${tail.join('')}`)
+
+const coordArb = fc.record({
+  x: fc.integer({ min: 0, max: 8 }),
+  y: fc.integer({ min: 0, max: 8 }),
+})
+
+const baseConfig: AsciiConfig = {
+  useAscii: true,
+  paddingX: 5,
+  paddingY: 5,
+  boxBorderPadding: 1,
+  graphDirection: 'TD',
+}
+
+type StepDir = 'R' | 'L' | 'U' | 'D'
+
+function makeNode(name: string, index: number, gridCoord: { x: number; y: number } | null): AsciiNode {
+  return {
+    name,
+    displayLabel: name,
+    shape: 'rectangle',
+    index,
+    gridCoord,
+    drawingCoord: null,
+    drawing: null,
+    drawn: false,
+    styleClassName: '',
+    styleClass: EMPTY_STYLE,
+  }
+}
+
+function makeGraph(direction: 'TD' | 'LR' = 'TD'): AsciiGraph {
+  return {
+    nodes: [],
+    edges: [],
+    canvas: [[]],
+    roleCanvas: [[]],
+    grid: new Map(),
+    columnWidth: new Map(),
+    rowHeight: new Map(),
+    subgraphs: [],
+    config: { ...baseConfig, graphDirection: direction },
+    offsetX: 0,
+    offsetY: 0,
+    bundles: [],
+  }
+}
+
+function occupyNode(graph: AsciiGraph, node: AsciiNode): void {
+  const gridCoord = node.gridCoord!
+  for (let dx = 0; dx < 3; dx++) {
+    for (let dy = 0; dy < 3; dy++) {
+      graph.grid.set(gridKey({ x: gridCoord.x + dx, y: gridCoord.y + dy }), node)
+    }
+  }
+}
+
+function isOrthogonalStep(path: Array<{ x: number; y: number }>, index: number): boolean {
+  const prev = path[index - 1]!
+  const current = path[index]!
+  return Math.abs(prev.x - current.x) + Math.abs(prev.y - current.y) === 1
+}
+
+function buildWalk(start: { x: number; y: number }, steps: Array<{ dir: StepDir; len: number }>) {
+  const path = [{ ...start }]
+  let current = { ...start }
+
+  for (const step of steps) {
+    for (let i = 0; i < step.len; i++) {
+      if (step.dir === 'R') current = { x: current.x + 1, y: current.y }
+      else if (step.dir === 'L') current = { x: current.x - 1, y: current.y }
+      else if (step.dir === 'U') current = { x: current.x, y: current.y - 1 }
+      else current = { x: current.x, y: current.y + 1 }
+      path.push(current)
+    }
+  }
+
+  return path
+}
+
+function renderNode(id: string, label: string, variant: 'rectangle' | 'rounded' | 'diamond'): string {
+  if (variant === 'rounded') return `${id}(${label})`
+  if (variant === 'diamond') return `${id}{${label}}`
+  return `${id}[${label}]`
+}
+
+describe('property-based ASCII pathfinding', () => {
+  it('returns a shortest Manhattan path on an empty grid', () => {
+    fc.assert(
+      fc.property(coordArb, coordArb, (from, to) => {
+        const path = getPath(new Map(), from, to)
+
+        expect(path).not.toBeNull()
+        expect(path![0]).toEqual(from)
+        expect(path![path!.length - 1]).toEqual(to)
+        expect(path!.length).toBe(Math.abs(from.x - to.x) + Math.abs(from.y - to.y) + 1)
+
+        for (let index = 1; index < path!.length; index++) {
+          expect(isOrthogonalStep(path!, index)).toBe(true)
+        }
+      }),
+      { numRuns: PROPERTY_RUNS },
+    )
+  })
+
+  it('avoids occupied cells while staying orthogonal', () => {
+    const obstacleArb = fc
+      .record({
+        from: coordArb,
+        to: coordArb,
+        obstacles: fc.uniqueArray(coordArb, { maxLength: 8, selector: value => `${value.x},${value.y}` }),
+      })
+      .filter(({ from, to, obstacles }) => {
+        if (from.x === to.x && from.y === to.y) return false
+        const blocked = new Set(obstacles.map(point => `${point.x},${point.y}`))
+        return !blocked.has(`${from.x},${from.y}`) && !blocked.has(`${to.x},${to.y}`)
+      })
+
+    fc.assert(
+      fc.property(obstacleArb, ({ from, to, obstacles }) => {
+        const grid = new Map<string, AsciiNode>()
+        obstacles.forEach((point, index) => {
+          grid.set(gridKey(point), makeNode(`N${index}`, index, point))
+        })
+
+        const path = getPath(grid, from, to)
+        if (path === null) return
+
+        expect(path[0]).toEqual(from)
+        expect(path[path.length - 1]).toEqual(to)
+
+        for (let index = 1; index < path.length; index++) {
+          expect(isOrthogonalStep(path, index)).toBe(true)
+        }
+
+        for (const point of path.slice(0, -1)) {
+          expect(grid.has(gridKey(point))).toBe(false)
+        }
+      }),
+      { numRuns: PROPERTY_RUNS },
+    )
+  })
+
+  it('mergePath preserves endpoints and is idempotent', () => {
+    const walkArb = fc
+      .array(
+        fc.record({
+          dir: fc.constantFrom<StepDir>('R', 'L', 'U', 'D'),
+          len: fc.integer({ min: 1, max: 3 }),
+        }),
+        { minLength: 1, maxLength: 8 },
+      )
+      .filter((steps) => {
+        let previous: StepDir | null = null
+        for (const step of steps) {
+          if (step.dir === previous) return false
+          previous = step.dir
+        }
+        return true
+      })
+
+    fc.assert(
+      fc.property(coordArb, walkArb, (start, steps) => {
+        const path = buildWalk(start, steps)
+        const merged = mergePath(path)
+
+        expect(merged[0]).toEqual(path[0])
+        expect(merged[merged.length - 1]).toEqual(path[path.length - 1])
+        expect(mergePath(merged)).toEqual(merged)
+        expect(merged.length <= path.length).toBe(true)
+      }),
+      { numRuns: PROPERTY_RUNS },
+    )
+  })
+})
+
+describe('property-based ASCII routing helpers', () => {
+  it('selects a label segment from the path and widens the midpoint column', () => {
+    const pathArb = fc.record({
+      direction: fc.constantFrom<'TD' | 'LR'>('TD', 'LR'),
+      x0: fc.integer({ min: 0, max: 6 }),
+      y0: fc.integer({ min: 0, max: 6 }),
+      length: fc.integer({ min: 2, max: 6 }),
+      label: labelArb,
+    })
+
+    fc.assert(
+      fc.property(pathArb, ({ direction, x0, y0, length, label }) => {
+        const graph = makeGraph(direction)
+        const edge: AsciiEdge = {
+          from: makeNode('A', 0, { x: x0, y: y0 }),
+          to: makeNode('B', 1, direction === 'TD' ? { x: x0, y: y0 + length } : { x: x0 + length, y: y0 }),
+          text: label,
+          path: direction === 'TD'
+            ? [{ x: x0, y: y0 }, { x: x0, y: y0 + length }]
+            : [{ x: x0, y: y0 }, { x: x0 + length, y: y0 }],
+          labelLine: [],
+          startDir: { x: 0, y: 0 },
+          endDir: { x: 0, y: 0 },
+          style: 'solid',
+          hasArrowStart: false,
+          hasArrowEnd: true,
+        }
+
+        for (let x = Math.min(edge.path[0]!.x, edge.path[1]!.x); x <= Math.max(edge.path[0]!.x, edge.path[1]!.x); x++) {
+          graph.columnWidth.set(x, 1)
+        }
+
+        determineLabelLine(graph, edge)
+
+        expect(edge.labelLine).toHaveLength(2)
+        expect(edge.labelLine[0]).toEqual(edge.path[0])
+        expect(edge.labelLine[1]).toEqual(edge.path[1])
+
+        const middleX = Math.min(edge.labelLine[0]!.x, edge.labelLine[1]!.x)
+          + Math.floor(Math.abs(edge.labelLine[0]!.x - edge.labelLine[1]!.x) / 2)
+        expect((graph.columnWidth.get(middleX) ?? 0) >= label.length + 2).toBe(true)
+      }),
+      { numRuns: PROPERTY_RUNS },
+    )
+  })
+
+  it('preserves insertion order and applied classes when converting to an ASCII graph', () => {
+    const graphArb = fc
+      .uniqueArray(
+        fc.record({
+          id: idArb,
+          label: labelArb,
+          shape: fc.constantFrom<'rectangle' | 'rounded' | 'diamond'>('rectangle', 'rounded', 'diamond'),
+        }),
+        { minLength: 2, maxLength: 5, selector: value => value.id },
+      )
+      .chain(nodes =>
+        fc.record({
+          nodes: fc.constant(nodes),
+          classAssignments: fc.dictionary(fc.constantFrom(...nodes.map(node => node.id)), fc.constantFrom('hot', 'cold')),
+        }),
+      )
+
+    fc.assert(
+      fc.property(graphArb, ({ nodes, classAssignments }) => {
+        const parsed: MermaidGraph = {
+          direction: 'TD',
+          nodes: new Map(nodes.map((node): [string, MermaidNode] => [node.id, {
+            id: node.id,
+            label: node.label,
+            shape: node.shape,
+          }])),
+          edges: [],
+          subgraphs: [],
+          classDefs: new Map([
+            ['hot', { fill: '#f00' }],
+            ['cold', { fill: '#00f' }],
+          ]),
+          classAssignments: new Map(Object.entries(classAssignments)),
+          nodeStyles: new Map(),
+          linkStyles: new Map(),
+        }
+
+        const graph = convertToAsciiGraph(parsed, baseConfig)
+
+        expect(graph.nodes.map(node => node.name)).toEqual(nodes.map(node => node.id))
+        for (const node of graph.nodes) {
+          const assignedClass = classAssignments[node.name]
+          if (!assignedClass) {
+            expect(node.styleClassName).toBe('')
+            continue
+          }
+          expect(node.styleClassName).toBe(assignedClass)
+          expect(node.styleClass.styles.fill).toBe(assignedClass === 'hot' ? '#f00' : '#00f')
+        }
+      }),
+      { numRuns: PROPERTY_RUNS },
+    )
+  })
+})
+
+describe('property-based renderMermaidASCII', () => {
+  it('keeps small generated flowcharts free of diagonal edges', () => {
+    const flowchartArb = fc
+      .uniqueArray(
+        fc.record({
+          id: idArb,
+          label: labelArb,
+          shape: fc.constantFrom<'rectangle' | 'rounded' | 'diamond'>('rectangle', 'rounded', 'diamond'),
+        }),
+        { minLength: 2, maxLength: 4, selector: value => value.id },
+      )
+      .chain(nodes =>
+        fc.record({
+          nodes: fc.constant(nodes),
+          edges: fc.uniqueArray(
+            fc.record({
+              from: fc.constantFrom(...nodes.map(node => node.id)),
+              to: fc.constantFrom(...nodes.map(node => node.id)),
+              label: fc.option(labelArb, { nil: undefined }),
+            }).filter(edge => edge.from !== edge.to),
+            {
+              minLength: 1,
+              maxLength: Math.min(4, nodes.length * (nodes.length - 1)),
+              selector: edge => `${edge.from}->${edge.to}:${edge.label ?? ''}`,
+            },
+          ),
+        }),
+      )
+
+    fc.assert(
+      fc.property(flowchartArb, ({ nodes, edges }) => {
+        const source = [
+          'graph TD',
+          ...nodes.map((node) => renderNode(node.id, node.label, node.shape)),
+          ...edges.map((edge) => `${edge.from} -->${edge.label ? `|${edge.label}|` : ''} ${edge.to}`),
+        ].join('\n')
+
+        const ascii = renderMermaidASCII(source, { colorMode: 'none', useAscii: false })
+        assertNoDiagonals(ascii)
+      }),
+      { numRuns: 30 },
+    )
+  })
+})

--- a/src/__tests__/property-diagram-parsers.test.ts
+++ b/src/__tests__/property-diagram-parsers.test.ts
@@ -1,0 +1,181 @@
+import { describe, expect, it } from 'bun:test'
+import fc from 'fast-check'
+
+import { parseClassDiagram } from '../class/parser.ts'
+import { parseSequenceDiagram } from '../sequence/parser.ts'
+import { parseTimelineDiagram } from '../timeline/parser.ts'
+
+const PROPERTY_RUNS = 50
+const ID_HEAD = [...'ABCDEFGHIJKLMNOPQRSTUVWXYZ']
+const ID_TAIL = [...'abcdefghijklmnopqrstuvwxyz0123456789']
+const WORD_CHARS = [...'abcdefghijklmnopqrstuvwxyz']
+
+const idArb = fc
+  .tuple(
+    fc.constantFrom(...ID_HEAD),
+    fc.array(fc.constantFrom(...ID_TAIL), { maxLength: 5 }),
+  )
+  .map(([head, tail]) => `${head}${tail.join('')}`)
+
+const wordArb = fc
+  .array(fc.constantFrom(...WORD_CHARS), { minLength: 1, maxLength: 8 })
+  .map(chars => chars.join(''))
+
+const labelArb = fc
+  .array(wordArb, { minLength: 1, maxLength: 3 })
+  .map(parts => parts.join(' '))
+
+function toLines(source: string): string[] {
+  return source
+    .split('\n')
+    .map(line => line.trim())
+    .filter(line => line.length > 0 && !line.startsWith('%%'))
+}
+
+describe('property-based sequence parsing', () => {
+  it('auto-creates referenced actors and preserves message count', () => {
+    const sequenceArb = fc.uniqueArray(idArb, { minLength: 2, maxLength: 5 }).chain(ids =>
+      fc.record({
+        ids: fc.constant(ids),
+        declaredIds: fc.subarray(ids, { maxLength: ids.length }),
+        messages: fc.array(
+          fc.record({
+            from: fc.constantFrom(...ids),
+            to: fc.constantFrom(...ids),
+            label: labelArb,
+          }),
+          { minLength: 1, maxLength: 6 },
+        ),
+      }),
+    )
+
+    fc.assert(
+      fc.property(sequenceArb, ({ declaredIds, messages }) => {
+        const source = [
+          'sequenceDiagram',
+          ...declaredIds.map(id => `participant ${id}`),
+          ...messages.map(message => `${message.from}->>${message.to}: ${message.label}`),
+        ].join('\n')
+
+        const diagram = parseSequenceDiagram(toLines(source))
+        const actorIds = new Set(diagram.actors.map(actor => actor.id))
+
+        expect(diagram.messages).toHaveLength(messages.length)
+        for (const message of messages) {
+          expect(actorIds.has(message.from)).toBe(true)
+          expect(actorIds.has(message.to)).toBe(true)
+        }
+      }),
+      { numRuns: PROPERTY_RUNS },
+    )
+  })
+})
+
+describe('property-based timeline parsing', () => {
+  it('preserves total periods and events and assigns unique ids', () => {
+    const sectionArb = fc.record({
+      label: fc.option(labelArb, { nil: undefined }),
+      periods: fc.array(
+        fc.record({
+          label: labelArb,
+          firstEvent: labelArb,
+          continuationEvents: fc.array(labelArb, { maxLength: 2 }),
+        }),
+        { minLength: 1, maxLength: 3 },
+      ),
+    })
+
+    fc.assert(
+      fc.property(fc.array(sectionArb, { minLength: 1, maxLength: 3 }), (sections) => {
+        const lines = ['timeline']
+        let expectedPeriodCount = 0
+        let expectedEventCount = 0
+
+        for (const section of sections) {
+          if (section.label) lines.push(`section ${section.label}`)
+          for (const period of section.periods) {
+            lines.push(`${period.label} : ${period.firstEvent}`)
+            expectedPeriodCount++
+            expectedEventCount++
+            for (const continuationEvent of period.continuationEvents) {
+              lines.push(`: ${continuationEvent}`)
+              expectedEventCount++
+            }
+          }
+        }
+
+        const diagram = parseTimelineDiagram(toLines(lines.join('\n')))
+        const periods = diagram.sections.flatMap(section => section.periods)
+        const events = periods.flatMap(period => period.events)
+
+        expect(periods).toHaveLength(expectedPeriodCount)
+        expect(events).toHaveLength(expectedEventCount)
+        expect(new Set(periods.map(period => period.id)).size).toBe(periods.length)
+        expect(new Set(events.map(event => event.id)).size).toBe(events.length)
+      }),
+      { numRuns: PROPERTY_RUNS },
+    )
+  })
+})
+
+describe('property-based class parsing', () => {
+  it('materializes relationship endpoints and keeps namespace membership valid', () => {
+    const relationshipArb = fc.constantFrom('<|--', '*--', 'o--', '-->', '..>', '..|>')
+    const classArb = fc.uniqueArray(idArb, { minLength: 2, maxLength: 5 }).chain(ids =>
+      fc.record({
+        ids: fc.constant(ids),
+        namespaces: fc.array(
+          fc.record({
+            name: wordArb.map(word => `${word.toUpperCase()}Space`),
+            members: fc.subarray(ids, { minLength: 1, maxLength: ids.length }),
+          }),
+          { maxLength: 2 },
+        ),
+        relationships: fc.array(
+          fc.record({
+            from: fc.constantFrom(...ids),
+            to: fc.constantFrom(...ids),
+            arrow: relationshipArb,
+            label: fc.option(labelArb, { nil: undefined }),
+          }).filter(entry => entry.from !== entry.to),
+          { minLength: 1, maxLength: 5 },
+        ),
+      }),
+    )
+
+    fc.assert(
+      fc.property(classArb, ({ ids, namespaces, relationships }) => {
+        const lines = ['classDiagram', ...ids.map(id => `class ${id}`)]
+
+        for (const namespace of namespaces) {
+          lines.push(`namespace ${namespace.name} {`)
+          for (const member of namespace.members) {
+            lines.push(`class ${member}`)
+          }
+          lines.push('}')
+        }
+
+        for (const relationship of relationships) {
+          lines.push(
+            `${relationship.from} ${relationship.arrow} ${relationship.to}${relationship.label ? ` : ${relationship.label}` : ''}`,
+          )
+        }
+
+        const diagram = parseClassDiagram(toLines(lines.join('\n')))
+        const classIds = new Set(diagram.classes.map(node => node.id))
+
+        for (const relationship of diagram.relationships) {
+          expect(classIds.has(relationship.from)).toBe(true)
+          expect(classIds.has(relationship.to)).toBe(true)
+        }
+
+        for (const namespace of diagram.namespaces) {
+          for (const classId of namespace.classIds) {
+            expect(classIds.has(classId)).toBe(true)
+          }
+        }
+      }),
+      { numRuns: PROPERTY_RUNS },
+    )
+  })
+})

--- a/src/__tests__/property-mermaid-source-and-parser.test.ts
+++ b/src/__tests__/property-mermaid-source-and-parser.test.ts
@@ -1,0 +1,265 @@
+import { describe, expect, it } from 'bun:test'
+import fc from 'fast-check'
+
+import { mergeMermaidConfigs, normalizeMermaidSource, type MermaidRuntimeConfig } from '../mermaid-source.ts'
+import { parseMermaid } from '../parser.ts'
+import type { MermaidGraph, MermaidNode } from '../types.ts'
+
+const PROPERTY_RUNS = 60
+const ID_HEAD = [...'ABCDEFGHIJKLMNOPQRSTUVWXYZ']
+const ID_TAIL = [...'abcdefghijklmnopqrstuvwxyz0123456789-']
+const WORD_CHARS = [...'abcdefghijklmnopqrstuvwxyz']
+
+const idArb = fc
+  .tuple(
+    fc.constantFrom(...ID_HEAD),
+    fc.array(fc.constantFrom(...ID_TAIL), { maxLength: 5 }),
+  )
+  .map(([head, tail]) => `${head}${tail.join('')}`)
+
+const wordArb = fc
+  .array(fc.constantFrom(...WORD_CHARS), { minLength: 1, maxLength: 8 })
+  .map(chars => chars.join(''))
+
+const labelArb = fc
+  .array(wordArb, { minLength: 1, maxLength: 3 })
+  .map(parts => parts.join(' '))
+
+const nodeShapeArb = fc.constantFrom<'rectangle' | 'rounded' | 'diamond'>('rectangle', 'rounded', 'diamond')
+
+const nodeDefArb = fc.record({
+  id: idArb,
+  label: labelArb,
+  shape: nodeShapeArb,
+})
+
+const runtimeConfigArb = fc.record({
+  theme: fc.option(fc.constantFrom('dark', 'forest', 'neutral'), { nil: undefined }),
+  fontFamily: fc.option(fc.constantFrom('Fira Code', 'IBM Plex Mono', 'Menlo'), { nil: undefined }),
+  primaryTextColor: fc.option(fc.constantFrom('#111111', '#fafafa', '#0ea5e9'), { nil: undefined }),
+  disableMulticolor: fc.option(fc.boolean(), { nil: undefined }),
+})
+
+function renderNodeDefinition(node: { id: string; label: string; shape: 'rectangle' | 'rounded' | 'diamond' }): string {
+  if (node.shape === 'rounded') return `${node.id}(${node.label})`
+  if (node.shape === 'diamond') return `${node.id}{${node.label}}`
+  return `${node.id}[${node.label}]`
+}
+
+function normalizeGraph(graph: MermaidGraph): Record<string, unknown> {
+  return {
+    direction: graph.direction,
+    nodes: [...graph.nodes.values()].map(node => ({
+      id: node.id,
+      label: node.label,
+      shape: node.shape,
+    })),
+    edges: graph.edges.map(edge => ({
+      source: edge.source,
+      target: edge.target,
+      label: edge.label,
+      style: edge.style,
+      hasArrowStart: edge.hasArrowStart,
+      hasArrowEnd: edge.hasArrowEnd,
+    })),
+    subgraphs: graph.subgraphs.map(subgraph => ({
+      id: subgraph.id,
+      label: subgraph.label,
+      nodeIds: [...subgraph.nodeIds],
+      direction: subgraph.direction,
+      children: subgraph.children.map(child => ({
+        id: child.id,
+        label: child.label,
+        nodeIds: [...child.nodeIds],
+      })),
+    })),
+    classDefs: [...graph.classDefs.entries()].sort(([a], [b]) => a.localeCompare(b)),
+    classAssignments: [...graph.classAssignments.entries()].sort(([a], [b]) => a.localeCompare(b)),
+    nodeStyles: [...graph.nodeStyles.entries()].sort(([a], [b]) => a.localeCompare(b)),
+    linkStyles: [...graph.linkStyles.entries()].sort(([a], [b]) => String(a).localeCompare(String(b))),
+  }
+}
+
+function addWhitespaceAndComments(source: string): string {
+  return source
+    .split('\n')
+    .flatMap((line, index, lines) => {
+      const padded = index % 2 === 0 ? `  ${line}  ` : `\t${line}\t`
+      if (index === lines.length - 1) return [padded]
+      return [padded, index % 2 === 0 ? '' : `%% ignored ${index}`]
+    })
+    .join('\n')
+}
+
+function makeRuntimeConfig(input: {
+  theme?: string
+  fontFamily?: string
+  primaryTextColor?: string
+  disableMulticolor?: boolean
+}): MermaidRuntimeConfig {
+  const config: MermaidRuntimeConfig = {}
+  if (input.theme) config.theme = input.theme
+  if (input.fontFamily) config.fontFamily = input.fontFamily
+  if (input.primaryTextColor) config.themeVariables = { primaryTextColor: input.primaryTextColor }
+  if (input.disableMulticolor !== undefined) config.timeline = { disableMulticolor: input.disableMulticolor }
+  return config
+}
+
+function yamlLinesForConfig(config: MermaidRuntimeConfig): string[] {
+  const lines: string[] = []
+  if (config.theme) lines.push(`theme: "${config.theme}"`)
+  if (config.fontFamily) lines.push(`fontFamily: "${config.fontFamily}"`)
+  if (config.themeVariables?.primaryTextColor) {
+    lines.push('themeVariables:')
+    lines.push(`  primaryTextColor: "${config.themeVariables.primaryTextColor}"`)
+  }
+  if (config.timeline?.disableMulticolor !== undefined) {
+    lines.push('timeline:')
+    lines.push(`  disableMulticolor: ${config.timeline.disableMulticolor}`)
+  }
+  return lines
+}
+
+describe('property-based mermaid source normalization', () => {
+  it('merges base config, frontmatter, and init directives while preserving body lines', () => {
+    const configArb = fc.record({
+      base: runtimeConfigArb,
+      frontmatter: runtimeConfigArb,
+      directive: runtimeConfigArb,
+    })
+
+    fc.assert(
+      fc.property(configArb, ({ base, frontmatter, directive }) => {
+        const baseConfig = makeRuntimeConfig(base)
+        const frontmatterConfig = makeRuntimeConfig(frontmatter)
+        const directiveConfig = makeRuntimeConfig(directive)
+
+        const sourceLines: string[] = []
+        const frontmatterLines = yamlLinesForConfig(frontmatterConfig)
+        if (frontmatterLines.length > 0) {
+          sourceLines.push('---', ...frontmatterLines, '---')
+        }
+
+        const directiveJson = JSON.stringify(directiveConfig)
+        if (directiveJson !== '{}') {
+          sourceLines.push(`%%{init: ${directiveJson}}%%`)
+        }
+
+        sourceLines.push('%% comment')
+        sourceLines.push('graph TD')
+        sourceLines.push('A --> B')
+
+        const normalized = normalizeMermaidSource(sourceLines.join('\n'), baseConfig)
+
+        expect(normalized.text).toBe('graph TD\nA --> B')
+        expect(normalized.lines).toEqual(['graph TD', 'A --> B'])
+        expect(normalized.config).toEqual(
+          mergeMermaidConfigs(baseConfig, frontmatterConfig, directiveConfig),
+        )
+      }),
+      { numRuns: PROPERTY_RUNS },
+    )
+  })
+})
+
+describe('property-based parseMermaid', () => {
+  it('is invariant to blank lines, comments, and surrounding whitespace', () => {
+    const graphArb = fc
+      .uniqueArray(nodeDefArb, { minLength: 2, maxLength: 5, selector: node => node.id })
+      .chain(nodes =>
+        fc.record({
+          nodes: fc.constant(nodes),
+          edges: fc.uniqueArray(
+            fc.record({
+              from: fc.constantFrom(...nodes.map(node => node.id)),
+              to: fc.constantFrom(...nodes.map(node => node.id)),
+              label: fc.option(labelArb, { nil: undefined }),
+            }).filter(edge => edge.from !== edge.to),
+            {
+              minLength: 1,
+              maxLength: Math.min(6, nodes.length * (nodes.length - 1)),
+              selector: edge => `${edge.from}->${edge.to}:${edge.label ?? ''}`,
+            },
+          ),
+        }),
+      )
+
+    fc.assert(
+      fc.property(graphArb, ({ nodes, edges }) => {
+        const source = [
+          'graph TD',
+          ...nodes.map(renderNodeDefinition),
+          ...edges.map(edge => `${edge.from} -->${edge.label ? `|${edge.label}|` : ''} ${edge.to}`),
+        ].join('\n')
+
+        expect(normalizeGraph(parseMermaid(addWhitespaceAndComments(source)))).toEqual(
+          normalizeGraph(parseMermaid(source)),
+        )
+      }),
+      { numRuns: PROPERTY_RUNS },
+    )
+  })
+
+  it('materializes the Cartesian product for parallel link groups', () => {
+    const parallelArb = fc.record({
+      left: fc.uniqueArray(idArb, { minLength: 1, maxLength: 3 }),
+      right: fc.uniqueArray(idArb, { minLength: 1, maxLength: 3 }),
+    }).filter(({ left, right }) => left.every(id => !right.includes(id)))
+
+    fc.assert(
+      fc.property(parallelArb, ({ left, right }) => {
+        const source = `graph TD\n${left.join(' & ')} --> ${right.join(' & ')}`
+        const graph = parseMermaid(source)
+        const edgePairs = new Set(graph.edges.map(edge => `${edge.source}->${edge.target}`))
+
+        expect(graph.edges).toHaveLength(left.length * right.length)
+        for (const from of left) {
+          for (const to of right) {
+            expect(edgePairs.has(`${from}->${to}`)).toBe(true)
+          }
+        }
+      }),
+      { numRuns: PROPERTY_RUNS },
+    )
+  })
+
+  it('always produces edges whose endpoints exist as nodes', () => {
+    const graphArb = fc
+      .uniqueArray(nodeDefArb, { minLength: 2, maxLength: 5, selector: node => node.id })
+      .chain(nodes =>
+        fc.record({
+          nodes: fc.constant(nodes),
+          edges: fc.uniqueArray(
+            fc.record({
+              from: fc.constantFrom(...nodes.map(node => node.id)),
+              to: fc.constantFrom(...nodes.map(node => node.id)),
+              label: fc.option(labelArb, { nil: undefined }),
+            }),
+            {
+              minLength: 1,
+              maxLength: 6,
+              selector: edge => `${edge.from}->${edge.to}:${edge.label ?? ''}`,
+            },
+          ),
+        }),
+      )
+
+    fc.assert(
+      fc.property(graphArb, ({ nodes, edges }) => {
+        const source = [
+          'graph TD',
+          ...nodes.map(renderNodeDefinition),
+          ...edges.map(edge => `${edge.from} -->${edge.label ? `|${edge.label}|` : ''} ${edge.to}`),
+        ].join('\n')
+
+        const graph = parseMermaid(source)
+
+        for (const edge of graph.edges) {
+          expect(graph.nodes.has(edge.source)).toBe(true)
+          expect(graph.nodes.has(edge.target)).toBe(true)
+        }
+      }),
+      { numRuns: PROPERTY_RUNS },
+    )
+  })
+})

--- a/src/__tests__/property-xychart.test.ts
+++ b/src/__tests__/property-xychart.test.ts
@@ -1,0 +1,170 @@
+import { describe, expect, it } from 'bun:test'
+import fc from 'fast-check'
+
+import { layoutXYChart } from '../xychart/layout.ts'
+import { parseXYChart } from '../xychart/parser.ts'
+
+const PROPERTY_RUNS = 50
+const WORD_CHARS = [...'abcdefghijklmnopqrstuvwxyz']
+
+const wordArb = fc
+  .array(fc.constantFrom(...WORD_CHARS), { minLength: 1, maxLength: 8 })
+  .map(chars => chars.join(''))
+
+const categoryLabelArb = fc
+  .array(wordArb, { minLength: 1, maxLength: 2 })
+  .map(parts => parts.join(' '))
+
+const numberArb = fc.integer({ min: -30, max: 90 })
+
+function toLines(source: string): string[] {
+  return source
+    .split('\n')
+    .map(line => line.trim())
+    .filter(line => line.length > 0 && !line.startsWith('%%'))
+}
+
+function renderCategories(labels: string[]): string {
+  return labels.join(', ')
+}
+
+function renderSeriesLine(type: 'bar' | 'line', values: number[]): string {
+  return `${type} [${values.join(', ')}]`
+}
+
+function expectInsidePlotArea(
+  plotArea: { x: number; y: number; width: number; height: number },
+  rect: { x: number; y: number; width: number; height: number },
+): void {
+  expect(Number.isFinite(rect.x)).toBe(true)
+  expect(Number.isFinite(rect.y)).toBe(true)
+  expect(Number.isFinite(rect.width)).toBe(true)
+  expect(Number.isFinite(rect.height)).toBe(true)
+  expect(rect.x >= plotArea.x - 0.0001).toBe(true)
+  expect(rect.y >= plotArea.y - 0.0001).toBe(true)
+  expect(rect.x + rect.width <= plotArea.x + plotArea.width + 0.0001).toBe(true)
+  expect(rect.y + rect.height <= plotArea.y + plotArea.height + 0.0001).toBe(true)
+}
+
+describe('property-based xychart parsing', () => {
+  it('preserves category labels and per-series data', () => {
+    const chartArb = fc.uniqueArray(categoryLabelArb, { minLength: 1, maxLength: 5 }).chain(labels =>
+      fc.record({
+        labels: fc.constant(labels),
+        barValues: fc.array(numberArb, { minLength: labels.length, maxLength: labels.length }),
+        lineValues: fc.array(numberArb, { minLength: labels.length, maxLength: labels.length }),
+      }),
+    )
+
+    fc.assert(
+      fc.property(chartArb, ({ labels, barValues, lineValues }) => {
+        const lines = toLines([
+          'xychart-beta',
+          `x-axis [${renderCategories(labels)}]`,
+          renderSeriesLine('bar', barValues),
+          renderSeriesLine('line', lineValues),
+        ].join('\n'))
+
+        const chart = parseXYChart(lines)
+
+        expect(chart.xAxis.categories).toEqual(labels)
+        expect(chart.series[0]!.data).toEqual(barValues)
+        expect(chart.series[1]!.data).toEqual(lineValues)
+      }),
+      { numRuns: PROPERTY_RUNS },
+    )
+  })
+
+  it('derives a y-axis range that always contains all data values', () => {
+    const chartArb = fc.integer({ min: 1, max: 5 }).chain(length =>
+      fc.record({
+        labels: fc.array(categoryLabelArb, { minLength: length, maxLength: length }),
+        series: fc.array(
+          fc.record({
+            type: fc.constantFrom<'bar' | 'line'>('bar', 'line'),
+            values: fc.array(numberArb, { minLength: length, maxLength: length }),
+          }),
+          { minLength: 1, maxLength: 3 },
+        ),
+      }),
+    )
+
+    fc.assert(
+      fc.property(chartArb, ({ labels, series }) => {
+        const lines = toLines([
+          'xychart-beta',
+          `x-axis [${renderCategories(labels)}]`,
+          ...series.map(entry => renderSeriesLine(entry.type, entry.values)),
+        ].join('\n'))
+
+        const chart = parseXYChart(lines)
+        const allValues = series.flatMap(entry => entry.values)
+
+        expect(chart.yAxis.range).toBeDefined()
+        expect(chart.yAxis.range!.min <= Math.min(...allValues)).toBe(true)
+        expect(chart.yAxis.range!.max >= Math.max(...allValues)).toBe(true)
+      }),
+      { numRuns: PROPERTY_RUNS },
+    )
+  })
+})
+
+describe('property-based xychart layout', () => {
+  it('keeps bars, points, and axes inside the plot area for vertical and horizontal charts', () => {
+    const layoutArb = fc.integer({ min: 1, max: 5 }).chain(length =>
+      fc.record({
+        orientation: fc.constantFrom<'horizontal' | 'vertical'>('horizontal', 'vertical'),
+        labels: fc.uniqueArray(categoryLabelArb, { minLength: length, maxLength: length }),
+        barValues: fc.array(numberArb, { minLength: length, maxLength: length }),
+        lineValues: fc.array(numberArb, { minLength: length, maxLength: length }),
+      }),
+    ).filter(({ barValues }) => barValues.some(value => value >= 0))
+
+    fc.assert(
+      fc.property(layoutArb, ({ orientation, labels, barValues, lineValues }) => {
+        const header = orientation === 'horizontal' ? 'xychart-beta horizontal' : 'xychart-beta'
+        const chart = parseXYChart(toLines([
+          header,
+          `x-axis [${renderCategories(labels)}]`,
+          renderSeriesLine('bar', barValues),
+          renderSeriesLine('line', lineValues),
+        ].join('\n')))
+
+        const positioned = layoutXYChart(chart)
+
+        expect(positioned.width > 0).toBe(true)
+        expect(positioned.height > 0).toBe(true)
+        expect(positioned.plotArea.width > 0).toBe(true)
+        expect(positioned.plotArea.height > 0).toBe(true)
+
+        for (const bar of positioned.bars) {
+          expectInsidePlotArea(positioned.plotArea, bar)
+        }
+
+        for (const line of positioned.lines) {
+          for (const point of line.points) {
+            expect(point.x >= positioned.plotArea.x - 0.0001).toBe(true)
+            expect(point.x <= positioned.plotArea.x + positioned.plotArea.width + 0.0001).toBe(true)
+            expect(point.y >= positioned.plotArea.y - 0.0001).toBe(true)
+            expect(point.y <= positioned.plotArea.y + positioned.plotArea.height + 0.0001).toBe(true)
+          }
+        }
+
+        for (const tick of positioned.xAxis.ticks) {
+          expect(Number.isFinite(tick.x)).toBe(true)
+          expect(Number.isFinite(tick.y)).toBe(true)
+          expect(Number.isFinite(tick.labelX)).toBe(true)
+          expect(Number.isFinite(tick.labelY)).toBe(true)
+        }
+
+        for (const tick of positioned.yAxis.ticks) {
+          expect(Number.isFinite(tick.x)).toBe(true)
+          expect(Number.isFinite(tick.y)).toBe(true)
+          expect(Number.isFinite(tick.labelX)).toBe(true)
+          expect(Number.isFinite(tick.labelY)).toBe(true)
+        }
+      }),
+      { numRuns: PROPERTY_RUNS },
+    )
+  })
+})


### PR DESCRIPTION
## What

Add a focused property-based testing layer for Mermaid source normalization, flowchart parsing, ASCII routing, diagram-family parsers, and xychart parsing/layout.

## Why

The existing suite is strong on example-driven coverage, but several core paths still benefit from invariant-style testing across many small generated inputs. This PR adds that randomized coverage without changing implementation code or broadening supported feature scope.

There is no linked issue for this branch; this is a test-depth improvement PR.

## How

- add `fast-check` as a dev dependency
- add property tests for ASCII pathfinding/routing invariants and diagonal-free flowchart rendering
- add property tests for Mermaid source normalization, parser whitespace/comment tolerance, edge endpoint validity, and parallel-link expansion
- add property tests for sequence, timeline, and class parser sanity invariants
- add property tests for xychart parsing and layout containment on the current `main` feature set

## Testing

- [x] New/modified tests pass
- [x] Full test suite passes (no regressions)
- [x] Build passes
- [x] Regression guard spot-check completed

Commands run:

- `bun test src/__tests__/property-ascii-routing.test.ts src/__tests__/property-diagram-parsers.test.ts src/__tests__/property-mermaid-source-and-parser.test.ts src/__tests__/property-xychart.test.ts`
- `bun test src/__tests__/`
- `npm run build`

Regression guard:

- in a temporary worktree, intentionally mutated `src/ascii/pathfinder.ts` to ignore occupied cells during routing
- confirmed `src/__tests__/property-ascii-routing.test.ts` then failed with a shrunk counterexample, proving the new obstacle-avoidance property is meaningful

## Risk

Low. This is a test-only change plus one dev dependency. The main residual risk is test flakiness, but the properties were kept small and deterministic enough to pass consistently in focused and full-suite runs.
