### PR TITLE
fix: use a standard Mermaid YAML parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -477,7 +477,7 @@ It also matches Mermaid's runtime affordances for:
 
 - semicolon-separated xychart statements on a single line
 - Mermaid accessibility directives: `accTitle` and `accDescr`
-- Mermaid YAML frontmatter lists, nested maps, and block scalars
+- Mermaid YAML frontmatter lists, nested maps, anchors, aliases, and block scalars
 - Mermaid-style loose object literals inside `init` / `initialize` directives
 
 ```yaml

--- a/bun.lock
+++ b/bun.lock
@@ -7,6 +7,7 @@
       "dependencies": {
         "elkjs": "^0.11.0",
         "entities": "^7.0.1",
+        "yaml": "^2.8.2",
       },
       "devDependencies": {
         "@types/bun": "^1.3.9",
@@ -315,6 +316,8 @@
     "vfile": ["vfile@6.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "vfile-message": "^4.0.0" } }, "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q=="],
 
     "vfile-message": ["vfile-message@4.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-stringify-position": "^4.0.0" } }, "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw=="],
+
+    "yaml": ["yaml@2.8.2", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A=="],
 
     "zwitch": ["zwitch@2.0.4", "", {}, "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="],
   }

--- a/package.json
+++ b/package.json
@@ -51,7 +51,8 @@
   },
   "dependencies": {
     "elkjs": "^0.11.0",
-    "entities": "^7.0.1"
+    "entities": "^7.0.1",
+    "yaml": "^2.8.2"
   },
   "devDependencies": {
     "@types/bun": "^1.3.9",

--- a/src/__tests__/mermaid-source.test.ts
+++ b/src/__tests__/mermaid-source.test.ts
@@ -1,41 +1,89 @@
 import { describe, expect, it } from 'bun:test'
-import { normalizeMermaidSource } from '../mermaid-source.ts'
 
-describe('normalizeMermaidSource', () => {
-  it('merges base config, frontmatter config, and init directives in Mermaid order', () => {
-    const normalized = normalizeMermaidSource(`---
+import {
+  getFrontmatterMap,
+  getFrontmatterScalar,
+  normalizeMermaidSource,
+  preprocessMermaidSource,
+} from '../mermaid-source.ts'
+
+describe('preprocessMermaidSource', () => {
+  it('parses real YAML frontmatter, including anchors, lists, and block scalars', () => {
+    const processed = preprocessMermaidSource(`---
+theme: base
+themeCSS: |
+  .foo { fill: red; }
+secure:
+  - theme
+palette: &palette
+  plotColorPalette: "#ff6b6b, #0ea5e9"
+themeVariables:
+  xyChart: *palette
 config:
-  themeVariables:
-    cScale0: "#112233"
-  timeline:
-    disableMulticolor: true
+  xyChart:
+    width: 640
 ---
-%%{init: {"fontFamily":"IBM Plex Sans","timeline":{"sectionFills":["#224466"]}}}%%
-%% comment
-timeline
-2024 : Launch`, {
-      timeline: {
-        disableMulticolor: false,
-        sectionColours: ['#f8f8f8'],
-      },
-    })
+xychart
+x-axis [A]
+bar [1]`)
 
-    expect(normalized.firstLine).toBe('timeline')
-    expect(normalized.lines).toEqual(['timeline', '2024 : Launch'])
-    expect(normalized.config.fontFamily).toBe('IBM Plex Sans')
-    expect(normalized.config.themeVariables?.cScale0).toBe('#112233')
-    expect(normalized.config.timeline?.disableMulticolor).toBe(true)
-    expect(normalized.config.timeline?.sectionFills).toEqual(['#224466'])
-    expect(normalized.config.timeline?.sectionColours).toEqual(['#f8f8f8'])
+    expect(processed.body).toBe(`xychart
+x-axis [A]
+bar [1]`)
+    expect(getFrontmatterScalar<string>(processed.frontmatter, ['theme'])).toBe('base')
+    expect(getFrontmatterScalar<string>(processed.frontmatter, ['themeCSS'])).toContain('.foo { fill: red; }')
+    expect(processed.frontmatter.secure).toEqual(['theme'])
+    expect(getFrontmatterScalar<string>(processed.frontmatter, ['themeVariables', 'xyChart', 'plotColorPalette']))
+      .toBe('#ff6b6b, #0ea5e9')
+    expect(getFrontmatterScalar<number>(processed.frontmatter, ['xyChart', 'width'])).toBe(640)
   })
 
-  it('supports initialize directives and quoted theme variable keys', () => {
-    const normalized = normalizeMermaidSource(`%%{initialize: {"themeVariables":{"cScale1":"#336699","cScaleLabel1":"#ffffff"}}}%%
-timeline
-2025 : General availability`)
+  it('merges init directives before and after the header and strips them from the body', () => {
+    const processed = preprocessMermaidSource(`%%{init: { theme: base, config: { xyChart: { width: 640 } } }}%%
+xychart
+%% regular comment
+x-axis [A]
+%%{initialize: { fontFamily: 'Fira Code', themeVariables: { primaryTextColor: '#111111' } }}%%
+bar [1]`)
 
-    expect(normalized.config.themeVariables?.cScale1).toBe('#336699')
-    expect(normalized.config.themeVariables?.cScaleLabel1).toBe('#ffffff')
-    expect(normalized.lines).toEqual(['timeline', '2025 : General availability'])
+    expect(processed.lines).toEqual([
+      'xychart',
+      'x-axis [A]',
+      'bar [1]',
+    ])
+    expect(processed.body).not.toContain('%%{')
+    expect(processed.lines).not.toContain('%% regular comment')
+    expect(getFrontmatterScalar<string>(processed.frontmatter, ['theme'])).toBe('base')
+    expect(getFrontmatterScalar<number>(processed.frontmatter, ['xyChart', 'width'])).toBe(640)
+    expect(getFrontmatterScalar<string>(processed.frontmatter, ['fontFamily'])).toBe('Fira Code')
+    expect(getFrontmatterScalar<string>(processed.frontmatter, ['themeVariables', 'primaryTextColor'])).toBe('#111111')
+  })
+})
+
+describe('normalizeMermaidSource', () => {
+  it('merges base config with parsed frontmatter and directive overrides', () => {
+    const normalized = normalizeMermaidSource(`---
+theme: neutral
+timeline:
+  disableMulticolor: false
+---
+%%{init: { timeline: { disableMulticolor: true, sectionColors: ['#111111', '#222222'] } }}%%
+timeline
+  title Release plan
+  section Now
+    Ship : Done`, {
+      fontFamily: 'IBM Plex Sans',
+      timeline: { disableMulticolor: false },
+    })
+
+    expect(normalized.text).toBe(`timeline
+title Release plan
+section Now
+Ship : Done`)
+    expect(normalized.config.theme).toBe('neutral')
+    expect(normalized.config.fontFamily).toBe('IBM Plex Sans')
+    expect(normalized.config.timeline?.disableMulticolor).toBe(true)
+    expect(normalized.config.timeline?.sectionColours).toEqual(['#111111', '#222222'])
+    expect(getFrontmatterMap(normalized.frontmatter, ['timeline'])).toBeDefined()
   })
 })

--- a/src/mermaid-source.ts
+++ b/src/mermaid-source.ts
@@ -9,6 +9,8 @@
 //   - normalized, trimmed diagram lines for downstream parsers
 // ============================================================================
 
+import YAML from 'yaml'
+
 export type MermaidConfigScalar = string | number | boolean | null
 export type MermaidConfigValue = MermaidConfigScalar | MermaidConfigValue[] | MermaidConfigMap
 
@@ -80,7 +82,7 @@ export function preprocessMermaidSource(
   baseFrontmatter: MermaidFrontmatterMap = {},
 ): ProcessedMermaidSource {
   const frontmatterMatch = text.match(FRONTMATTER_REGEX)
-  const yamlFrontmatter = frontmatterMatch ? canonicalizeFrontmatterMap(parseFrontmatter(frontmatterMatch[1]!)) : {}
+  const yamlFrontmatter = frontmatterMatch ? canonicalizeFrontmatterMap(parseYamlDocument(frontmatterMatch[1]!)) : {}
   const rawBody = frontmatterMatch ? text.slice(frontmatterMatch[0].length) : text
   const { body, frontmatter: directiveFrontmatter } = extractInitDirectives(rawBody)
   const frontmatter = mergeFrontmatterMaps(
@@ -252,14 +254,12 @@ function canonicalizeFrontmatterMap(raw: MermaidFrontmatterMap): MermaidFrontmat
   return configRoot ? mergeFrontmatterMaps(configRoot, topLevel) : topLevel
 }
 
-function parseFrontmatter(text: string): MermaidFrontmatterMap {
-  const lines = text.split(/\r?\n/)
-  const firstIndex = skipYamlNoise(lines, 0)
-  if (firstIndex >= lines.length) return {}
-
-  const baseIndent = getIndent(lines[firstIndex]!)
-  const state = { lines, index: firstIndex }
-  return parseYamlMap(state, baseIndent).value
+function parseYamlDocument(text: string): MermaidFrontmatterMap {
+  try {
+    return toFrontmatterMap(YAML.parse(text)) ?? {}
+  } catch {
+    return {}
+  }
 }
 
 function extractInitDirectives(text: string): { body: string; frontmatter: MermaidFrontmatterMap } {
@@ -276,7 +276,7 @@ function extractInitDirectives(text: string): { body: string; frontmatter: Merma
 
 function parseDirectiveMap(text: string): MermaidFrontmatterMap | undefined {
   try {
-    return toFrontmatterMap(JSON.parse(text))
+    return toFrontmatterMap(YAML.parse(text))
   } catch {
     return parseLooseObjectLiteral(text)
   }
@@ -453,236 +453,6 @@ function splitFlowEntries(text: string): string[] {
   const trailing = current.trim()
   if (trailing) entries.push(trailing)
   return entries
-}
-
-function parseYamlMap(
-  state: { lines: string[]; index: number },
-  indent: number,
-): { value: MermaidFrontmatterMap; index: number } {
-  const map: MermaidFrontmatterMap = {}
-  let index = state.index
-
-  while (index < state.lines.length) {
-    index = skipYamlNoise(state.lines, index)
-    if (index >= state.lines.length) break
-
-    const rawLine = state.lines[index]!
-    const lineIndent = getIndent(rawLine)
-    if (lineIndent < indent) break
-    if (lineIndent > indent) {
-      index++
-      continue
-    }
-
-    const line = rawLine.trim()
-    if (line.startsWith('-')) break
-
-    const colonIdx = findSeparatorIndex(line, ':')
-    if (colonIdx === -1) {
-      index++
-      continue
-    }
-
-    const key = line.slice(0, colonIdx).trim()
-    if (!key) {
-      index++
-      continue
-    }
-
-    const valueText = line.slice(colonIdx + 1).trim()
-    index++
-
-    if (isBlockScalarIndicator(valueText)) {
-      const block = parseYamlBlockScalar(state.lines, index, lineIndent, valueText[0] as '|' | '>')
-      map[key] = block.value
-      index = block.index
-      continue
-    }
-
-    if (valueText.length === 0) {
-      const nested = parseYamlNestedValue(state.lines, index, lineIndent)
-      map[key] = nested.value
-      index = nested.index
-      continue
-    }
-
-    map[key] = parseYamlValue(valueText)
-  }
-
-  state.index = index
-  return { value: map, index }
-}
-
-function parseYamlSequence(
-  state: { lines: string[]; index: number },
-  indent: number,
-): { value: MermaidFrontmatterList; index: number } {
-  const items: MermaidFrontmatterList = []
-  let index = state.index
-
-  while (index < state.lines.length) {
-    index = skipYamlNoise(state.lines, index)
-    if (index >= state.lines.length) break
-
-    const rawLine = state.lines[index]!
-    const lineIndent = getIndent(rawLine)
-    if (lineIndent < indent) break
-    if (lineIndent > indent) {
-      index++
-      continue
-    }
-
-    const line = rawLine.slice(indent).trim()
-    if (!line.startsWith('-')) break
-
-    const valueText = line.slice(1).trim()
-    index++
-
-    if (valueText.length === 0) {
-      const nested = parseYamlNestedValue(state.lines, index, lineIndent)
-      items.push(nested.value)
-      index = nested.index
-      continue
-    }
-
-    if (isBlockScalarIndicator(valueText)) {
-      const block = parseYamlBlockScalar(state.lines, index, lineIndent, valueText[0] as '|' | '>')
-      items.push(block.value)
-      index = block.index
-      continue
-    }
-
-    const colonIdx = findSeparatorIndex(valueText, ':')
-    if (
-      colonIdx !== -1 &&
-      !valueText.startsWith('{') &&
-      !valueText.startsWith('[') &&
-      !valueText.startsWith('"') &&
-      !valueText.startsWith("'")
-    ) {
-      const key = valueText.slice(0, colonIdx).trim()
-      const rawValue = valueText.slice(colonIdx + 1).trim()
-      const item: MermaidFrontmatterMap = {}
-
-      if (isBlockScalarIndicator(rawValue)) {
-        const block = parseYamlBlockScalar(state.lines, index, lineIndent, rawValue[0] as '|' | '>')
-        item[key] = block.value
-        index = block.index
-      } else if (rawValue.length === 0) {
-        const nested = parseYamlNestedValue(state.lines, index, lineIndent)
-        item[key] = nested.value
-        index = nested.index
-      } else {
-        item[key] = parseYamlValue(rawValue)
-      }
-
-      const nestedState = { lines: state.lines, index }
-      const extra = parseYamlMap(nestedState, lineIndent + 2)
-      index = nestedState.index
-      items.push(Object.keys(extra.value).length > 0 ? mergeFrontmatterMaps(item, extra.value) : item)
-      continue
-    }
-
-    items.push(parseYamlValue(valueText))
-  }
-
-  state.index = index
-  return { value: items, index }
-}
-
-function parseYamlNestedValue(
-  lines: string[],
-  startIndex: number,
-  parentIndent: number,
-): { value: MermaidFrontmatterValue; index: number } {
-  const nextIndex = skipYamlNoise(lines, startIndex)
-  if (nextIndex >= lines.length) return { value: {}, index: nextIndex }
-
-  const nextLine = lines[nextIndex]!
-  const indent = getIndent(nextLine)
-  if (indent <= parentIndent) return { value: {}, index: nextIndex }
-
-  const state = { lines, index: nextIndex }
-  if (nextLine.slice(indent).trim().startsWith('-')) {
-    return parseYamlSequence(state, indent)
-  }
-  return parseYamlMap(state, indent)
-}
-
-function parseYamlBlockScalar(
-  lines: string[],
-  startIndex: number,
-  parentIndent: number,
-  mode: '|' | '>',
-): { value: string; index: number } {
-  let index = startIndex
-  const chunks: string[] = []
-  let blockIndent: number | undefined
-
-  while (index < lines.length) {
-    const rawLine = lines[index]!
-    const lineIndent = getIndent(rawLine)
-    if (rawLine.trim().length === 0) {
-      chunks.push('')
-      index++
-      continue
-    }
-    if (lineIndent <= parentIndent) break
-
-    if (blockIndent === undefined) blockIndent = lineIndent
-    chunks.push(rawLine.slice(Math.min(rawLine.length, blockIndent)))
-    index++
-  }
-
-  return {
-    value: mode === '>' ? foldYamlBlockScalar(chunks) : chunks.join('\n'),
-    index,
-  }
-}
-
-function parseYamlValue(text: string): MermaidFrontmatterValue {
-  const flowValue = parseFlowValue(text)
-  return flowValue === undefined ? parseScalar(text) : flowValue
-}
-
-function foldYamlBlockScalar(lines: string[]): string {
-  let result = ''
-  let previousBlank = false
-
-  for (const line of lines) {
-    if (line.length === 0) {
-      result += result.endsWith('\n') || result.length === 0 ? '\n' : '\n\n'
-      previousBlank = true
-      continue
-    }
-
-    if (result.length > 0 && !previousBlank && !result.endsWith('\n')) result += ' '
-    result += line
-    previousBlank = false
-  }
-
-  return result
-}
-
-function skipYamlNoise(lines: string[], index: number): number {
-  let cursor = index
-  while (cursor < lines.length) {
-    const trimmed = lines[cursor]!.trim()
-    if (trimmed.length === 0 || trimmed.startsWith('#')) {
-      cursor++
-      continue
-    }
-    break
-  }
-  return cursor
-}
-
-function getIndent(line: string): number {
-  return line.match(/^\s*/)?.[0].length ?? 0
-}
-
-function isBlockScalarIndicator(valueText: string): valueText is '|' | '>' | '|-' | '>-' | '|+' | '>+' {
-  return /^[|>][-+]?$/.test(valueText)
 }
 
 function findSeparatorIndex(text: string, separator: ':' | ','): number {


### PR DESCRIPTION
## What

Use a standard YAML parser for Mermaid frontmatter and `init` / `initialize` directive payloads, while preserving Beautiful Mermaid's existing config merge and canonicalization behavior.

## Why

Beautiful Mermaid already advertises Mermaid-style frontmatter and directive support, but the implementation still relied on a hand-rolled YAML subset parser. That made the native pipeline fragile for valid Mermaid/YAML features such as anchors and aliases, and it kept the parser logic more complex than necessary.

There is no dedicated issue for this slice; this PR closes a native Mermaid-config parity gap in the existing source-normalization layer.

## How

- add the standard `yaml` package and route Mermaid frontmatter parsing through it
- parse `%%{init: ...}%%` and `%%{initialize: ...}%%` payloads with the same YAML parser, while keeping the loose-object-literal fallback for Mermaid-style directive syntax
- preserve the current config merge order and `config:` root canonicalization so the rest of the native renderers keep working unchanged
- replace the old hand-rolled YAML map/sequence/block-scalar parser with the simpler parser-backed normalization path
- add focused source-normalization tests for YAML anchors, aliases, lists, block scalars, and before/after-header directive merges
- update the README claim so it matches the stronger native YAML support

## Testing

- [x] New/modified tests pass
- [x] Tests fail when fix is reverted (regression guard)
- [x] Full test suite passes (no regressions)
- [x] Manual testing completed (describe below)

Commands run:

- `bun x tsc --noEmit`
- `bun test src/__tests__/mermaid-source.test.ts src/__tests__/property-mermaid-source-and-parser.test.ts src/__tests__/property-xychart.test.ts`
- `bun test src/__tests__/`
- `bun run build`

Regression guard:

- in a throwaway worktree, restored the previous `src/mermaid-source.ts` and reran `bun test src/__tests__/mermaid-source.test.ts`
- the new anchor/alias test failed immediately (`plotColorPalette` resolved to `undefined`), so the added coverage meaningfully protects the parser change

Manual checks:

- verified Mermaid source normalization still preserves existing merge behavior for base config + frontmatter + directives through `normalizeMermaidSource`
- verified xychart parsing/property tests still pass with the parser swap, so the native Mermaid-config consumer remains wired correctly

## Risk

Low to moderate. This touches a shared parser used by Mermaid source normalization, so the blast radius is broader than a single diagram family, but the change is tightly scoped to parsing and keeps the existing merge/canonicalization behavior in place. The main residual risk is permissiveness drift between the old fallback parser and the new YAML-backed path; the focused Mermaid-source tests, xychart parser/property tests, full suite, and regression guard are there to keep that risk bounded.
