### PR TITLE
feat: add new-diagrams showcase page

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -59,7 +59,18 @@ const THEME_LABELS: Record<string, string> = {
   'one-dark': 'One Dark',
 }
 
-async function generateHtml(): Promise<string> {
+export interface GenerateHtmlOptions {
+  /** Filter to only these categories. If omitted, all categories are included. */
+  categories?: Set<string>
+  /** Override the page title. */
+  title?: string
+  /** Override the meta description. */
+  description?: string
+  /** Extra samples to append before filtering. */
+  extraSamples?: typeof samples
+}
+
+export async function generateHtml(options: GenerateHtmlOptions = {}): Promise<string> {
   // Step 0: Create Shiki highlighter for mermaid syntax highlighting in source panels.
   // We use 'github-light' as the base theme — its hex colors get overridden by CSS
   // color-mix() rules derived from --t-fg / --t-bg so tokens adapt to any theme.
@@ -82,8 +93,15 @@ async function generateHtml(): Promise<string> {
   const bundleJs = await buildResult.outputs[0]!.text()
   console.log(`Browser bundle: ${(bundleJs.length / 1024).toFixed(1)} KB`)
 
-  // Step 2: Build sample JSON (only serializable fields needed by client)
-  const samplesJson = JSON.stringify(samples.map(s => ({
+  // Step 2: Filter and build sample JSON
+  const allSamples = options.extraSamples
+    ? [...samples, ...options.extraSamples]
+    : samples
+  const filteredSamples = options.categories
+    ? allSamples.filter(s => options.categories!.has(s.category ?? 'Other'))
+    : allSamples
+
+  const samplesJson = JSON.stringify(filteredSamples.map(s => ({
     title: s.title,
     description: s.description,
     source: s.source,
@@ -93,7 +111,7 @@ async function generateHtml(): Promise<string> {
 
   // Step 3: Group samples by category for TOC (done at build time since it's static)
   const categories = new Map<string, number[]>()
-  samples.forEach((sample, i) => {
+  filteredSamples.forEach((sample, i) => {
     const cat = sample.category ?? 'Other'
     if (!categories.has(cat)) categories.set(cat, [])
     categories.get(cat)!.push(i)
@@ -124,7 +142,7 @@ async function generateHtml(): Promise<string> {
   }
 
   // Build mapping from original index to display number (excluding Hero samples)
-  const heroCount = samples.filter(s => s.category === 'Hero').length
+  const heroCount = filteredSamples.filter(s => s.category === 'Hero').length
   const displayNum = (i: number) => i + 1 - heroCount
 
   const tocSections = [...categories.entries()]
@@ -133,7 +151,7 @@ async function generateHtml(): Promise<string> {
     const badgeColor = categoryBadgeColors[cat] ?? '#71717a'
     const prefix = categoryPrefixes[cat]
     const items = indices.map(i => {
-      let title = samples[i]!.title
+      let title = filteredSamples[i]!.title
       // Strip the category prefix from the title since it's already under the category heading
       if (prefix && title.startsWith(prefix)) title = title.slice(prefix.length)
       return `<li><a href="#sample-${i}"><span class="toc-num">${displayNum(i)}.</span> ${escapeHtml(title)}</a></li>`
@@ -190,7 +208,7 @@ async function generateHtml(): Promise<string> {
   // (see https://github.com/shikijs/shiki/issues/973), so we wrap each source with
   // ```mermaid ... ``` and then strip those fence lines from the output HTML.
   // Source panels always use github-dark — Shiki's inline colors are used directly.
-  const highlightedSources = samples.map(sample => {
+  const highlightedSources = filteredSamples.map(sample => {
     const fenced = '```mermaid\n' + sample.source.trim() + '\n```'
     const html = highlighter.codeToHtml(fenced, {
       lang: 'mermaid',
@@ -212,7 +230,7 @@ async function generateHtml(): Promise<string> {
   const heroCards: string[] = []
   const regularCards: string[] = []
 
-  samples.forEach((sample, i) => {
+  filteredSamples.forEach((sample, i) => {
     const bg = sample.options?.bg ?? ''
     const isHero = sample.category === 'Hero'
 
@@ -265,8 +283,8 @@ async function generateHtml(): Promise<string> {
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta name="theme-color" id="theme-color-meta" content="#f9f9fa" />
-  <title>Beautiful Mermaid — Mermaid Rendering, Made Beautiful</title>
-  <meta name="description" content="Open source diagram rendering library built for the AI era. Ultra-fast, fully themeable, outputs to SVG and ASCII. Supports Flowchart, State, Architecture, Sequence, Class, ER, and XY diagrams." />
+  <title>${escapeHtml(options.title ?? 'Beautiful Mermaid — Mermaid Rendering, Made Beautiful')}</title>
+  <meta name="description" content="${escapeHtml(options.description ?? 'Open source diagram rendering library built for the AI era. Ultra-fast, fully themeable, outputs to SVG and ASCII. Supports Flowchart, State, Architecture, Sequence, Class, ER, and XY diagrams.')}" />
   <link rel="icon" type="image/svg+xml" href="/mermaid/favicon.svg" />
   <link rel="icon" type="image/x-icon" href="/mermaid/favicon.ico" />
   <link rel="apple-touch-icon" href="/mermaid/apple-touch-icon.png" />
@@ -1277,7 +1295,7 @@ async function generateHtml(): Promise<string> {
       </button>
     </div>
     <div class="hero-meta">
-      <p class="meta" id="total-timing">Rendering ${samples.length * 2} samples\u2026</p>
+      <p class="meta" id="total-timing">Rendering ${filteredSamples.length * 2} samples\u2026</p>
       <div class="meta">ASCII rendering based on <a href="https://github.com/AlexanderGrooff/mermaid-ascii" target="_blank" rel="noopener">Mermaid-ASCII</a></div>
       <div class="meta">Early preview — actively evolving</div>
     </div>
@@ -1852,10 +1870,12 @@ ${bundleJs}
 }
 
 // ============================================================================
-// Main
+// Main — only runs when this file is the entry point (not when imported)
 // ============================================================================
 
-const html = await generateHtml()
-const outPath = new URL('./index.html', import.meta.url).pathname
-await Bun.write(outPath, html)
-console.log(`Written to ${outPath} (${(html.length / 1024).toFixed(1)} KB)`)
+if (import.meta.main) {
+  const html = await generateHtml()
+  const outPath = new URL('./index.html', import.meta.url).pathname
+  await Bun.write(outPath, html)
+  console.log(`Written to ${outPath} (${(html.length / 1024).toFixed(1)} KB)`)
+}

--- a/new-diagrams.ts
+++ b/new-diagrams.ts
@@ -1,0 +1,170 @@
+/**
+ * Generates new-diagrams.html — a focused showcase for the recently added
+ * diagram types: Architecture, Timeline, and Journey.
+ *
+ * Usage: bun run new-diagrams.ts
+ *
+ * Reuses the exact same generator as the main gallery (index.ts), just
+ * filtered to the three new diagram families with additional samples.
+ */
+
+import { generateHtml } from './index.ts'
+import type { Sample } from './samples-data.ts'
+
+const extraSamples: Sample[] = [
+  {
+    title: 'Architecture: Microservices',
+    category: 'Architecture',
+    description: 'A typical microservices topology with API gateway, service mesh, and backing stores.',
+    source: `architecture-beta
+  group mesh(cloud)[Service Mesh]
+  service gateway(server)[API Gateway]
+  service users(server)[User Service] in mesh
+  service orders(server)[Order Service] in mesh
+  service payments(server)[Payment Service] in mesh
+  service db(database)[PostgreSQL]
+  service cache(disk)[Redis Cache]
+  gateway:B --> T:users
+  gateway:B --> T:orders
+  orders:R --> L:payments
+  users:B --> T:cache
+  orders:B --> T:db
+  payments:B --> T:db`,
+  },
+  {
+    title: 'Architecture: CI/CD Pipeline',
+    category: 'Architecture',
+    description: 'Build and deploy pipeline with artifact storage and staged environments.',
+    source: `architecture-beta
+  group build(server)[Build]
+  group deploy(cloud)[Deploy]
+  service repo(disk)[Git Repo]
+  service ci(server)[CI Runner] in build
+  service registry(database)[Container Registry] in build
+  service staging(server)[Staging] in deploy
+  service prod(server)[Production] in deploy
+  junction gate in deploy
+  repo:R --> L:ci
+  ci:R --> L:registry
+  registry:R --> L:gate
+  gate:R -[promote]-> L:staging
+  gate:B -[release]-> T:prod`,
+    options: {
+      bg: '#1e1b2e',
+      fg: '#e0def4',
+      line: '#6e6a86',
+      accent: '#c4a7e7',
+      muted: '#908caa',
+      surface: '#26233a',
+      border: '#524f67',
+    },
+  },
+  {
+    title: 'Timeline: Framework Evolution',
+    category: 'Timeline',
+    description: 'Evolution of a framework across major releases with grouped eras.',
+    source: `timeline
+  title Framework Evolution
+  section Early Days
+    2018 : Initial prototype
+         : Core parser written
+    2019 : First public release
+         : 12 early adopters
+  section Growth
+    2020 : Plugin system
+         : 200 GitHub stars
+    2021 : Theme engine
+         : Enterprise pilot
+  section Maturity
+    2023 : v2.0 rewrite
+         : ASCII renderer
+    2024 : Architecture diagrams
+         : 10K weekly downloads`,
+  },
+  {
+    title: 'Timeline: Sprint Roadmap',
+    category: 'Timeline',
+    description: 'A product sprint roadmap tracking feature delivery across quarters.',
+    source: `timeline
+  title 2024 Product Roadmap
+  section Q1
+    Jan : User research
+    Feb : Design system v2
+    Mar : Beta launch
+  section Q2
+    Apr : Public launch
+        : Marketing campaign
+    May : Mobile app
+    Jun : Analytics dashboard
+  section Q3
+    Jul : API v2
+    Aug : Enterprise features
+    Sep : SOC 2 compliance`,
+    options: {
+      bg: '#fafaf9',
+      fg: '#1c1917',
+      line: '#a8a29e',
+      accent: '#ea580c',
+      muted: '#78716c',
+      surface: '#f5f5f4',
+      border: '#d6d3d1',
+    },
+  },
+  {
+    title: 'Journey: Onboarding Flow',
+    category: 'Journey',
+    description: 'New user onboarding experience scored by satisfaction.',
+    source: `journey
+  title New User Onboarding
+  section Sign Up
+    Visit landing page: 5: User
+    Click "Get Started": 4: User
+    Fill registration form: 2: User
+    Verify email: 3: User
+  section First Use
+    Complete tutorial: 4: User, System
+    Create first project: 5: User
+    Invite teammate: 3: User
+  section Retention
+    Return next day: 4: User
+    Upgrade to paid: 2: User, Sales`,
+  },
+  {
+    title: 'Journey: Support Ticket',
+    category: 'Journey',
+    description: 'Customer support journey from issue to resolution.',
+    source: `journey
+  title Support Ticket Lifecycle
+  section Report
+    Encounter bug: 1: Customer
+    Search knowledge base: 3: Customer
+    Submit ticket: 4: Customer
+  section Triage
+    Auto-categorize: 5: System
+    Assign to agent: 4: System, Agent
+  section Resolve
+    Reproduce issue: 3: Agent
+    Deploy fix: 5: Agent, Engineer
+    Confirm resolution: 5: Customer`,
+    options: {
+      bg: '#0c1222',
+      fg: '#c9d1d9',
+      accent: '#58a6ff',
+      line: '#30363d',
+      muted: '#8b949e',
+      surface: '#161b22',
+      border: '#30363d',
+    },
+  },
+]
+
+const html = await generateHtml({
+  categories: new Set(['Architecture', 'Timeline', 'Journey']),
+  title: 'Beautiful Mermaid — New Diagram Types',
+  description: 'Architecture, Timeline, and Journey diagram showcase for beautiful-mermaid.',
+  extraSamples,
+})
+
+const outPath = new URL('./new-diagrams.html', import.meta.url).pathname
+await Bun.write(outPath, html)
+console.log(`Written to ${outPath} (${(html.length / 1024).toFixed(1)} KB)`)


### PR DESCRIPTION
## Summary

- Adds a standalone showcase page for the three recently added diagram types: Architecture, Timeline, and Journey
- Refactors `index.ts` to export `generateHtml()` with filtering support so both the main gallery and focused pages share the exact same generator, CSS, theme switching, edit dialog, and progressive rendering
- Includes 6 new samples beyond what's in `samples-data.ts` (2 Architecture, 2 Timeline, 2 Journey)

## Changes

- **`index.ts`**: Export `generateHtml(options?)` with `categories` filter, `title`/`description` overrides, and `extraSamples`. Guard main entry with `import.meta.main`.
- **`new-diagrams.ts`**: Thin wrapper — defines extra samples and calls `generateHtml({ categories: new Set(['Architecture', 'Timeline', 'Journey']) })`

## Usage

```bash
bun run new-diagrams.ts    # generates new-diagrams.html
bun run index.ts           # main gallery (unchanged behavior)
```

## Test plan

- [x] `bun run index.ts` produces identical output to before (same size, same content)
- [x] `bun run new-diagrams.ts` produces `new-diagrams.html` with 14 samples across 3 categories
- [x] Importing `index.ts` from another file does not trigger side effects (no `index.html` written)
- [x] Theme switching, edit dialog, progressive rendering all work on the new page

🤖 Generated with [Claude Code](https://claude.com/claude-code)