### PR TITLE
Add journey diagram support across SVG and ASCII renderers

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ The ASCII rendering engine is based on [mermaid-ascii](https://github.com/Alexan
 
 ## Features
 
-- **7 diagram types** — Flowcharts, State, Sequence, Class, ER, Timeline, and XY Charts (bar, line, combined)
+- **8 diagram types** — Flowcharts, State, Sequence, Class, ER, Timeline, User Journey, and XY Charts (bar, line, combined)
 - **Dual output** — SVG for rich UIs, ASCII/Unicode for terminals
 - **Synchronous rendering** — No async, no flash. Works with React `useMemo()`
 - **15 built-in themes** — And dead simple to add your own
@@ -370,6 +370,20 @@ timeline
   2006 : Twitter
 ```
 
+### User Journey Diagrams
+
+Scored user tasks grouped into sections — using Mermaid's `journey` syntax.
+
+```
+journey
+  title My working day
+  section Go to work
+    Make tea: 5: Me
+    Go upstairs: 3: Me
+  section Workday
+    Do work: 1: Me, Cat
+```
+
 ### Inline Edge Styling
 
 Use `linkStyle` to override edge colors and stroke widths — just like [Mermaid's linkStyle](https://mermaid.js.org/syntax/flowchart.html#styling-links):
@@ -597,7 +611,7 @@ Render a Mermaid diagram to SVG. Synchronous. Auto-detects diagram type.
 | `interactive` | `boolean` | `false` | Enable hover tooltips on XY chart bars and data points |
 | `mermaidConfig` | `MermaidRuntimeConfig` | — | Optional Mermaid-style config merged with frontmatter and `%%{init}` / `%%{initialize}` directives |
 
-**Timeline + XY Charts:** Diagrams starting with `timeline`, `xychart`, or `xychart-beta` are auto-detected — no separate function needed. For xychart, the `accent` color option drives the series palette unless Mermaid config provides `plotColorPalette`, and Mermaid `xyChart.width` / `height` are treated as total chart dimensions, matching Mermaid's own renderer.
+**Timeline + Journey + XY Charts:** Diagrams starting with `timeline`, `journey`, `xychart`, or `xychart-beta` are auto-detected — no separate function needed. For xychart, the `accent` color option drives the series palette unless Mermaid config provides `plotColorPalette`, and Mermaid `xyChart.width` / `height` are treated as total chart dimensions, matching Mermaid's own renderer.
 
 ### `renderMermaidSVGAsync(text, options?): Promise<string>`
 

--- a/README.md
+++ b/README.md
@@ -384,6 +384,20 @@ journey
     Do work: 1: Me, Cat
 ```
 
+Official Mermaid docs example:
+
+```
+journey
+  title My working day
+  section Go to work
+    Make tea: 5: Me
+    Go upstairs: 3: Me
+    Do work: 1: Me, Cat
+  section Go home
+    Go downstairs: 5: Me
+    Sit down: 3: Me
+```
+
 ### Inline Edge Styling
 
 Use `linkStyle` to override edge colors and stroke widths — just like [Mermaid's linkStyle](https://mermaid.js.org/syntax/flowchart.html#styling-links):

--- a/README.md
+++ b/README.md
@@ -373,6 +373,9 @@ timeline
 ### User Journey Diagrams
 
 Scored user tasks grouped into sections — using Mermaid's `journey` syntax.
+Supports Mermaid accessibility directives `accTitle:` and `accDescr:` as SVG
+metadata, including multiline `accDescr { ... }` blocks. Design note:
+[`journey-design.md`](./journey-design.md).
 
 ```
 journey

--- a/index.ts
+++ b/index.ts
@@ -105,6 +105,7 @@ async function generateHtml(): Promise<string> {
     Sequence: '#10b981',
     Class: '#f59e0b',
     ER: '#ef4444',
+    Journey: '#14b8a6',
     'XY Chart': '#f97316',
     'Theme Showcase': '#06b6d4',
   }
@@ -115,6 +116,7 @@ async function generateHtml(): Promise<string> {
     'Sequence': 'Sequence: ',
     'Class': 'Class: ',
     'ER': 'ER: ',
+    'Journey': 'Journey: ',
     'XY Chart': 'XY: ',
     'Theme Showcase': 'Theme: ',
   }

--- a/journey-design.md
+++ b/journey-design.md
@@ -1,0 +1,83 @@
+# User Journey (`journey`) Design Note
+
+## Overview
+
+This document captures the design choices behind Beautiful Mermaid's `journey`
+implementation. The goal is Mermaid syntax compatibility with output that still
+feels native to the rest of the library rather than like a separate embedded
+renderer.
+
+The implementation follows the standard Beautiful Mermaid pipeline:
+
+- `src/journey/parser.ts`
+- `src/journey/layout.ts`
+- `src/journey/renderer.ts`
+- `src/ascii/journey.ts`
+
+## Input Model
+
+Supported Mermaid constructs:
+
+- `journey`
+- `title ...`
+- `section ...`
+- scored tasks in the form `Task: 1..5[: Actor, Actor]`
+- `accTitle: ...`
+- `accDescr: ...`
+- multiline `accDescr { ... }`
+- Mermaid comments, frontmatter, and init directives before the header
+
+Quoted labels are normalized the same way other Beautiful Mermaid diagram
+parsers normalize Mermaid labels. `<br>` is converted to multi-line text for
+titles, section labels, tasks, actor labels, and accessibility metadata.
+
+## Layout Strategy
+
+Journey diagrams are rendered as horizontally arranged sections with vertically
+stacked task cards:
+
+- each section becomes a fixed column
+- named sections get a framed container and header band
+- unnamed implicit sections stay unframed so a single unsectioned task list
+  does not look artificially boxed
+- each task card reserves space for:
+  - the task label
+  - a five-cell score meter
+  - an optional row of actor pills
+
+The layout uses the shared text measurement helpers so card widths and heights
+expand from content rather than from hardcoded label assumptions.
+
+## Visual Language
+
+The renderer intentionally borrows existing Beautiful Mermaid cues:
+
+- crisp rectangular section frames, similar to timeline/class/ER grouping
+- subtle accent rails instead of full-card fills for task emphasis
+- compact metadata presentation so actor labels and score state read quickly
+- theme-driven colors via shared CSS custom properties instead of renderer-local
+  color constants
+
+This keeps the diagram family distinct from flowcharts while still matching the
+library's spacing, contrast, and restraint.
+
+## Accessibility
+
+`accTitle` and `accDescr` are surfaced as root SVG accessibility metadata:
+
+- root SVG gets `role="img"`
+- root SVG gets `aria-roledescription="user journey"`
+- `accTitle` maps to `<title>` and `aria-labelledby`
+- `accDescr` maps to `<desc>` and `aria-describedby`
+- when `accTitle` is absent, the visible Mermaid `title` becomes the fallback
+  accessible title
+
+Accessibility metadata is intentionally non-visual. It improves assistive
+technology output without changing the rendered diagram layout.
+
+## Known Boundaries
+
+- Journey support currently models Mermaid's scored-task syntax, not richer
+  swimlane semantics beyond section grouping.
+- Accessibility metadata is surfaced in SVG output; ASCII output ignores it,
+  because it is not part of the visible terminal rendering model.

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "class-diagram",
     "er-diagram",
     "timeline-diagram",
+    "journey-diagram",
     "xychart",
     "state-diagram",
     "visualization",

--- a/samples-data.ts
+++ b/samples-data.ts
@@ -1231,8 +1231,10 @@ export const samples: Sample[] = [
   {
     title: 'Journey: My Working Day',
     category: 'Journey',
-    description: 'Scored tasks grouped into sections with actor tags.',
+    description: 'Scored tasks grouped into sections with actor tags and accessibility metadata.',
     source: `journey
+    accTitle: My working day journey
+    accDescr: A compact user journey showing commute and workday tasks
     title My working day
     section Go to work
       Make tea: 5: Me

--- a/samples-data.ts
+++ b/samples-data.ts
@@ -1225,6 +1225,24 @@ export const samples: Sample[] = [
   },
 
   // ══════════════════════════════════════════════════════════════════════════
+  //  USER JOURNEYS
+  // ══════════════════════════════════════════════════════════════════════════
+
+  {
+    title: 'Journey: My Working Day',
+    category: 'Journey',
+    description: 'Scored tasks grouped into sections with actor tags.',
+    source: `journey
+    title My working day
+    section Go to work
+      Make tea: 5: Me
+      Go upstairs: 3: Me
+    section Workday
+      Do work: 1: Me, Cat
+      Review PRs: 4: Me, Team`,
+  },
+
+  // ══════════════════════════════════════════════════════════════════════════
   //  XY CHARTS (xychart-beta)
   // ══════════════════════════════════════════════════════════════════════════
 

--- a/samples-data.ts
+++ b/samples-data.ts
@@ -1241,6 +1241,20 @@ export const samples: Sample[] = [
       Do work: 1: Me, Cat
       Review PRs: 4: Me, Team`,
   },
+  {
+    title: 'Journey: Mermaid Docs Example',
+    category: 'Journey',
+    description: 'Official Mermaid user journey example, matching the docs structure and scoring pattern.',
+    source: `journey
+    title My working day
+    section Go to work
+      Make tea: 5: Me
+      Go upstairs: 3: Me
+      Do work: 1: Me, Cat
+    section Go home
+      Go downstairs: 5: Me
+      Sit down: 3: Me`,
+  },
 
   // ══════════════════════════════════════════════════════════════════════════
   //  XY CHARTS (xychart-beta)

--- a/src/__tests__/journey-ascii.test.ts
+++ b/src/__tests__/journey-ascii.test.ts
@@ -1,0 +1,51 @@
+/**
+ * Tests for journey ASCII rendering.
+ */
+import { describe, it, expect } from 'bun:test'
+import { renderMermaidASCII } from '../ascii/index.ts'
+
+function render(text: string, useAscii = false): string {
+  return renderMermaidASCII(text, { colorMode: 'none', useAscii })
+}
+
+describe('journey ASCII', () => {
+  it('renders a basic journey with title, section, score, and actors', () => {
+    const result = render(`journey
+      title My working day
+      section Go to work
+      Make tea: 5: Me`)
+
+    expect(result).toContain('My working day')
+    expect(result).toContain('[Go to work]')
+    expect(result).toContain('●●●●● Make tea')
+    expect(result).toContain('by Me')
+  })
+
+  it('renders multiple actors', () => {
+    const result = render(`journey
+      section Work
+      Ship feature: 4: Me, QA`)
+
+    expect(result).toContain('●●●●○ Ship feature')
+    expect(result).toContain('by Me, QA')
+  })
+
+  it('uses ASCII-safe glyphs in ASCII mode', () => {
+    const result = render(`journey
+      section Work
+      Deep work: 3: Me`, true)
+
+    expect(result).toContain('###.. Deep work')
+    expect(result).not.toContain('●')
+    expect(result).not.toContain('○')
+  })
+
+  it('renders multiline task text on subsequent indented lines', () => {
+    const result = render(`journey
+      section Work
+      Make<br>tea: 5: Me`)
+
+    expect(result).toContain('Make')
+    expect(result).toContain('tea')
+  })
+})

--- a/src/__tests__/journey-ascii.test.ts
+++ b/src/__tests__/journey-ascii.test.ts
@@ -4,8 +4,8 @@
 import { describe, it, expect } from 'bun:test'
 import { renderMermaidASCII } from '../ascii/index.ts'
 
-function render(text: string, useAscii = false): string {
-  return renderMermaidASCII(text, { colorMode: 'none', useAscii })
+function render(text: string, options: Parameters<typeof renderMermaidASCII>[1] = {}): string {
+  return renderMermaidASCII(text, { colorMode: 'none', ...options })
 }
 
 describe('journey ASCII', () => {
@@ -33,7 +33,7 @@ describe('journey ASCII', () => {
   it('uses ASCII-safe glyphs in ASCII mode', () => {
     const result = render(`journey
       section Work
-      Deep work: 3: Me`, true)
+      Deep work: 3: Me`, { useAscii: true })
 
     expect(result).toContain('###.. Deep work')
     expect(result).not.toContain('●')
@@ -47,5 +47,33 @@ describe('journey ASCII', () => {
 
     expect(result).toContain('Make')
     expect(result).toContain('tea')
+  })
+
+  it('supports themed HTML output and escapes labels safely', () => {
+    const result = render(`journey
+      title Roadmap < 2025
+      section Phase <1>
+      Ship <alpha>: 3: Me, QA <Lead>`, {
+      colorMode: 'html',
+      theme: {
+        fg: '#101010',
+        border: '#202020',
+        line: '#303030',
+        arrow: '#404040',
+        junction: '#505050',
+        corner: '#606060',
+      },
+    })
+
+    expect(result).toContain('<span style="color:#101010">Roadmap</span>')
+    expect(result).toContain('<span style="color:#101010">&lt;</span>')
+    expect(result).toContain('<span style="color:#202020">[</span>')
+    expect(result).toContain('<span style="color:#101010">Phase</span>')
+    expect(result).toContain('<span style="color:#202020">]</span>')
+    expect(result).toContain('<span style="color:#404040">●●●</span>')
+    expect(result).toContain('<span style="color:#202020">○○</span>')
+    expect(result).toContain('<span style="color:#202020">by</span>')
+    expect(result).toContain('<span style="color:#101010">&lt;Lead&gt;</span>')
+    expect(result).not.toContain('QA <Lead>')
   })
 })

