### PR TITLE
Increase agent doc example test timeout

### DIFF
--- a/src/__tests__/agent-doc-sync.test.ts
+++ b/src/__tests__/agent-doc-sync.test.ts
@@ -332,7 +332,7 @@ describe('shipped distribution artifacts present', () => {
     expect(payload.cases).toEqual(['auth-flow', 'order-domain-er'])
     expect(payload.sources['auth-flow']).toContain('G --> H[Dashboard]')
     expect(payload.sources['order-domain-er']).toContain('CUSTOMER ||--o{ ORDER : places')
-  })
+  }, 30_000)
 
   test('agent improvement example assesses, mutates, reassesses, and writes render files', async () => {
     const outDir = mkdtempSync(join(tmpdir(), 'am-example-test-'))
@@ -356,7 +356,7 @@ describe('shipped distribution artifacts present', () => {
     } finally {
       rmSync(outDir, { recursive: true, force: true })
     }
-  })
+  }, 30_000)
 
   test('npm package includes bundled PNG fonts documented for deterministic output', () => {
     const pkg = JSON.parse(readFileSync(join(REPO, 'package.json'), 'utf8'))


### PR DESCRIPTION
## Summary
- Increase the Bun test timeout for the two doc-sync example subprocess tests so slower GitHub Actions runners don't fail at the default 5s while the helper itself still enforces a 60s subprocess timeout.

## Validation
- `bun test src/__tests__/agent-doc-sync.test.ts`
- `git diff --check`

## Context
PR #15 passed pull-request checks but the post-merge main CI hit Bun's default per-test timeout on `agent improvement example assesses, mutates, reassesses, and writes render files` after ~5s on the GitHub runner.
