### PR TITLE
Add GitHub Pages deployment workflow

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,50 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v1
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Build samples site
+        run: |
+          bun run index.ts
+          mkdir -p _site
+          mv index.html _site/
+          cp -r public/* _site/
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Summary

- Adds a GitHub Actions workflow that builds the samples site and deploys it to GitHub Pages on push to main

## Changes

- **`.github/workflows/pages.yml`**: Workflow with build + deploy jobs using `oven-sh/setup-bun`, `actions/upload-pages-artifact@v3`, and `actions/deploy-pages@v4`

## Notes

Branch rebased onto current main to avoid reverting the architecture diagram work from PR #2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)