--- a/src/__tests__/journey-ascii.test.ts
+++ b/src/__tests__/journey-ascii.test.ts
@@ -30,6 +30,21 @@ describe('journey ASCII', () => {
     expect(result).toContain('by Me, QA')
   })
 
+  it('supports journey routing through frontmatter and Mermaid init directives', () => {
+    const result = render(`---
+      title: Journey sample
+      config:
+        theme: dark
+      ---
+      %%{init: {'theme': 'base'}}%%
+      journey
+      section Work
+      Deep work: 3: Me`)
+
+    expect(result).toContain('[Work]')
+    expect(result).toContain('●●●○○ Deep work')
+  })
+
   it('uses ASCII-safe glyphs in ASCII mode', () => {
     const result = render(`journey
       section Work

--- a/src/__tests__/journey-integration.test.ts
+++ b/src/__tests__/journey-integration.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Integration tests for journey diagrams — end-to-end parse → layout → render.
+ */
+import { describe, it, expect } from 'bun:test'
+import { renderMermaidSVG } from '../index.ts'
+import type { RenderOptions } from '../types.ts'
+
+function render(text: string, options: RenderOptions = {}): string {
+  return renderMermaidSVG(text, options)
+}
+
+describe('renderMermaidSVG – journey diagrams', () => {
+  it('renders a basic user journey to valid SVG', () => {
+    const svg = render(`journey
+      title My working day
+      section Go to work
+      Make tea: 5: Me
+      Go upstairs: 3: Me`)
+
+    expect(svg).toContain('<svg')
+    expect(svg).toContain('</svg>')
+    expect(svg).toContain('My working day')
+    expect(svg).toContain('class="journey-section"')
+    expect(svg).toContain('class="journey-task"')
+    expect(svg).toContain('class="journey-score-cell-filled"')
+    expect(svg).toContain('class="journey-actor-pill"')
+  })
+
+  it('emits semantic data attributes for section, score, and actors', () => {
+    const svg = render(`journey
+      section Go to work
+      Make tea: 5: Me, Cat`)
+
+    expect(svg).toContain('data-label="Go to work"')
+    expect(svg).toContain('data-score="5"')
+    expect(svg).toContain('data-actors="Me, Cat"')
+    expect(svg).toContain('data-actor="Me"')
+    expect(svg).toContain('data-actor="Cat"')
+  })
+
+  it('renders the correct number of filled and empty score cells', () => {
+    const svg = render(`journey
+      section Work
+      Do work: 3: Me`)
+
+    const filledCount = (svg.match(/class="journey-score-cell-filled"/g) ?? []).length
+    const emptyCount = (svg.match(/class="journey-score-cell-empty"/g) ?? []).length
+    expect(filledCount).toBe(3)
+    expect(emptyCount).toBe(2)
+  })
+
+  it('renders multiline labels with tspans', () => {
+    const svg = render(`journey
+      title Product<br>journey
+      section Go<br>to work
+      Make<br>tea: 5: Me`)
+
+    expect(svg).toContain('<tspan')
+    expect(svg).toContain('Product')
+    expect(svg).toContain('journey')
+    expect(svg).toContain('Make')
+    expect(svg).toContain('tea')
+  })
+
+  it('supports CSS variable colors without NaN output', () => {
+    const svg = render(`journey
+      section Work
+      Deep work: 4: Me`, {
+      bg: 'var(--background)',
+      fg: 'var(--foreground)',
+      accent: 'var(--accent)',
+    })
+
+    expect(svg).toContain('--bg:var(--background)')
+    expect(svg).toContain('--fg:var(--foreground)')
+    expect(svg).not.toContain('NaN')
+  })
+})

--- a/src/__tests__/journey-integration.test.ts
+++ b/src/__tests__/journey-integration.test.ts
@@ -42,6 +42,35 @@ describe('renderMermaidSVG – journey diagrams', () => {
     expect(svg).toContain('Make tea')
   })
 
+  it('surfaces accTitle and accDescr as SVG accessibility metadata', () => {
+    const svg = render(`journey
+      accTitle: Working day accessibility title
+      accDescr {
+        A compact summary
+        of the working day journey
+      }
+      title My working day
+      section Go to work
+      Make tea: 5: Me`)
+
+    expect(svg).toContain('role="img"')
+    expect(svg).toContain('aria-roledescription="user journey"')
+    expect(svg).toContain('aria-labelledby="journey-a11y-title"')
+    expect(svg).toContain('aria-describedby="journey-a11y-desc"')
+    expect(svg).toContain('<title id="journey-a11y-title">Working day accessibility title</title>')
+    expect(svg).toContain('<desc id="journey-a11y-desc">A compact summary')
+  })
+
+  it('falls back to the visible title for accessibility metadata when accTitle is absent', () => {
+    const svg = render(`journey
+      title My working day
+      section Go to work
+      Make tea: 5: Me`)
+
+    expect(svg).toContain('aria-labelledby="journey-a11y-title"')
+    expect(svg).toContain('<title id="journey-a11y-title">My working day</title>')
+  })
+
   it('emits semantic data attributes for section, score, and actors', () => {
     const svg = render(`journey
       section Go to work

--- a/src/__tests__/journey-integration.test.ts
+++ b/src/__tests__/journey-integration.test.ts
@@ -26,6 +26,22 @@ describe('renderMermaidSVG – journey diagrams', () => {
     expect(svg).toContain('class="journey-actor-pill"')
   })
 
+  it('routes journey diagrams through frontmatter and Mermaid init directives', () => {
+    const svg = render(`---
+      title: Journey sample
+      config:
+        theme: dark
+      ---
+      %%{init: {'theme': 'base'}}%%
+      journey
+      section Go to work
+      Make tea: 5: Me`)
+
+    expect(svg).toContain('<svg')
+    expect(svg).toContain('class="journey-task"')
+    expect(svg).toContain('Make tea')
+  })
+
   it('emits semantic data attributes for section, score, and actors', () => {
     const svg = render(`journey
       section Go to work

--- a/src/__tests__/journey-layout.test.ts
+++ b/src/__tests__/journey-layout.test.ts
@@ -1,0 +1,70 @@
+/**
+ * Direct layout invariants for journey diagrams.
+ */
+import { describe, it, expect } from 'bun:test'
+import { preprocessMermaidLines } from '../mermaid-source.ts'
+import { parseJourneyDiagram } from '../journey/parser.ts'
+import { layoutJourneyDiagram } from '../journey/layout.ts'
+
+function layout(text: string) {
+  const parsed = parseJourneyDiagram(preprocessMermaidLines(text))
+  return layoutJourneyDiagram(parsed)
+}
+
+describe('layoutJourneyDiagram', () => {
+  it('places named sections side by side without overlap', () => {
+    const diagram = layout(`journey
+      title My working day
+      section Go to work
+      Make tea: 5: Me
+      Go upstairs: 3: Me
+      section Go home
+      Go downstairs: 5: Me`)
+
+    expect(diagram.sections).toHaveLength(2)
+    const first = diagram.sections[0]!
+    const second = diagram.sections[1]!
+
+    expect(first.framed).toBe(true)
+    expect(second.framed).toBe(true)
+    expect(first.headerHeight).toBeGreaterThan(0)
+    expect(first.x + first.width).toBeLessThan(second.x)
+    expect(first.y).toBe(second.y)
+  })
+
+  it('keeps score cells and actor pills inside each task card', () => {
+    const diagram = layout(`journey
+      section Work
+      Prototype<br>review: 3: Design, Eng
+      Ship: 5: Eng, QA`)
+
+    const task = diagram.sections[0]!.tasks[0]!
+
+    for (const cell of task.scoreCells) {
+      expect(cell.x).toBeGreaterThanOrEqual(task.x)
+      expect(cell.y).toBeGreaterThanOrEqual(task.y)
+      expect(cell.x + cell.size).toBeLessThanOrEqual(task.x + task.width)
+      expect(cell.y + cell.size).toBeLessThanOrEqual(task.y + task.height)
+    }
+
+    for (const pill of task.actorPills) {
+      expect(pill.x).toBeGreaterThanOrEqual(task.x)
+      expect(pill.y).toBeGreaterThanOrEqual(task.y)
+      expect(pill.x + pill.width).toBeLessThanOrEqual(task.x + task.width)
+      expect(pill.y + pill.height).toBeLessThanOrEqual(task.y + task.height)
+    }
+  })
+
+  it('leaves a single implicit section unframed while stacking tasks top-to-bottom', () => {
+    const diagram = layout(`journey
+      Wake up: 3: Me
+      Make coffee: 5: Me`)
+
+    expect(diagram.sections).toHaveLength(1)
+    const section = diagram.sections[0]!
+
+    expect(section.framed).toBe(false)
+    expect(section.headerHeight).toBe(0)
+    expect(section.tasks[0]!.y + section.tasks[0]!.height).toBeLessThan(section.tasks[1]!.y)
+  })
+})

--- a/src/__tests__/journey-parser.test.ts
+++ b/src/__tests__/journey-parser.test.ts
@@ -2,14 +2,15 @@
  * Tests for the journey diagram parser.
  *
  * Covers: title, sections, implicit sections, actor parsing, <br> handling,
- * optional actor lists, and invalid scores.
+ * comments/directives/frontmatter preprocessing, optional actor lists, and
+ * invalid scores.
  */
 import { describe, it, expect } from 'bun:test'
+import { preprocessMermaidLines } from '../mermaid-source.ts'
 import { parseJourneyDiagram } from '../journey/parser.ts'
 
 function parse(text: string) {
-  const lines = text.split('\n').map(l => l.trim()).filter(l => l.length > 0 && !l.startsWith('%%'))
-  return parseJourneyDiagram(lines)
+  return parseJourneyDiagram(preprocessMermaidLines(text))
 }
 
 describe('parseJourneyDiagram', () => {
@@ -57,6 +58,36 @@ describe('parseJourneyDiagram', () => {
     expect(diagram.sections[0]!.label).toBe('Go\nto work')
     expect(diagram.sections[0]!.tasks[0]!.text).toBe('Make\ntea')
     expect(diagram.sections[0]!.tasks[0]!.actors).toEqual(['Me / Team'])
+  })
+
+  it('normalizes quoted labels the same way Mermaid labels are normalized elsewhere', () => {
+    const diagram = parse(`journey
+      title "My working day"
+      section "Go to work"
+      "Make tea": 5: "Me"`)
+
+    expect(diagram.title).toBe('My working day')
+    expect(diagram.sections[0]!.label).toBe('Go to work')
+    expect(diagram.sections[0]!.tasks[0]!.text).toBe('Make tea')
+    expect(diagram.sections[0]!.tasks[0]!.actors).toEqual(['Me'])
+  })
+
+  it('ignores Mermaid comments, frontmatter, and init directives before the journey header', () => {
+    const diagram = parse(`---
+      title: Journey sample
+      config:
+        theme: dark
+      ---
+      %%{init: {'theme': 'base'}}%%
+      %% comment before header
+      journey
+      %% comment inside body
+      section Go to work
+      Make tea: 5: Me`)
+
+    expect(diagram.sections).toHaveLength(1)
+    expect(diagram.sections[0]!.label).toBe('Go to work')
+    expect(diagram.sections[0]!.tasks[0]!.text).toBe('Make tea')
   })
 
   it('allows tasks without actor lists', () => {

--- a/src/__tests__/journey-parser.test.ts
+++ b/src/__tests__/journey-parser.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Tests for the journey diagram parser.
+ *
+ * Covers: title, sections, implicit sections, actor parsing, <br> handling,
+ * optional actor lists, and invalid scores.
+ */
+import { describe, it, expect } from 'bun:test'
+import { parseJourneyDiagram } from '../journey/parser.ts'
+
+function parse(text: string) {
+  const lines = text.split('\n').map(l => l.trim()).filter(l => l.length > 0 && !l.startsWith('%%'))
+  return parseJourneyDiagram(lines)
+}
+
+describe('parseJourneyDiagram', () => {
+  it('parses a basic journey with title, section, score, and actors', () => {
+    const diagram = parse(`journey
+      title My working day
+      section Go to work
+      Make tea: 5: Me`)
+
+    expect(diagram.title).toBe('My working day')
+    expect(diagram.sections).toHaveLength(1)
+    expect(diagram.sections[0]!.label).toBe('Go to work')
+    expect(diagram.sections[0]!.tasks[0]!.text).toBe('Make tea')
+    expect(diagram.sections[0]!.tasks[0]!.score).toBe(5)
+    expect(diagram.sections[0]!.tasks[0]!.actors).toEqual(['Me'])
+  })
+
+  it('creates an implicit section for tasks before the first section', () => {
+    const diagram = parse(`journey
+      Wake up: 3: Me
+      section Morning
+      Make coffee: 5: Me`)
+
+    expect(diagram.sections).toHaveLength(2)
+    expect(diagram.sections[0]!.label).toBeUndefined()
+    expect(diagram.sections[0]!.tasks[0]!.text).toBe('Wake up')
+    expect(diagram.sections[1]!.label).toBe('Morning')
+  })
+
+  it('parses and trims multiple actors', () => {
+    const diagram = parse(`journey
+      section Work
+      Ship feature: 4: Me, Design, QA`)
+
+    expect(diagram.sections[0]!.tasks[0]!.actors).toEqual(['Me', 'Design', 'QA'])
+  })
+
+  it('normalizes <br> tags in title, sections, tasks, and actors', () => {
+    const diagram = parse(`journey
+      title Product<br>journey
+      section Go<br>to work
+      Make<br>tea: 5: Me<br>Team`)
+
+    expect(diagram.title).toBe('Product\njourney')
+    expect(diagram.sections[0]!.label).toBe('Go\nto work')
+    expect(diagram.sections[0]!.tasks[0]!.text).toBe('Make\ntea')
+    expect(diagram.sections[0]!.tasks[0]!.actors).toEqual(['Me / Team'])
+  })
+
+  it('allows tasks without actor lists', () => {
+    const diagram = parse(`journey
+      section Solo
+      Deep work: 4`)
+
+    expect(diagram.sections[0]!.tasks[0]!.actors).toEqual([])
+  })
+
+  it('throws on scores outside the 1..5 range', () => {
+    expect(() => parse(`journey
+      section Work
+      Do work: 6: Me`)).toThrow('invalid score 6')
+  })
+
+  it('throws when the diagram has no tasks', () => {
+    expect(() => parse(`journey
+      title Empty`)).toThrow('Journey diagram must include at least one scored task')
+  })
+})

--- a/src/__tests__/journey-parser.test.ts
+++ b/src/__tests__/journey-parser.test.ts
@@ -60,6 +60,29 @@ describe('parseJourneyDiagram', () => {
     expect(diagram.sections[0]!.tasks[0]!.actors).toEqual(['Me / Team'])
   })
 
+  it('parses accessibility title and single-line description', () => {
+    const diagram = parse(`journey
+      accTitle: Working day accessibility title
+      accDescr: A compact summary of the working day journey
+      section Go to work
+      Make tea: 5: Me`)
+
+    expect(diagram.accessibilityTitle).toBe('Working day accessibility title')
+    expect(diagram.accessibilityDescription).toBe('A compact summary of the working day journey')
+  })
+
+  it('parses multiline accDescr blocks', () => {
+    const diagram = parse(`journey
+      accDescr {
+        A compact summary
+        of the working day journey
+      }
+      section Go to work
+      Make tea: 5: Me`)
+
+    expect(diagram.accessibilityDescription).toBe('A compact summary\nof the working day journey')
+  })
+
   it('normalizes quoted labels the same way Mermaid labels are normalized elsewhere', () => {
     const diagram = parse(`journey
       title "My working day"
@@ -102,6 +125,14 @@ describe('parseJourneyDiagram', () => {
     expect(() => parse(`journey
       section Work
       Do work: 6: Me`)).toThrow('invalid score 6')
+  })
+
+  it('throws when an accDescr block is not closed', () => {
+    expect(() => parse(`journey
+      accDescr {
+        Missing closing brace
+      section Work
+      Do work: 3: Me`)).toThrow('missing a closing "}"')
   })
 
   it('throws when the diagram has no tasks', () => {

--- a/src/__tests__/journey-svg-snapshot.test.ts
+++ b/src/__tests__/journey-svg-snapshot.test.ts
@@ -1,0 +1,34 @@
+/**
+ * Golden-file regression test for journey SVG rendering.
+ */
+import { describe, it, expect } from 'bun:test'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { renderMermaidSVG } from '../index.ts'
+
+const snapshotDir = join(import.meta.dir, 'testdata', 'svg')
+
+function normalizeSvg(svg: string): string {
+  return svg
+    .replaceAll('\r\n', '\n')
+    .split('\n')
+    .map(line => line.trimEnd())
+    .join('\n')
+    .trim()
+}
+
+describe('renderMermaidSVG – journey snapshots', () => {
+  it('matches the representative journey golden SVG', () => {
+    const actual = renderMermaidSVG(`journey
+      title Product journey
+      section Discover
+      Interview users: 4: PM, Research
+      section Deliver
+      Prototype<br>review: 3: Design, Eng
+      Ship: 5: Eng, QA`)
+
+    const expected = readFileSync(join(snapshotDir, 'journey-representative.svg'), 'utf-8')
+
+    expect(normalizeSvg(actual)).toBe(normalizeSvg(expected))
+  })
+})

--- a/src/__tests__/journey-svg-snapshot.test.ts
+++ b/src/__tests__/journey-svg-snapshot.test.ts
@@ -31,4 +31,20 @@ describe('renderMermaidSVG – journey snapshots', () => {
 
     expect(normalizeSvg(actual)).toBe(normalizeSvg(expected))
   })
+
+  it('matches the Mermaid docs journey example SVG', () => {
+    const actual = renderMermaidSVG(`journey
+      title My working day
+      section Go to work
+      Make tea: 5: Me
+      Go upstairs: 3: Me
+      Do work: 1: Me, Cat
+      section Go home
+      Go downstairs: 5: Me
+      Sit down: 3: Me`)
+
+    const expected = readFileSync(join(snapshotDir, 'journey-mermaid-docs-example.svg'), 'utf-8')
+
+    expect(normalizeSvg(actual)).toBe(normalizeSvg(expected))
+  })
 })

--- a/src/__tests__/journey-theme.test.ts
+++ b/src/__tests__/journey-theme.test.ts
@@ -1,0 +1,38 @@
+/**
+ * Journey-specific theme coverage for built-in light and dark palettes.
+ */
+import { describe, it, expect } from 'bun:test'
+import { renderMermaidSVG } from '../index.ts'
+import { THEMES } from '../theme.ts'
+
+const source = `journey
+  title My working day
+  section Go to work
+  Make tea: 5: Me
+  Go upstairs: 3: Me
+  section Go home
+  Sit down: 3: Me`
+
+describe('renderMermaidSVG – journey themes', () => {
+  it('renders correctly with the built-in light theme palette', () => {
+    const svg = renderMermaidSVG(source, THEMES['github-light'])
+
+    expect(svg).toContain('--bg:#ffffff')
+    expect(svg).toContain('--fg:#1f2328')
+    expect(svg).toContain('--accent:#0969da')
+    expect(svg).toContain('--line:#d1d9e0')
+    expect(svg).toContain('class="journey-task-card"')
+    expect(svg).not.toContain('NaN')
+  })
+
+  it('renders correctly with the built-in dark theme palette', () => {
+    const svg = renderMermaidSVG(source, THEMES['github-dark'])
+
+    expect(svg).toContain('--bg:#0d1117')
+    expect(svg).toContain('--fg:#e6edf3')
+    expect(svg).toContain('--accent:#4493f8')
+    expect(svg).toContain('--line:#3d444d')
+    expect(svg).toContain('class="journey-task-card"')
+    expect(svg).not.toContain('NaN')
+  })
+})

--- a/src/__tests__/testdata/svg/journey-mermaid-docs-example.svg
+++ b/src/__tests__/testdata/svg/journey-mermaid-docs-example.svg
@@ -1,4 +1,5 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 604 446.6" width="604" height="446.6" style="--bg:#FFFFFF;--fg:#27272A;background:var(--bg)">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 604 446.6" width="604" height="446.6" style="--bg:#FFFFFF;--fg:#27272A;background:var(--bg)" role="img" aria-roledescription="user journey" aria-labelledby="journey-a11y-title">
+<title id="journey-a11y-title">My working day</title>
 <style>
   @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&amp;display=swap');
   text { font-family: 'Inter', system-ui, sans-serif; }

--- a/src/__tests__/testdata/svg/journey-mermaid-docs-example.svg
+++ b/src/__tests__/testdata/svg/journey-mermaid-docs-example.svg
@@ -1,0 +1,119 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 604 446.6" width="604" height="446.6" style="--bg:#FFFFFF;--fg:#27272A;background:var(--bg)">
+<style>
+  @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&amp;display=swap');
+  text { font-family: 'Inter', system-ui, sans-serif; }
+  svg {
+    /* Derived from --bg and --fg (overridable via --line, --accent, etc.) */
+    --_text:          var(--fg);
+    --_text-sec:      var(--muted, color-mix(in srgb, var(--fg) 60%, var(--bg)));
+    --_text-muted:    var(--muted, color-mix(in srgb, var(--fg) 40%, var(--bg)));
+    --_text-faint:    color-mix(in srgb, var(--fg) 25%, var(--bg));
+    --_line:          var(--line, color-mix(in srgb, var(--fg) 50%, var(--bg)));
+    --_arrow:         var(--accent, color-mix(in srgb, var(--fg) 85%, var(--bg)));
+    --_node-fill:     var(--surface, color-mix(in srgb, var(--fg) 3%, var(--bg)));
+    --_node-stroke:   var(--border, color-mix(in srgb, var(--fg) 20%, var(--bg)));
+    --_group-fill:    var(--bg);
+    --_group-hdr:     color-mix(in srgb, var(--fg) 5%, var(--bg));
+    --_inner-stroke:  color-mix(in srgb, var(--fg) 12%, var(--bg));
+    --_key-badge:     color-mix(in srgb, var(--fg) 10%, var(--bg));
+  }
+</style>
+<style>
+  .journey-title { fill: var(--_text); }
+  .journey-section-bg { fill: color-mix(in srgb, var(--_node-fill) 88%, var(--bg)); stroke: var(--_node-stroke); stroke-width: 1; }
+  .journey-section-band { fill: color-mix(in srgb, var(--_arrow) 8%, var(--bg)); stroke: var(--_node-stroke); stroke-width: 1; }
+  .journey-section-label { fill: var(--_text-sec); }
+  .journey-task-card { fill: var(--_node-fill); stroke: var(--_node-stroke); stroke-width: 1; }
+  .journey-task-accent { fill: color-mix(in srgb, var(--_arrow) 18%, var(--bg)); }
+  .journey-task-text { fill: var(--_text); }
+  .journey-score-cell-filled { fill: var(--_arrow); stroke: var(--_arrow); stroke-width: 1; }
+  .journey-score-cell-empty { fill: color-mix(in srgb, var(--bg) 55%, var(--_node-fill)); stroke: color-mix(in srgb, var(--_node-stroke) 82%, var(--bg)); stroke-width: 1; }
+  .journey-actor-pill { fill: color-mix(in srgb, var(--_arrow) 8%, var(--bg)); stroke: color-mix(in srgb, var(--_arrow) 22%, var(--bg)); stroke-width: 1; }
+  .journey-actor-text { fill: var(--_text-sec); }
+</style>
+<g class="journey-section" data-id="section-0" data-label="Go to work">
+  <rect class="journey-section-bg" x="32" y="75.4" width="256" height="343.20000000000005" rx="0" ry="0" />
+  <rect class="journey-section-band" x="32" y="75.4" width="256" height="27.6" rx="0" ry="0" />
+  <text x="44" y="89.2" class="journey-section-label" text-anchor="start" font-size="12" font-weight="600" dy="4.199999999999999">Go to work</text>
+</g>
+<g class="journey-section" data-id="section-1" data-label="Go home">
+  <rect class="journey-section-bg" x="316" y="75.4" width="256" height="250" rx="0" ry="0" />
+  <rect class="journey-section-band" x="316" y="75.4" width="256" height="27.6" rx="0" ry="0" />
+  <text x="328" y="89.2" class="journey-section-label" text-anchor="start" font-size="12" font-weight="600" dy="4.199999999999999">Go home</text>
+</g>
+<g class="journey-task" data-id="task-0" data-score="5" data-section="Go to work" data-actors="Me">
+  <rect class="journey-task-card" x="50" y="135" width="220" height="79.2" rx="0" ry="0" />
+  <rect class="journey-task-accent" x="50" y="135" width="4" height="79.2" rx="0" ry="0" />
+  <text x="68" y="155.45" class="journey-task-text" text-anchor="start" font-size="13" font-weight="500" dy="4.55">Make tea</text>
+  <rect class="journey-score-cell-filled" x="186" y="150.45" width="10" height="10" rx="2" ry="2" />
+  <rect class="journey-score-cell-filled" x="201" y="150.45" width="10" height="10" rx="2" ry="2" />
+  <rect class="journey-score-cell-filled" x="216" y="150.45" width="10" height="10" rx="2" ry="2" />
+  <rect class="journey-score-cell-filled" x="231" y="150.45" width="10" height="10" rx="2" ry="2" />
+  <rect class="journey-score-cell-filled" x="246" y="150.45" width="10" height="10" rx="2" ry="2" />
+  <g class="journey-actor" data-actor="Me">
+    <rect class="journey-actor-pill" x="68" y="175.9" width="44" height="26.3" rx="13.15" ry="13.15" />
+    <text x="90" y="189.05" class="journey-actor-text" text-anchor="middle" font-size="11" font-weight="600" dy="3.8499999999999996">Me</text>
+  </g>
+</g>
+<g class="journey-task" data-id="task-1" data-score="3" data-section="Go to work" data-actors="Me">
+  <rect class="journey-task-card" x="50" y="228.2" width="220" height="79.2" rx="0" ry="0" />
+  <rect class="journey-task-accent" x="50" y="228.2" width="4" height="79.2" rx="0" ry="0" />
+  <text x="68" y="248.64999999999998" class="journey-task-text" text-anchor="start" font-size="13" font-weight="500" dy="4.55">Go upstairs</text>
+  <rect class="journey-score-cell-filled" x="186" y="243.64999999999998" width="10" height="10" rx="2" ry="2" />
+  <rect class="journey-score-cell-filled" x="201" y="243.64999999999998" width="10" height="10" rx="2" ry="2" />
+  <rect class="journey-score-cell-filled" x="216" y="243.64999999999998" width="10" height="10" rx="2" ry="2" />
+  <rect class="journey-score-cell-empty" x="231" y="243.64999999999998" width="10" height="10" rx="2" ry="2" />
+  <rect class="journey-score-cell-empty" x="246" y="243.64999999999998" width="10" height="10" rx="2" ry="2" />
+  <g class="journey-actor" data-actor="Me">
+    <rect class="journey-actor-pill" x="68" y="269.09999999999997" width="44" height="26.3" rx="13.15" ry="13.15" />
+    <text x="90" y="282.24999999999994" class="journey-actor-text" text-anchor="middle" font-size="11" font-weight="600" dy="3.8499999999999996">Me</text>
+  </g>
+</g>
+<g class="journey-task" data-id="task-2" data-score="1" data-section="Go to work" data-actors="Me, Cat">
+  <rect class="journey-task-card" x="50" y="321.4" width="220" height="79.2" rx="0" ry="0" />
+  <rect class="journey-task-accent" x="50" y="321.4" width="4" height="79.2" rx="0" ry="0" />
+  <text x="68" y="341.84999999999997" class="journey-task-text" text-anchor="start" font-size="13" font-weight="500" dy="4.55">Do work</text>
+  <rect class="journey-score-cell-filled" x="186" y="336.84999999999997" width="10" height="10" rx="2" ry="2" />
+  <rect class="journey-score-cell-empty" x="201" y="336.84999999999997" width="10" height="10" rx="2" ry="2" />
+  <rect class="journey-score-cell-empty" x="216" y="336.84999999999997" width="10" height="10" rx="2" ry="2" />
+  <rect class="journey-score-cell-empty" x="231" y="336.84999999999997" width="10" height="10" rx="2" ry="2" />
+  <rect class="journey-score-cell-empty" x="246" y="336.84999999999997" width="10" height="10" rx="2" ry="2" />
+  <g class="journey-actor" data-actor="Me">
+    <rect class="journey-actor-pill" x="68" y="362.29999999999995" width="44" height="26.3" rx="13.15" ry="13.15" />
+    <text x="90" y="375.44999999999993" class="journey-actor-text" text-anchor="middle" font-size="11" font-weight="600" dy="3.8499999999999996">Me</text>
+  </g>
+  <g class="journey-actor" data-actor="Cat">
+    <rect class="journey-actor-pill" x="118" y="362.29999999999995" width="44" height="26.3" rx="13.15" ry="13.15" />
+    <text x="140" y="375.44999999999993" class="journey-actor-text" text-anchor="middle" font-size="11" font-weight="600" dy="3.8499999999999996">Cat</text>
+  </g>
+</g>
+<g class="journey-task" data-id="task-3" data-score="5" data-section="Go home" data-actors="Me">
+  <rect class="journey-task-card" x="334" y="135" width="220" height="79.2" rx="0" ry="0" />
+  <rect class="journey-task-accent" x="334" y="135" width="4" height="79.2" rx="0" ry="0" />
+  <text x="352" y="155.45" class="journey-task-text" text-anchor="start" font-size="13" font-weight="500" dy="4.55">Go downstairs</text>
+  <rect class="journey-score-cell-filled" x="470" y="150.45" width="10" height="10" rx="2" ry="2" />
+  <rect class="journey-score-cell-filled" x="485" y="150.45" width="10" height="10" rx="2" ry="2" />
+  <rect class="journey-score-cell-filled" x="500" y="150.45" width="10" height="10" rx="2" ry="2" />
+  <rect class="journey-score-cell-filled" x="515" y="150.45" width="10" height="10" rx="2" ry="2" />
+  <rect class="journey-score-cell-filled" x="530" y="150.45" width="10" height="10" rx="2" ry="2" />
+  <g class="journey-actor" data-actor="Me">
+    <rect class="journey-actor-pill" x="352" y="175.9" width="44" height="26.3" rx="13.15" ry="13.15" />
+    <text x="374" y="189.05" class="journey-actor-text" text-anchor="middle" font-size="11" font-weight="600" dy="3.8499999999999996">Me</text>
+  </g>
+</g>
+<g class="journey-task" data-id="task-4" data-score="3" data-section="Go home" data-actors="Me">
+  <rect class="journey-task-card" x="334" y="228.2" width="220" height="79.2" rx="0" ry="0" />
+  <rect class="journey-task-accent" x="334" y="228.2" width="4" height="79.2" rx="0" ry="0" />
+  <text x="352" y="248.64999999999998" class="journey-task-text" text-anchor="start" font-size="13" font-weight="500" dy="4.55">Sit down</text>
+  <rect class="journey-score-cell-filled" x="470" y="243.64999999999998" width="10" height="10" rx="2" ry="2" />
+  <rect class="journey-score-cell-filled" x="485" y="243.64999999999998" width="10" height="10" rx="2" ry="2" />
+  <rect class="journey-score-cell-filled" x="500" y="243.64999999999998" width="10" height="10" rx="2" ry="2" />
+  <rect class="journey-score-cell-empty" x="515" y="243.64999999999998" width="10" height="10" rx="2" ry="2" />
+  <rect class="journey-score-cell-empty" x="530" y="243.64999999999998" width="10" height="10" rx="2" ry="2" />
+  <g class="journey-actor" data-actor="Me">
+    <rect class="journey-actor-pill" x="352" y="269.09999999999997" width="44" height="26.3" rx="13.15" ry="13.15" />
+    <text x="374" y="282.24999999999994" class="journey-actor-text" text-anchor="middle" font-size="11" font-weight="600" dy="3.8499999999999996">Me</text>
+  </g>
+</g>
+<text x="302" y="39.7" class="journey-title" text-anchor="middle" font-size="18" font-weight="600" dy="6.3">My working day</text>
+</svg>

--- a/src/__tests__/testdata/svg/journey-representative.svg
+++ b/src/__tests__/testdata/svg/journey-representative.svg
@@ -1,4 +1,5 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 604 370.29999999999995" width="604" height="370.29999999999995" style="--bg:#FFFFFF;--fg:#27272A;background:var(--bg)">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 604 370.29999999999995" width="604" height="370.29999999999995" style="--bg:#FFFFFF;--fg:#27272A;background:var(--bg)" role="img" aria-roledescription="user journey" aria-labelledby="journey-a11y-title">
+<title id="journey-a11y-title">Product journey</title>
 <style>
   @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&amp;display=swap');
   text { font-family: 'Inter', system-ui, sans-serif; }

--- a/src/__tests__/testdata/svg/journey-representative.svg
+++ b/src/__tests__/testdata/svg/journey-representative.svg
@@ -1,0 +1,99 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 604 370.29999999999995" width="604" height="370.29999999999995" style="--bg:#FFFFFF;--fg:#27272A;background:var(--bg)">
+<style>
+  @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&amp;display=swap');
+  text { font-family: 'Inter', system-ui, sans-serif; }
+  svg {
+    /* Derived from --bg and --fg (overridable via --line, --accent, etc.) */
+    --_text:          var(--fg);
+    --_text-sec:      var(--muted, color-mix(in srgb, var(--fg) 60%, var(--bg)));
+    --_text-muted:    var(--muted, color-mix(in srgb, var(--fg) 40%, var(--bg)));
+    --_text-faint:    color-mix(in srgb, var(--fg) 25%, var(--bg));
+    --_line:          var(--line, color-mix(in srgb, var(--fg) 50%, var(--bg)));
+    --_arrow:         var(--accent, color-mix(in srgb, var(--fg) 85%, var(--bg)));
+    --_node-fill:     var(--surface, color-mix(in srgb, var(--fg) 3%, var(--bg)));
+    --_node-stroke:   var(--border, color-mix(in srgb, var(--fg) 20%, var(--bg)));
+    --_group-fill:    var(--bg);
+    --_group-hdr:     color-mix(in srgb, var(--fg) 5%, var(--bg));
+    --_inner-stroke:  color-mix(in srgb, var(--fg) 12%, var(--bg));
+    --_key-badge:     color-mix(in srgb, var(--fg) 10%, var(--bg));
+  }
+</style>
+<style>
+  .journey-title { fill: var(--_text); }
+  .journey-section-bg { fill: color-mix(in srgb, var(--_node-fill) 88%, var(--bg)); stroke: var(--_node-stroke); stroke-width: 1; }
+  .journey-section-band { fill: color-mix(in srgb, var(--_arrow) 8%, var(--bg)); stroke: var(--_node-stroke); stroke-width: 1; }
+  .journey-section-label { fill: var(--_text-sec); }
+  .journey-task-card { fill: var(--_node-fill); stroke: var(--_node-stroke); stroke-width: 1; }
+  .journey-task-accent { fill: color-mix(in srgb, var(--_arrow) 18%, var(--bg)); }
+  .journey-task-text { fill: var(--_text); }
+  .journey-score-cell-filled { fill: var(--_arrow); stroke: var(--_arrow); stroke-width: 1; }
+  .journey-score-cell-empty { fill: color-mix(in srgb, var(--bg) 55%, var(--_node-fill)); stroke: color-mix(in srgb, var(--_node-stroke) 82%, var(--bg)); stroke-width: 1; }
+  .journey-actor-pill { fill: color-mix(in srgb, var(--_arrow) 8%, var(--bg)); stroke: color-mix(in srgb, var(--_arrow) 22%, var(--bg)); stroke-width: 1; }
+  .journey-actor-text { fill: var(--_text-sec); }
+</style>
+<g class="journey-section" data-id="section-0" data-label="Discover">
+  <rect class="journey-section-bg" x="32" y="75.4" width="256" height="156.8" rx="0" ry="0" />
+  <rect class="journey-section-band" x="32" y="75.4" width="256" height="27.6" rx="0" ry="0" />
+  <text x="44" y="89.2" class="journey-section-label" text-anchor="start" font-size="12" font-weight="600" dy="4.199999999999999">Discover</text>
+</g>
+<g class="journey-section" data-id="section-1" data-label="Deliver">
+  <rect class="journey-section-bg" x="316" y="75.4" width="256" height="266.9" rx="0" ry="0" />
+  <rect class="journey-section-band" x="316" y="75.4" width="256" height="27.6" rx="0" ry="0" />
+  <text x="328" y="89.2" class="journey-section-label" text-anchor="start" font-size="12" font-weight="600" dy="4.199999999999999">Deliver</text>
+</g>
+<g class="journey-task" data-id="task-0" data-score="4" data-section="Discover" data-actors="PM, Research">
+  <rect class="journey-task-card" x="50" y="135" width="220" height="79.2" rx="0" ry="0" />
+  <rect class="journey-task-accent" x="50" y="135" width="4" height="79.2" rx="0" ry="0" />
+  <text x="68" y="155.45" class="journey-task-text" text-anchor="start" font-size="13" font-weight="500" dy="4.55">Interview users</text>
+  <rect class="journey-score-cell-filled" x="186" y="150.45" width="10" height="10" rx="2" ry="2" />
+  <rect class="journey-score-cell-filled" x="201" y="150.45" width="10" height="10" rx="2" ry="2" />
+  <rect class="journey-score-cell-filled" x="216" y="150.45" width="10" height="10" rx="2" ry="2" />
+  <rect class="journey-score-cell-filled" x="231" y="150.45" width="10" height="10" rx="2" ry="2" />
+  <rect class="journey-score-cell-empty" x="246" y="150.45" width="10" height="10" rx="2" ry="2" />
+  <g class="journey-actor" data-actor="PM">
+    <rect class="journey-actor-pill" x="68" y="175.9" width="44" height="26.3" rx="13.15" ry="13.15" />
+    <text x="90" y="189.05" class="journey-actor-text" text-anchor="middle" font-size="11" font-weight="600" dy="3.8499999999999996">PM</text>
+  </g>
+  <g class="journey-actor" data-actor="Research">
+    <rect class="journey-actor-pill" x="118" y="175.9" width="70.44999999999999" height="26.3" rx="13.15" ry="13.15" />
+    <text x="153.225" y="189.05" class="journey-actor-text" text-anchor="middle" font-size="11" font-weight="600" dy="3.8499999999999996">Research</text>
+  </g>
+</g>
+<g class="journey-task" data-id="task-1" data-score="3" data-section="Deliver" data-actors="Design, Eng">
+  <rect class="journey-task-card" x="334" y="135" width="220" height="96.1" rx="0" ry="0" />
+  <rect class="journey-task-accent" x="334" y="135" width="4" height="96.1" rx="0" ry="0" />
+  <text x="352" y="163.9" class="journey-task-text" text-anchor="start" font-size="13" font-weight="500"><tspan x="352" dy="-3.9000000000000012">Prototype</tspan><tspan x="352" dy="16.900000000000002">review</tspan></text>
+  <rect class="journey-score-cell-filled" x="470" y="158.9" width="10" height="10" rx="2" ry="2" />
+  <rect class="journey-score-cell-filled" x="485" y="158.9" width="10" height="10" rx="2" ry="2" />
+  <rect class="journey-score-cell-filled" x="500" y="158.9" width="10" height="10" rx="2" ry="2" />
+  <rect class="journey-score-cell-empty" x="515" y="158.9" width="10" height="10" rx="2" ry="2" />
+  <rect class="journey-score-cell-empty" x="530" y="158.9" width="10" height="10" rx="2" ry="2" />
+  <g class="journey-actor" data-actor="Design">
+    <rect class="journey-actor-pill" x="352" y="192.8" width="54.60999999999999" height="26.3" rx="13.15" ry="13.15" />
+    <text x="379.305" y="205.95000000000002" class="journey-actor-text" text-anchor="middle" font-size="11" font-weight="600" dy="3.8499999999999996">Design</text>
+  </g>
+  <g class="journey-actor" data-actor="Eng">
+    <rect class="journey-actor-pill" x="412.61" y="192.8" width="44" height="26.3" rx="13.15" ry="13.15" />
+    <text x="434.61" y="205.95000000000002" class="journey-actor-text" text-anchor="middle" font-size="11" font-weight="600" dy="3.8499999999999996">Eng</text>
+  </g>
+</g>
+<g class="journey-task" data-id="task-2" data-score="5" data-section="Deliver" data-actors="Eng, QA">
+  <rect class="journey-task-card" x="334" y="245.1" width="220" height="79.2" rx="0" ry="0" />
+  <rect class="journey-task-accent" x="334" y="245.1" width="4" height="79.2" rx="0" ry="0" />
+  <text x="352" y="265.55" class="journey-task-text" text-anchor="start" font-size="13" font-weight="500" dy="4.55">Ship</text>
+  <rect class="journey-score-cell-filled" x="470" y="260.55" width="10" height="10" rx="2" ry="2" />
+  <rect class="journey-score-cell-filled" x="485" y="260.55" width="10" height="10" rx="2" ry="2" />
+  <rect class="journey-score-cell-filled" x="500" y="260.55" width="10" height="10" rx="2" ry="2" />
+  <rect class="journey-score-cell-filled" x="515" y="260.55" width="10" height="10" rx="2" ry="2" />
+  <rect class="journey-score-cell-filled" x="530" y="260.55" width="10" height="10" rx="2" ry="2" />
+  <g class="journey-actor" data-actor="Eng">
+    <rect class="journey-actor-pill" x="352" y="286" width="44" height="26.3" rx="13.15" ry="13.15" />
+    <text x="374" y="299.15" class="journey-actor-text" text-anchor="middle" font-size="11" font-weight="600" dy="3.8499999999999996">Eng</text>
+  </g>
+  <g class="journey-actor" data-actor="QA">
+    <rect class="journey-actor-pill" x="402" y="286" width="44" height="26.3" rx="13.15" ry="13.15" />
+    <text x="424" y="299.15" class="journey-actor-text" text-anchor="middle" font-size="11" font-weight="600" dy="3.8499999999999996">QA</text>
+  </g>
+</g>
+<text x="302" y="39.7" class="journey-title" text-anchor="middle" font-size="18" font-weight="600" dy="6.3">Product journey</text>
+</svg>

--- a/src/ascii/index.ts
+++ b/src/ascii/index.ts
@@ -11,6 +11,7 @@
 //   - Class diagrams (classDiagram) — level-based UML layout
 //   - ER diagrams (erDiagram) — grid layout with crow's foot notation
 //   - Timeline diagrams (timeline) — chronological outline with grouped milestones
+//   - User Journey diagrams (journey) — scored task lists with actor annotations
 //   - XY charts (xychart / xychart-beta)
 //
 // Usage:
@@ -27,6 +28,7 @@ import { renderSequenceAscii } from './sequence.ts'
 import { renderClassAscii } from './class-diagram.ts'
 import { renderErAscii } from './er-diagram.ts'
 import { renderTimelineAscii } from './timeline.ts'
+import { renderJourneyAscii } from './journey.ts'
 import { renderXYChartAscii } from './xychart.ts'
 import { detectColorMode, DEFAULT_ASCII_THEME, diagramColorsToAsciiTheme } from './ansi.ts'
 import type { AsciiConfig, AsciiTheme, ColorMode } from './types.ts'
@@ -67,9 +69,10 @@ export interface AsciiRenderOptions {
  * Detect the diagram type from the mermaid source text.
  * Mirrors the detection logic in src/index.ts for the SVG renderer.
  */
-function detectDiagramType(firstLine: string): 'flowchart' | 'sequence' | 'class' | 'er' | 'timeline' | 'xychart' {
+function detectDiagramType(firstLine: string): 'flowchart' | 'sequence' | 'class' | 'er' | 'timeline' | 'journey' | 'xychart' {
   if (/^xychart(-beta)?\b/.test(firstLine)) return 'xychart'
   if (/^timeline\s*$/.test(firstLine)) return 'timeline'
+  if (/^journey\s*$/.test(firstLine)) return 'journey'
   if (/^sequencediagram\s*$/.test(firstLine)) return 'sequence'
   if (/^classdiagram\s*$/.test(firstLine)) return 'class'
   if (/^erdiagram\s*$/.test(firstLine)) return 'er'
@@ -142,6 +145,9 @@ export function renderMermaidASCII(
 
     case 'timeline':
       return renderTimelineAscii(normalizedSource.lines, config, colorMode, theme)
+
+    case 'journey':
+      return renderJourneyAscii(normalizedSource.text, config, colorMode, theme)
 
     case 'flowchart':
     default: {

--- a/src/ascii/journey.ts
+++ b/src/ascii/journey.ts
@@ -6,12 +6,40 @@
 // ============================================================================
 
 import { parseJourneyDiagram } from '../journey/parser.ts'
-import type { AsciiConfig, AsciiTheme, ColorMode } from './types.ts'
+import { colorizeLine, DEFAULT_ASCII_THEME } from './ansi.ts'
+import type { AsciiConfig, AsciiTheme, CharRole, ColorMode } from './types.ts'
 
-function renderScore(score: number, useAscii: boolean): string {
+interface StyledSegment {
+  text: string
+  role: CharRole | null
+}
+
+function renderStyledLine(
+  segments: StyledSegment[],
+  colorMode: ColorMode,
+  theme: AsciiTheme,
+): string {
+  const chars: string[] = []
+  const roles: (CharRole | null)[] = []
+
+  for (const segment of segments) {
+    for (const char of segment.text) {
+      chars.push(char)
+      roles.push(segment.role)
+    }
+  }
+
+  return colorizeLine(chars, roles, theme, colorMode)
+}
+
+function renderScoreSegments(score: number, useAscii: boolean): StyledSegment[] {
   const filled = useAscii ? '#' : '●'
   const empty = useAscii ? '.' : '○'
-  return filled.repeat(score) + empty.repeat(5 - score)
+
+  return [
+    { text: filled.repeat(score), role: 'arrow' },
+    { text: empty.repeat(5 - score), role: 'border' },
+  ].filter(segment => segment.text.length > 0)
 }
 
 /**
@@ -20,43 +48,65 @@ function renderScore(score: number, useAscii: boolean): string {
 export function renderJourneyAscii(
   text: string,
   config: AsciiConfig,
-  _colorMode?: ColorMode,
-  _theme?: AsciiTheme,
+  colorMode: ColorMode = 'none',
+  theme: AsciiTheme = DEFAULT_ASCII_THEME,
 ): string {
   const lines = text.split('\n').map(l => l.trim()).filter(l => l.length > 0 && !l.startsWith('%%'))
   const diagram = parseJourneyDiagram(lines)
   const useAscii = config.useAscii
   const out: string[] = []
+  const pushLine = (segments: StyledSegment[] = []): void => {
+    out.push(segments.length === 0 ? '' : renderStyledLine(segments, colorMode, theme))
+  }
 
   if (diagram.title) {
-    out.push(...diagram.title.split('\n'))
-    out.push('')
+    for (const line of diagram.title.split('\n')) {
+      pushLine([{ text: line, role: 'text' }])
+    }
+    pushLine()
   }
 
   for (let sectionIndex = 0; sectionIndex < diagram.sections.length; sectionIndex++) {
     const section = diagram.sections[sectionIndex]!
 
     if (section.label) {
-      out.push(`[${section.label.replace(/\n/g, ' / ')}]`)
+      pushLine([
+        { text: '[', role: 'border' },
+        { text: section.label.replace(/\n/g, ' / '), role: 'text' },
+        { text: ']', role: 'border' },
+      ])
     }
 
     for (let taskIndex = 0; taskIndex < section.tasks.length; taskIndex++) {
       const task = section.tasks[taskIndex]!
-      const score = renderScore(task.score, useAscii)
+      const scoreSegments = renderScoreSegments(task.score, useAscii)
+      const scoreWidth = 5
       const taskLines = task.text.split('\n')
 
-      out.push(`${score} ${taskLines[0] ?? ''}`)
+      pushLine([
+        ...scoreSegments,
+        { text: ' ', role: null },
+        { text: taskLines[0] ?? '', role: 'text' },
+      ])
       for (const line of taskLines.slice(1)) {
-        out.push(`${' '.repeat(score.length + 1)} ${line}`)
+        pushLine([
+          { text: `${' '.repeat(scoreWidth + 1)} `, role: null },
+          { text: line, role: 'text' },
+        ])
       }
 
       if (task.actors.length > 0) {
-        out.push(`  by ${task.actors.join(', ')}`)
+        pushLine([
+          { text: '  ', role: null },
+          { text: 'by', role: 'border' },
+          { text: ' ', role: null },
+          { text: task.actors.join(', '), role: 'text' },
+        ])
       }
 
       const moreTasks = taskIndex < section.tasks.length - 1
       const moreSections = sectionIndex < diagram.sections.length - 1
-      if (moreTasks || moreSections) out.push('')
+      if (moreTasks || moreSections) pushLine()
     }
   }
 

--- a/src/ascii/journey.ts
+++ b/src/ascii/journey.ts
@@ -1,0 +1,64 @@
+// ============================================================================
+// ASCII renderer — journey diagrams
+//
+// Renders Mermaid user journeys as compact scored task lists with optional
+// section headings and actor annotations.
+// ============================================================================
+
+import { parseJourneyDiagram } from '../journey/parser.ts'
+import type { AsciiConfig, AsciiTheme, ColorMode } from './types.ts'
+
+function renderScore(score: number, useAscii: boolean): string {
+  const filled = useAscii ? '#' : '●'
+  const empty = useAscii ? '.' : '○'
+  return filled.repeat(score) + empty.repeat(5 - score)
+}
+
+/**
+ * Render a Mermaid journey diagram to ASCII/Unicode text.
+ */
+export function renderJourneyAscii(
+  text: string,
+  config: AsciiConfig,
+  _colorMode?: ColorMode,
+  _theme?: AsciiTheme,
+): string {
+  const lines = text.split('\n').map(l => l.trim()).filter(l => l.length > 0 && !l.startsWith('%%'))
+  const diagram = parseJourneyDiagram(lines)
+  const useAscii = config.useAscii
+  const out: string[] = []
+
+  if (diagram.title) {
+    out.push(...diagram.title.split('\n'))
+    out.push('')
+  }
+
+  for (let sectionIndex = 0; sectionIndex < diagram.sections.length; sectionIndex++) {
+    const section = diagram.sections[sectionIndex]!
+
+    if (section.label) {
+      out.push(`[${section.label.replace(/\n/g, ' / ')}]`)
+    }
+
+    for (let taskIndex = 0; taskIndex < section.tasks.length; taskIndex++) {
+      const task = section.tasks[taskIndex]!
+      const score = renderScore(task.score, useAscii)
+      const taskLines = task.text.split('\n')
+
+      out.push(`${score} ${taskLines[0] ?? ''}`)
+      for (const line of taskLines.slice(1)) {
+        out.push(`${' '.repeat(score.length + 1)} ${line}`)
+      }
+
+      if (task.actors.length > 0) {
+        out.push(`  by ${task.actors.join(', ')}`)
+      }
+
+      const moreTasks = taskIndex < section.tasks.length - 1
+      const moreSections = sectionIndex < diagram.sections.length - 1
+      if (moreTasks || moreSections) out.push('')
+    }
+  }
+
+  return out.join('\n').trimEnd()
+}

--- a/src/ascii/journey.ts
+++ b/src/ascii/journey.ts
@@ -6,6 +6,7 @@
 // ============================================================================
 
 import { parseJourneyDiagram } from '../journey/parser.ts'
+import { preprocessMermaidLines } from '../mermaid-source.ts'
 import { colorizeLine, DEFAULT_ASCII_THEME } from './ansi.ts'
 import type { AsciiConfig, AsciiTheme, CharRole, ColorMode } from './types.ts'
 
@@ -51,7 +52,7 @@ export function renderJourneyAscii(
   colorMode: ColorMode = 'none',
   theme: AsciiTheme = DEFAULT_ASCII_THEME,
 ): string {
-  const lines = text.split('\n').map(l => l.trim()).filter(l => l.length > 0 && !l.startsWith('%%'))
+  const lines = preprocessMermaidLines(text)
   const diagram = parseJourneyDiagram(lines)
   const useAscii = config.useAscii
   const out: string[] = []

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@
 //   - Class diagrams (classDiagram)
 //   - ER diagrams (erDiagram)
 //   - Timeline diagrams (timeline)
+//   - User Journey diagrams (journey)
 //   - XY charts (xychart / xychart-beta)
 //
 // Theming uses CSS custom properties (--bg, --fg, + optional enrichment).
@@ -51,6 +52,9 @@ import { renderErSvg } from './er/renderer.ts'
 import { parseTimelineDiagram } from './timeline/parser.ts'
 import { layoutTimelineDiagram } from './timeline/layout.ts'
 import { renderTimelineSvg } from './timeline/renderer.ts'
+import { parseJourneyDiagram } from './journey/parser.ts'
+import { layoutJourneyDiagram } from './journey/layout.ts'
+import { renderJourneySvg } from './journey/renderer.ts'
 import { parseXYChart } from './xychart/parser.ts'
 import { layoutXYChart } from './xychart/layout.ts'
 import { renderXYChartSvg } from './xychart/renderer.ts'
@@ -59,9 +63,10 @@ import { renderXYChartSvg } from './xychart/renderer.ts'
  * Detect the diagram type from the mermaid source text.
  * Returns the type keyword used for routing to the correct pipeline.
  */
-function detectDiagramType(firstLine: string): 'flowchart' | 'sequence' | 'class' | 'er' | 'timeline' | 'xychart' {
+function detectDiagramType(firstLine: string): 'flowchart' | 'sequence' | 'class' | 'er' | 'timeline' | 'journey' | 'xychart' {
   if (/^xychart(-beta)?\b/.test(firstLine)) return 'xychart'
   if (/^timeline\s*$/.test(firstLine)) return 'timeline'
+  if (/^journey\s*$/.test(firstLine)) return 'journey'
   if (/^sequencediagram\s*$/.test(firstLine)) return 'sequence'
   if (/^classdiagram\s*$/.test(firstLine)) return 'class'
   if (/^erdiagram\s*$/.test(firstLine)) return 'er'
@@ -198,6 +203,11 @@ export function renderMermaidSVG(
         normalizedSource.config.timeline,
         normalizedSource.config.themeVariables,
       )
+    }
+    case 'journey': {
+      const diagram = parseJourneyDiagram(lines)
+      const positioned = layoutJourneyDiagram(diagram, options)
+      return renderJourneySvg(positioned, colors, font, transparent)
     }
     case 'xychart': {
       const chart = parseXYChart(lines, normalizedSource.frontmatter)

--- a/src/journey/layout.ts
+++ b/src/journey/layout.ts
@@ -264,6 +264,8 @@ export function layoutJourneyDiagram(
           y: JY.paddingY + titleMetrics!.height / 2,
         }
       : undefined,
+    accessibilityTitle: diagram.accessibilityTitle,
+    accessibilityDescription: diagram.accessibilityDescription,
     sections,
   }
 }

--- a/src/journey/layout.ts
+++ b/src/journey/layout.ts
@@ -1,0 +1,269 @@
+import type {
+  JourneyDiagram,
+  PositionedJourneyDiagram,
+  PositionedJourneySection,
+  PositionedJourneyTask,
+  PositionedJourneyActorPill,
+  PositionedJourneyScoreCell,
+} from './types.ts'
+import type { RenderOptions } from '../types.ts'
+import { measureMultilineText, measureTextWidth } from '../text-metrics.ts'
+import { stripFormattingTags } from '../multiline-utils.ts'
+
+// ============================================================================
+// Journey diagram layout engine
+//
+// Computes direct coordinates for horizontally arranged sections with stacked
+// task cards, score meters, and actor pills.
+// ============================================================================
+
+const JY = {
+  paddingX: 32,
+  paddingY: 28,
+  titleFontSize: 18,
+  titleFontWeight: 600,
+  titleGap: 24,
+  sectionFontSize: 12,
+  sectionFontWeight: 600,
+  sectionHeaderMinHeight: 24,
+  sectionHeaderPadX: 12,
+  sectionHeaderPadY: 6,
+  sectionHeaderGap: 14,
+  sectionPadX: 18,
+  sectionPadY: 18,
+  sectionGap: 28,
+  taskGap: 14,
+  taskMinWidth: 220,
+  taskFontSize: 13,
+  taskFontWeight: 500,
+  taskPadX: 14,
+  taskPadY: 12,
+  taskToScoreGap: 18,
+  taskAccentWidth: 4,
+  scoreCellSize: 10,
+  scoreCellGap: 5,
+  actorGapTop: 12,
+  actorFontSize: 11,
+  actorFontWeight: 600,
+  actorPadX: 8,
+  actorPadY: 6,
+  actorGapX: 6,
+  actorMinWidth: 44,
+} as const
+
+interface ActorPillMetric {
+  label: string
+  width: number
+  height: number
+}
+
+interface TaskMetric {
+  textWidth: number
+  textHeight: number
+  topAreaHeight: number
+  actorPills: ActorPillMetric[]
+  actorRowWidth: number
+  actorRowHeight: number
+  minWidth: number
+  height: number
+}
+
+interface SectionMetric {
+  headerWidth: number
+  tasks: TaskMetric[]
+  innerWidth: number
+  height: number
+}
+
+const SCORE_TRACK_WIDTH = JY.scoreCellSize * 5 + JY.scoreCellGap * 4
+
+/**
+ * Lay out a parsed journey diagram.
+ */
+export function layoutJourneyDiagram(
+  diagram: JourneyDiagram,
+  _options: RenderOptions = {}
+): PositionedJourneyDiagram {
+  const hasNamedSections = diagram.sections.some(section => !!section.label)
+  const showSectionFrames = diagram.sections.length > 1 || hasNamedSections
+
+  const titleMetrics = diagram.title
+    ? measureMultilineText(diagram.title, JY.titleFontSize, JY.titleFontWeight)
+    : undefined
+
+  const headerHeights = diagram.sections
+    .map(section => section.label
+      ? measureMultilineText(section.label, JY.sectionFontSize, JY.sectionFontWeight).height + JY.sectionHeaderPadY * 2
+      : 0)
+  const sectionHeaderHeight = hasNamedSections
+    ? Math.max(JY.sectionHeaderMinHeight, ...headerHeights)
+    : 0
+
+  const sectionMetrics: SectionMetric[] = diagram.sections.map(section => {
+    const headerWidth = section.label
+      ? measureMultilineText(section.label, JY.sectionFontSize, JY.sectionFontWeight).width + JY.sectionHeaderPadX * 2
+      : 0
+
+    const taskMetrics: TaskMetric[] = section.tasks.map(task => {
+      const text = measureMultilineText(task.text, JY.taskFontSize, JY.taskFontWeight)
+      const topAreaHeight = Math.max(text.height, JY.scoreCellSize)
+
+      const actorPills: ActorPillMetric[] = task.actors.map(actor => {
+        const plain = stripFormattingTags(actor)
+        const width = Math.max(
+          JY.actorMinWidth,
+          measureTextWidth(plain, JY.actorFontSize, JY.actorFontWeight) + JY.actorPadX * 2,
+        )
+        const height = measureMultilineText(actor, JY.actorFontSize, JY.actorFontWeight).height + JY.actorPadY * 2
+        return { label: actor, width, height }
+      })
+
+      const actorRowWidth = actorPills.reduce((sum, pill, index) => {
+        const gap = index === 0 ? 0 : JY.actorGapX
+        return sum + gap + pill.width
+      }, 0)
+      const actorRowHeight = actorPills.length > 0 ? Math.max(...actorPills.map(pill => pill.height)) : 0
+
+      const minWidth = Math.max(
+        JY.taskMinWidth,
+        text.width + JY.taskToScoreGap + SCORE_TRACK_WIDTH + JY.taskPadX * 2 + JY.taskAccentWidth,
+        actorRowWidth > 0 ? actorRowWidth + JY.taskPadX * 2 + JY.taskAccentWidth : 0,
+      )
+
+      const height = JY.taskPadY * 2
+        + topAreaHeight
+        + (actorRowHeight > 0 ? JY.actorGapTop + actorRowHeight : 0)
+
+      return {
+        textWidth: text.width,
+        textHeight: text.height,
+        topAreaHeight,
+        actorPills,
+        actorRowWidth,
+        actorRowHeight,
+        minWidth,
+        height,
+      }
+    })
+
+    const innerWidth = Math.max(
+      headerWidth,
+      ...taskMetrics.map(task => task.minWidth),
+    )
+
+    const taskStackHeight = taskMetrics.reduce((sum, task, index) => {
+      const gap = index === 0 ? 0 : JY.taskGap
+      return sum + gap + task.height
+    }, 0)
+
+    const height = sectionHeaderHeight
+      + (hasNamedSections ? JY.sectionHeaderGap : 0)
+      + (showSectionFrames ? JY.sectionPadY * 2 : 0)
+      + taskStackHeight
+
+    return { headerWidth, tasks: taskMetrics, innerWidth, height }
+  })
+
+  let contentTop = JY.paddingY
+  if (titleMetrics) {
+    contentTop += titleMetrics.height
+    contentTop += JY.titleGap
+  }
+
+  let cursorX = JY.paddingX
+  let maxBottom = contentTop
+  const sections: PositionedJourneySection[] = []
+
+  for (let sectionIndex = 0; sectionIndex < diagram.sections.length; sectionIndex++) {
+    const section = diagram.sections[sectionIndex]!
+    const metric = sectionMetrics[sectionIndex]!
+    const sectionWidth = metric.innerWidth + (showSectionFrames ? JY.sectionPadX * 2 : 0)
+    const sectionInnerX = cursorX + (showSectionFrames ? JY.sectionPadX : 0)
+    const taskStartY = contentTop
+      + sectionHeaderHeight
+      + (hasNamedSections ? JY.sectionHeaderGap : 0)
+      + (showSectionFrames ? JY.sectionPadY : 0)
+
+    let taskCursorY = taskStartY
+    const tasks: PositionedJourneyTask[] = []
+
+    for (let taskIndex = 0; taskIndex < section.tasks.length; taskIndex++) {
+      const task = section.tasks[taskIndex]!
+      const taskMetric = metric.tasks[taskIndex]!
+      const topAreaY = taskCursorY + JY.taskPadY
+      const meterY = topAreaY + (taskMetric.topAreaHeight - JY.scoreCellSize) / 2
+      const meterStartX = sectionInnerX + metric.innerWidth - JY.taskPadX - SCORE_TRACK_WIDTH
+
+      const scoreCells: PositionedJourneyScoreCell[] = Array.from({ length: 5 }, (_, scoreIndex) => ({
+        x: meterStartX + scoreIndex * (JY.scoreCellSize + JY.scoreCellGap),
+        y: meterY,
+        size: JY.scoreCellSize,
+        filled: scoreIndex < task.score,
+      }))
+
+      let pillCursorX = sectionInnerX + JY.taskAccentWidth + JY.taskPadX
+      const pillY = topAreaY + taskMetric.topAreaHeight + JY.actorGapTop
+      const actorPills: PositionedJourneyActorPill[] = taskMetric.actorPills.map(pill => {
+        const positioned = {
+          label: pill.label,
+          x: pillCursorX,
+          y: pillY,
+          width: pill.width,
+          height: pill.height,
+        }
+        pillCursorX += pill.width + JY.actorGapX
+        return positioned
+      })
+
+      tasks.push({
+        id: task.id,
+        sectionId: section.id,
+        text: task.text,
+        score: task.score,
+        actors: task.actors,
+        x: sectionInnerX,
+        y: taskCursorY,
+        width: metric.innerWidth,
+        height: taskMetric.height,
+        textX: sectionInnerX + JY.taskAccentWidth + JY.taskPadX,
+        textY: topAreaY + taskMetric.topAreaHeight / 2,
+        scoreCells,
+        actorPills,
+      })
+
+      taskCursorY += taskMetric.height + JY.taskGap
+    }
+
+    sections.push({
+      id: section.id,
+      label: section.label,
+      x: cursorX,
+      y: contentTop,
+      width: sectionWidth,
+      height: metric.height,
+      framed: showSectionFrames,
+      headerHeight: sectionHeaderHeight,
+      tasks,
+    })
+
+    maxBottom = Math.max(maxBottom, contentTop + metric.height)
+    cursorX += sectionWidth
+    if (sectionIndex < diagram.sections.length - 1) cursorX += JY.sectionGap
+  }
+
+  const width = cursorX + JY.paddingX
+  const height = maxBottom + JY.paddingY
+
+  return {
+    width,
+    height,
+    title: diagram.title
+      ? {
+          text: diagram.title,
+          x: width / 2,
+          y: JY.paddingY + titleMetrics!.height / 2,
+        }
+      : undefined,
+    sections,
+  }
+}

--- a/src/journey/parser.ts
+++ b/src/journey/parser.ts
@@ -1,0 +1,110 @@
+import type { JourneyDiagram, JourneySection, JourneyTask } from './types.ts'
+import { normalizeBrTags } from '../multiline-utils.ts'
+
+// ============================================================================
+// Journey diagram parser
+//
+// Parses Mermaid user journey syntax into a JourneyDiagram structure.
+//
+// Supported syntax:
+//   journey
+//   title My working day
+//   section Go to work
+//   Make tea: 5: Me
+//   Do work: 1: Me, Cat
+// ============================================================================
+
+function normalizeActorLabel(label: string): string {
+  return normalizeBrTags(label.trim())
+    .split('\n')
+    .map(part => part.trim())
+    .filter(Boolean)
+    .join(' / ')
+}
+
+/**
+ * Parse a Mermaid user journey diagram.
+ * Expects the first line to be "journey".
+ */
+export function parseJourneyDiagram(lines: string[]): JourneyDiagram {
+  const diagram: JourneyDiagram = { sections: [] }
+
+  let currentSection: JourneySection | undefined
+  let sectionIndex = 0
+  let taskIndex = 0
+
+  const ensureSection = (): JourneySection => {
+    if (currentSection) return currentSection
+    currentSection = {
+      id: `section-${sectionIndex++}`,
+      tasks: [],
+    }
+    diagram.sections.push(currentSection)
+    return currentSection
+  }
+
+  for (let i = 1; i < lines.length; i++) {
+    const line = lines[i]!
+
+    if (/^journey\b/i.test(line)) continue
+
+    if (/^acc(?:Title|Descr)\b/i.test(line)) continue
+
+    const titleMatch = line.match(/^title\s+(.+)$/i)
+    if (titleMatch) {
+      diagram.title = normalizeBrTags(titleMatch[1]!.trim())
+      continue
+    }
+
+    const sectionMatch = line.match(/^section\s+(.+)$/i)
+    if (sectionMatch) {
+      currentSection = {
+        id: `section-${sectionIndex++}`,
+        label: normalizeBrTags(sectionMatch[1]!.trim()),
+        tasks: [],
+      }
+      diagram.sections.push(currentSection)
+      continue
+    }
+
+    const taskMatch = line.match(/^(.+?)\s*:\s*([0-9]+)\s*(?::\s*(.*))?$/)
+    if (taskMatch) {
+      const text = normalizeBrTags(taskMatch[1]!.trim())
+      const rawScore = taskMatch[2]!
+      const score = Number.parseInt(rawScore, 10)
+
+      if (!text) {
+        throw new Error(`Invalid user journey task: "${line}"`)
+      }
+
+      if (!Number.isInteger(score) || score < 1 || score > 5) {
+        throw new Error(`Journey task "${text}" has invalid score ${rawScore}. Expected a number between 1 and 5`)
+      }
+
+      const actors = (taskMatch[3] ?? '')
+        .split(',')
+        .map(normalizeActorLabel)
+        .filter(Boolean)
+
+      const task: JourneyTask = {
+        id: `task-${taskIndex++}`,
+        text,
+        score,
+        actors,
+      }
+
+      ensureSection().tasks.push(task)
+      continue
+    }
+
+    if (line.includes(':')) {
+      throw new Error(`Invalid user journey task: "${line}". Expected "Task name: 3: Actor"`)
+    }
+  }
+
+  if (diagram.sections.length === 0 || diagram.sections.every(section => section.tasks.length === 0)) {
+    throw new Error('Journey diagram must include at least one scored task')
+  }
+
+  return diagram
+}

--- a/src/journey/parser.ts
+++ b/src/journey/parser.ts
@@ -9,6 +9,9 @@ import { normalizeBrTags } from '../multiline-utils.ts'
 // Supported syntax:
 //   journey
 //   title My working day
+//   accTitle: My working day accessibility title
+//   accDescr: Short accessibility description
+//   accDescr { Multi-line accessibility description }
 //   section Go to work
 //   Make tea: 5: Me
 //   Do work: 1: Me, Cat
@@ -48,7 +51,26 @@ export function parseJourneyDiagram(lines: string[]): JourneyDiagram {
 
     if (/^journey\b/i.test(line)) continue
 
-    if (/^acc(?:Title|Descr)\b/i.test(line)) continue
+    const accTitle = parseAccessibilityLine(line, 'accTitle')
+    if (accTitle !== undefined) {
+      diagram.accessibilityTitle = accTitle
+      continue
+    }
+
+    const accDescrStart = line.match(/^accDescr\s*:?\s*\{\s*(.*)$/i)
+    if (accDescrStart) {
+      const initial = accDescrStart[1] ?? ''
+      const parsed = collectAccessibilityBlock(initial, lines, i)
+      diagram.accessibilityDescription = normalizeBrTags(parsed.text)
+      i = parsed.nextIndex
+      continue
+    }
+
+    const accDescr = parseAccessibilityLine(line, 'accDescr')
+    if (accDescr !== undefined) {
+      diagram.accessibilityDescription = accDescr
+      continue
+    }
 
     const titleMatch = line.match(/^title\s+(.+)$/i)
     if (titleMatch) {
@@ -107,4 +129,44 @@ export function parseJourneyDiagram(lines: string[]): JourneyDiagram {
   }
 
   return diagram
+}
+
+function parseAccessibilityLine(
+  line: string,
+  directive: 'accTitle' | 'accDescr',
+): string | undefined {
+  const match = line.match(new RegExp(`^${directive}\\s*:?[ \\t]+(.+)$`, 'i'))
+  return match ? normalizeBrTags(match[1]!.trim()) : undefined
+}
+
+function collectAccessibilityBlock(
+  initial: string,
+  lines: string[],
+  startIndex: number,
+): { text: string; nextIndex: number } {
+  const initialEnd = initial.indexOf('}')
+  if (initialEnd !== -1) {
+    return {
+      text: initial.slice(0, initialEnd).trim(),
+      nextIndex: startIndex,
+    }
+  }
+
+  const parts = [initial.trim()].filter(Boolean)
+
+  for (let i = startIndex + 1; i < lines.length; i++) {
+    const line = lines[i]!
+    const end = line.indexOf('}')
+    if (end !== -1) {
+      const beforeBrace = line.slice(0, end).trim()
+      if (beforeBrace) parts.push(beforeBrace)
+      return {
+        text: parts.join('\n'),
+        nextIndex: i,
+      }
+    }
+    parts.push(line)
+  }
+
+  throw new Error('Journey accDescr block is missing a closing "}"')
 }

--- a/src/journey/renderer.ts
+++ b/src/journey/renderer.ts
@@ -1,0 +1,172 @@
+import type { PositionedJourneyDiagram, PositionedJourneySection, PositionedJourneyTask, PositionedJourneyActorPill } from './types.ts'
+import type { DiagramColors } from '../theme.ts'
+import { svgOpenTag, buildStyleBlock } from '../theme.ts'
+import { renderMultilineText, escapeXml } from '../multiline-utils.ts'
+
+// ============================================================================
+// Journey diagram SVG renderer
+//
+// Visual language:
+//   - crisp section frames consistent with timeline / class / ER styling
+//   - stacked task cards with an accent rail
+//   - compact score meters and actor pills for readable metadata
+// ============================================================================
+
+const JY = {
+  titleFontSize: 18,
+  titleFontWeight: 600,
+  sectionFontSize: 12,
+  sectionFontWeight: 600,
+  taskFontSize: 13,
+  taskFontWeight: 500,
+  actorFontSize: 11,
+  actorFontWeight: 600,
+  taskAccentWidth: 4,
+} as const
+
+/**
+ * Render a positioned journey diagram as an SVG string.
+ */
+export function renderJourneySvg(
+  diagram: PositionedJourneyDiagram,
+  colors: DiagramColors,
+  font: string = 'Inter',
+  transparent: boolean = false
+): string {
+  const parts: string[] = []
+
+  parts.push(svgOpenTag(diagram.width, diagram.height, colors, transparent))
+  parts.push(buildStyleBlock(font, false))
+  parts.push(journeyStyles())
+
+  for (const section of diagram.sections) {
+    if (section.framed) {
+      parts.push(renderSectionFrame(section))
+    }
+  }
+
+  for (const section of diagram.sections) {
+    for (const task of section.tasks) {
+      parts.push(renderTask(task, section.label))
+    }
+  }
+
+  if (diagram.title) {
+    parts.push(
+      renderMultilineText(
+        diagram.title.text,
+        diagram.title.x,
+        diagram.title.y,
+        JY.titleFontSize,
+        `class="journey-title" text-anchor="middle" font-size="${JY.titleFontSize}" font-weight="${JY.titleFontWeight}"`,
+      )
+    )
+  }
+
+  parts.push('</svg>')
+  return parts.join('\n')
+}
+
+function journeyStyles(): string {
+  return `<style>
+  .journey-title { fill: var(--_text); }
+  .journey-section-bg { fill: color-mix(in srgb, var(--_node-fill) 88%, var(--bg)); stroke: var(--_node-stroke); stroke-width: 1; }
+  .journey-section-band { fill: color-mix(in srgb, var(--_arrow) 8%, var(--bg)); stroke: var(--_node-stroke); stroke-width: 1; }
+  .journey-section-label { fill: var(--_text-sec); }
+  .journey-task-card { fill: var(--_node-fill); stroke: var(--_node-stroke); stroke-width: 1; }
+  .journey-task-accent { fill: color-mix(in srgb, var(--_arrow) 18%, var(--bg)); }
+  .journey-task-text { fill: var(--_text); }
+  .journey-score-cell-filled { fill: var(--_arrow); stroke: var(--_arrow); stroke-width: 1; }
+  .journey-score-cell-empty { fill: color-mix(in srgb, var(--bg) 55%, var(--_node-fill)); stroke: color-mix(in srgb, var(--_node-stroke) 82%, var(--bg)); stroke-width: 1; }
+  .journey-actor-pill { fill: color-mix(in srgb, var(--_arrow) 8%, var(--bg)); stroke: color-mix(in srgb, var(--_arrow) 22%, var(--bg)); stroke-width: 1; }
+  .journey-actor-text { fill: var(--_text-sec); }
+</style>`
+}
+
+function renderSectionFrame(section: PositionedJourneySection): string {
+  const parts: string[] = []
+  const labelAttr = section.label ? ` data-label="${escapeAttr(section.label)}"` : ''
+
+  parts.push(`<g class="journey-section" data-id="${escapeAttr(section.id)}"${labelAttr}>`)
+  parts.push(
+    `  <rect class="journey-section-bg" x="${section.x}" y="${section.y}" width="${section.width}" height="${section.height}" rx="0" ry="0" />`
+  )
+
+  if (section.headerHeight > 0) {
+    parts.push(
+      `  <rect class="journey-section-band" x="${section.x}" y="${section.y}" width="${section.width}" height="${section.headerHeight}" rx="0" ry="0" />`
+    )
+
+    if (section.label) {
+      parts.push(
+        '  ' + renderMultilineText(
+          section.label,
+          section.x + 12,
+          section.y + section.headerHeight / 2,
+          JY.sectionFontSize,
+          `class="journey-section-label" text-anchor="start" font-size="${JY.sectionFontSize}" font-weight="${JY.sectionFontWeight}"`,
+        )
+      )
+    }
+  }
+
+  parts.push('</g>')
+  return parts.join('\n')
+}
+
+function renderTask(task: PositionedJourneyTask, sectionLabel?: string): string {
+  const parts: string[] = []
+  const sectionAttr = sectionLabel ? ` data-section="${escapeAttr(sectionLabel)}"` : ''
+  const actorAttr = task.actors.length > 0 ? ` data-actors="${escapeAttr(task.actors.join(', '))}"` : ''
+
+  parts.push(
+    `<g class="journey-task" data-id="${escapeAttr(task.id)}" data-score="${task.score}"${sectionAttr}${actorAttr}>`
+  )
+  parts.push(
+    `  <rect class="journey-task-card" x="${task.x}" y="${task.y}" width="${task.width}" height="${task.height}" rx="0" ry="0" />`
+  )
+  parts.push(
+    `  <rect class="journey-task-accent" x="${task.x}" y="${task.y}" width="${JY.taskAccentWidth}" height="${task.height}" rx="0" ry="0" />`
+  )
+  parts.push(
+    '  ' + renderMultilineText(
+      task.text,
+      task.textX,
+      task.textY,
+      JY.taskFontSize,
+      `class="journey-task-text" text-anchor="start" font-size="${JY.taskFontSize}" font-weight="${JY.taskFontWeight}"`,
+    )
+  )
+
+  for (const cell of task.scoreCells) {
+    parts.push(
+      `  <rect class="${cell.filled ? 'journey-score-cell-filled' : 'journey-score-cell-empty'}" x="${cell.x}" y="${cell.y}" width="${cell.size}" height="${cell.size}" rx="2" ry="2" />`
+    )
+  }
+
+  for (const pill of task.actorPills) {
+    parts.push(renderActorPill(pill))
+  }
+
+  parts.push('</g>')
+  return parts.join('\n')
+}
+
+function renderActorPill(pill: PositionedJourneyActorPill): string {
+  return [
+    `  <g class="journey-actor" data-actor="${escapeAttr(pill.label)}">`,
+    `    <rect class="journey-actor-pill" x="${pill.x}" y="${pill.y}" width="${pill.width}" height="${pill.height}" rx="${pill.height / 2}" ry="${pill.height / 2}" />`,
+    '    ' + renderMultilineText(
+      pill.label,
+      pill.x + pill.width / 2,
+      pill.y + pill.height / 2,
+      JY.actorFontSize,
+      `class="journey-actor-text" text-anchor="middle" font-size="${JY.actorFontSize}" font-weight="${JY.actorFontWeight}"`,
+    ),
+    '  </g>',
+  ].join('\n')
+}
+
+function escapeAttr(text: string): string {
+  return escapeXml(text)
+}

--- a/src/journey/renderer.ts
+++ b/src/journey/renderer.ts
@@ -10,6 +10,7 @@ import { renderMultilineText, escapeXml } from '../multiline-utils.ts'
 //   - crisp section frames consistent with timeline / class / ER styling
 //   - stacked task cards with an accent rail
 //   - compact score meters and actor pills for readable metadata
+//   - root SVG accessibility metadata sourced from Mermaid accTitle/accDescr
 // ============================================================================
 
 const JY = {
@@ -35,7 +36,15 @@ export function renderJourneySvg(
 ): string {
   const parts: string[] = []
 
-  parts.push(svgOpenTag(diagram.width, diagram.height, colors, transparent))
+  const accessibility = buildJourneyAccessibility(diagram)
+
+  parts.push(openJourneySvgTag(diagram, colors, transparent, accessibility))
+  if (accessibility.title) {
+    parts.push(`<title id="journey-a11y-title">${escapeXml(accessibility.title)}</title>`)
+  }
+  if (accessibility.description) {
+    parts.push(`<desc id="journey-a11y-desc">${escapeXml(accessibility.description)}</desc>`)
+  }
   parts.push(buildStyleBlock(font, false))
   parts.push(journeyStyles())
 
@@ -65,6 +74,30 @@ export function renderJourneySvg(
 
   parts.push('</svg>')
   return parts.join('\n')
+}
+
+function buildJourneyAccessibility(diagram: PositionedJourneyDiagram): {
+  title?: string
+  description?: string
+} {
+  return {
+    title: diagram.accessibilityTitle ?? diagram.title?.text,
+    description: diagram.accessibilityDescription,
+  }
+}
+
+function openJourneySvgTag(
+  diagram: PositionedJourneyDiagram,
+  colors: DiagramColors,
+  transparent: boolean,
+  accessibility: { title?: string; description?: string },
+): string {
+  const attrs = ['role="img"', 'aria-roledescription="user journey"']
+  if (accessibility.title) attrs.push('aria-labelledby="journey-a11y-title"')
+  if (accessibility.description) attrs.push('aria-describedby="journey-a11y-desc"')
+
+  return svgOpenTag(diagram.width, diagram.height, colors, transparent)
+    .replace('>', ` ${attrs.join(' ')}>`)
 }
 
 function journeyStyles(): string {

--- a/src/journey/types.ts
+++ b/src/journey/types.ts
@@ -1,0 +1,92 @@
+// ============================================================================
+// Journey diagram types
+//
+// Models Mermaid user journey diagrams in parsed and positioned form.
+// Journey diagrams group scored tasks into optional sections with per-task actors.
+// ============================================================================
+
+/** Parsed journey diagram — logical structure from Mermaid text */
+export interface JourneyDiagram {
+  /** Optional diagram title */
+  title?: string
+  /** Ordered sections in input order */
+  sections: JourneySection[]
+}
+
+export interface JourneySection {
+  id: string
+  /** Optional section label. Undefined means an implicit / ungrouped section. */
+  label?: string
+  tasks: JourneyTask[]
+}
+
+export interface JourneyTask {
+  id: string
+  text: string
+  /** Satisfaction score on a 1..5 scale */
+  score: number
+  /** Optional actors attached to the task */
+  actors: string[]
+}
+
+// ============================================================================
+// Positioned journey diagram — ready for SVG rendering
+// ============================================================================
+
+export interface PositionedJourneyDiagram {
+  width: number
+  height: number
+  title?: PositionedJourneyTitle
+  sections: PositionedJourneySection[]
+}
+
+export interface PositionedJourneyTitle {
+  text: string
+  x: number
+  y: number
+}
+
+export interface PositionedJourneySection {
+  id: string
+  label?: string
+  x: number
+  y: number
+  width: number
+  height: number
+  /** Whether to render a framed background for this section. */
+  framed: boolean
+  /** Height of the section header band. 0 when there is no visible header row. */
+  headerHeight: number
+  tasks: PositionedJourneyTask[]
+}
+
+export interface PositionedJourneyTask {
+  id: string
+  sectionId: string
+  text: string
+  score: number
+  actors: string[]
+  x: number
+  y: number
+  width: number
+  height: number
+  textX: number
+  textY: number
+  scoreCells: PositionedJourneyScoreCell[]
+  actorPills: PositionedJourneyActorPill[]
+}
+
+export interface PositionedJourneyScoreCell {
+  x: number
+  y: number
+  size: number
+  filled: boolean
+}
+
+export interface PositionedJourneyActorPill {
+  label: string
+  x: number
+  y: number
+  width: number
+  height: number
+}

--- a/src/journey/types.ts
+++ b/src/journey/types.ts
@@ -9,6 +9,10 @@
 export interface JourneyDiagram {
   /** Optional diagram title */
   title?: string
+  /** Optional accessibility title from Mermaid accTitle */
+  accessibilityTitle?: string
+  /** Optional accessibility description from Mermaid accDescr */
+  accessibilityDescription?: string
   /** Ordered sections in input order */
   sections: JourneySection[]
 }
@@ -37,6 +41,8 @@ export interface PositionedJourneyDiagram {
   width: number
   height: number
   title?: PositionedJourneyTitle
+  accessibilityTitle?: string
+  accessibilityDescription?: string
   sections: PositionedJourneySection[]
 }
 

--- a/src/mermaid-source.ts
+++ b/src/mermaid-source.ts
@@ -735,3 +735,30 @@ function unescapeQuotedString(valueText: string): string {
     return valueText.slice(1, -1)
   }
 }
+
+export type RoutedDiagramType = 'flowchart' | 'sequence' | 'class' | 'er' | 'timeline' | 'journey' | 'xychart'
+
+/**
+ * Return the logical Mermaid lines after frontmatter/init/comment normalization.
+ * This is a thin wrapper around the richer source preprocessing used by the
+ * public SVG and ASCII entry points.
+ */
+export function preprocessMermaidLines(text: string): string[] {
+  return preprocessMermaidSource(text).lines
+}
+
+/**
+ * Detect the routed Mermaid diagram family from the first logical line.
+ */
+export function detectDiagramType(text: string): RoutedDiagramType {
+  const firstLine = preprocessMermaidLines(text)[0]?.split(';')[0]?.trim().toLowerCase() ?? ''
+
+  if (/^xychart(-beta)?\b/.test(firstLine)) return 'xychart'
+  if (/^timeline\s*$/.test(firstLine)) return 'timeline'
+  if (/^journey\s*$/.test(firstLine)) return 'journey'
+  if (/^sequencediagram\s*$/.test(firstLine)) return 'sequence'
+  if (/^classdiagram\s*$/.test(firstLine)) return 'class'
+  if (/^erdiagram\s*$/.test(firstLine)) return 'er'
+
+  return 'flowchart'
+}


### PR DESCRIPTION
## What

Add Mermaid `journey` diagram support across Beautiful Mermaid's SVG and ASCII renderers, including Mermaid-parity parsing, SVG accessibility metadata, theme-aware terminal output, and representative regression fixtures.

## Why

There is no tracked issue in this fork for the change.

Before this PR, Mermaid `journey` input was rejected with `Invalid mermaid header: "journey"`, so the library could not render user journey diagrams at all. The implementation also needed to fit Beautiful Mermaid's existing SVG, ASCII, theming, and contributor conventions instead of landing as an isolated one-off renderer.

## How

- Add a dedicated `src/journey/*` parser, layout, types, and SVG renderer pipeline and route `journey` through the public SVG and ASCII entry points.
- Support Mermaid's real journey syntax, including sections, scored tasks, actors, comments, quoted labels, frontmatter/init preambles, multiline labels, and `accTitle` / `accDescr` accessibility directives.
- Render journey ASCII through the shared role-based color pipeline so `colorMode` and theme settings affect score glyphs, section brackets, metadata labels, and task text consistently.
- Add parser, layout, integration, ASCII, theme, and SVG golden snapshot coverage, including the official Mermaid docs example.
- Document the renderer's intended behavior in `journey-design.md` so the journey pipeline has an explicit design reference alongside the code.

## Testing

- [x] New/modified tests pass
- [x] Tests fail when fix is reverted (regression guard)
- [x] Full test suite passes (no regressions)
- [x] Manual testing completed (described below)

Commands run on the rebased branch:

- `bun test src/__tests__/`
- `bun run samples`
- `bun run bench`
- `npm run build`

Regression guard:

- Verified the parity tests fail against the pre-parity implementation state used during branch development.
- The older code does not populate journey accessibility metadata, does not emit the final SVG accessibility wiring, and fails the newer parity assertions.

Manual verification:

- Rendered representative journey samples locally and checked the resulting output against the repo's existing visual language for spacing, hierarchy, and section/task treatment.
- Compared the Mermaid docs journey example structure to the rendered Beautiful Mermaid output to confirm the same section grouping and score pattern.

## Screenshots / Recordings

This change affects generated diagram output rather than an application UI, so the visual evidence is the rendered output itself.

**Before:**

- `journey` diagrams were rejected and produced no renderable output.

**After:**

- [Representative journey SVG fixture](https://github.com/adewale/beautiful-mermaid/blob/codex/add-user-journey-support-clean/src/__tests__/testdata/svg/journey-representative.svg)
- ![Representative journey render](https://raw.githubusercontent.com/adewale/beautiful-mermaid/codex/add-user-journey-support-clean/src/__tests__/testdata/svg/journey-representative.svg)
- [Mermaid docs example SVG fixture](https://github.com/adewale/beautiful-mermaid/blob/codex/add-user-journey-support-clean/src/__tests__/testdata/svg/journey-mermaid-docs-example.svg)
- ![Mermaid docs journey render](https://raw.githubusercontent.com/adewale/beautiful-mermaid/codex/add-user-journey-support-clean/src/__tests__/testdata/svg/journey-mermaid-docs-example.svg)

## Risk

Risk is moderate but contained.

This PR adds a new public diagram family and touches both SVG and ASCII dispatch, so the main risk areas are diagram-type routing, layout stability, Mermaid syntax parity, and output consistency across themes and transports. Those risks are mitigated by dedicated parser, layout, integration, ASCII, theme, and SVG snapshot coverage; regression-guard verification against the previous implementation state; full-suite, samples, benchmark, and build runs; and a design note documenting the renderer's intended behavior.

The branch does not introduce new dependencies and stays scoped to journey support plus narrow routing, docs, and sample updates.
