### PR TITLE
Preserve flowchart node metadata safely

### DIFF
--- a/src/__tests__/agent-quality.test.ts
+++ b/src/__tests__/agent-quality.test.ts
@@ -24,7 +24,7 @@ describe('quality metrics — deterministic', () => {
     let measured = 0
     for (const e of corpus.slice(0, 30)) {
       const p = parseMermaid(e.source)
-      if (!p.ok || p.value.body.kind !== 'flowchart') continue
+      if (!p.ok || p.value.kind !== 'flowchart') continue
       const layout = layoutMermaid(p.value)
       if (layout.nodes.length === 0) continue
       const m = measureQuality(layout)
@@ -41,7 +41,7 @@ describe('quality metrics — deterministic', () => {
     const flow = corpus.find(e => e.source.includes('-->'))
     if (!flow) return
     const p = parseMermaid(flow.source)
-    if (!p.ok || p.value.body.kind !== 'flowchart') return
+    if (!p.ok || p.value.kind !== 'flowchart') return
     const a = measureQuality(layoutMermaid(p.value))
     const b = measureQuality(layoutMermaid(p.value))
     expect(a).toEqual(b)
@@ -150,7 +150,7 @@ describe('quality regression baseline (flowchart corpus median + p90)', () => {
     const metrics: ReturnType<typeof measureQuality>[] = []
     for (const e of corpus) {
       const p = parseMermaid(e.source)
-      if (!p.ok || p.value.body.kind !== 'flowchart') continue
+      if (!p.ok || p.value.kind !== 'flowchart') continue
       const layout = layoutMermaid(p.value)
       if (layout.nodes.length === 0) continue
       metrics.push(measureQuality(layout))

--- a/src/__tests__/flowchart-metadata.test.ts
+++ b/src/__tests__/flowchart-metadata.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, test } from 'bun:test'
+import fc from 'fast-check'
+
+import { parseMermaid as parseGraph } from '../parser.ts'
+import {
+  asFlowchart,
+  layoutMermaid,
+  parseMermaid,
+  renderMermaidASCII,
+  renderMermaidSVG,
+  serializeMermaid,
+  verifyMermaid,
+} from '../agent/index.ts'
+
+const ISSUE_29_CASES = [
+  {
+    name: 'inline metadata on an edge statement',
+    source: 'flowchart TD\n  A@{ shape: manual-input, label: "User types" } --> B[OK]\n',
+    expectedNodes: ['A', 'B'],
+    expectedEdges: [['A', 'B']],
+    labels: { A: 'User types', B: 'OK' },
+  },
+  {
+    name: 'standalone metadata statement',
+    source: 'flowchart TD\n  A@{ shape: document, label: "Spec" }\n  A --> B[OK]\n',
+    expectedNodes: ['A', 'B'],
+    expectedEdges: [['A', 'B']],
+    labels: { A: 'Spec', B: 'OK' },
+  },
+  {
+    name: 'standalone metadata updates an existing implicit node',
+    source: 'flowchart TD\n  A --> B[OK]\n  A@{ shape: document, label: "Spec" }\n',
+    expectedNodes: ['A', 'B'],
+    expectedEdges: [['A', 'B']],
+    labels: { A: 'Spec', B: 'OK' },
+  },
+  {
+    name: 'multiline metadata block',
+    source: 'flowchart TD\n  A@{\n    shape: delay,\n    label: "Wait"\n  }\n  A --> B\n',
+    expectedNodes: ['A', 'B'],
+    expectedEdges: [['A', 'B']],
+    labels: { A: 'Wait', B: 'B' },
+  },
+] as const
+
+function parseAgent(source: string) {
+  const parsed = parseMermaid(source)
+  if (!parsed.ok) throw new Error(JSON.stringify(parsed.error))
+  return parsed.value
+}
+
+describe('flowchart @{...} node metadata preservation (issue #29)', () => {
+  for (const c of ISSUE_29_CASES) {
+    test(`${c.name}: agent parse falls back to lossless opaque source`, () => {
+      const diagram = parseAgent(c.source)
+      expect(diagram.kind).toBe('flowchart')
+      expect(diagram.body.kind).toBe('opaque')
+      expect(diagram.body.kind === 'opaque' ? diagram.body.source : '').toBe(c.source)
+      expect(serializeMermaid(diagram)).toBe(c.source)
+      expect(asFlowchart(diagram)).toBeNull()
+
+      const reparsed = parseAgent(serializeMermaid(diagram))
+      expect(serializeMermaid(reparsed)).toBe(c.source)
+    })
+
+    test(`${c.name}: legacy renderer parser keeps nodes and edges without fabricating metadata keys`, () => {
+      const graph = parseGraph(c.source)
+      expect([...graph.nodes.keys()].sort()).toEqual([...c.expectedNodes].sort())
+      expect(graph.nodes.has('shape')).toBe(false)
+      expect(graph.nodes.has('label')).toBe(false)
+      for (const [id, label] of Object.entries(c.labels)) {
+        expect(graph.nodes.get(id)?.label).toBe(label)
+      }
+      expect(graph.edges.map(e => [e.source, e.target])).toEqual(c.expectedEdges.map(([source, target]) => [source, target]))
+    })
+
+    test(`${c.name}: render and layout degrade to labeled rectangle fallback`, () => {
+      const diagram = parseAgent(c.source)
+      const verify = verifyMermaid(c.source)
+      expect(verify.ok).toBe(true)
+      expect(verify.layout.nodes.map(n => n.id).sort()).toEqual([...c.expectedNodes].sort())
+      expect(verify.layout.nodes.some(n => n.id === 'shape' || n.id === 'label')).toBe(false)
+
+      const layout = layoutMermaid(diagram)
+      expect(layout.nodes.map(n => n.id).sort()).toEqual([...c.expectedNodes].sort())
+      expect(layout.edges.map(e => [e.from, e.to])).toEqual(c.expectedEdges.map(([source, target]) => [source, target]))
+
+      const svg = renderMermaidSVG(c.source)
+      const ascii = renderMermaidASCII(c.source)
+      for (const label of Object.values(c.labels)) {
+        expect(svg).toContain(label)
+        expect(ascii).toContain(label)
+      }
+    })
+  }
+
+  test('metadata keys are never interpreted as nodes across generated blocks', () => {
+    const idArb = fc.constantFrom('A', 'Node_1', 'node-2')
+    const shapeArb = fc.constantFrom('manual-input', 'document', 'delay', 'rect', 'cloud')
+    const labelArb = fc
+      .array(fc.constantFrom(...'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789 '.split('')), { minLength: 1, maxLength: 12 })
+      .map(chars => chars.join('').trim() || 'Node')
+    fc.assert(
+      fc.property(idArb, shapeArb, labelArb, fc.boolean(), (id, shape, label, multiline) => {
+        const metadata = multiline
+          ? `${id}@{\n    shape: ${shape},\n    label: "${label}"\n  }`
+          : `${id}@{ shape: ${shape}, label: "${label}" }`
+        const source = `flowchart TD\n  ${metadata}\n  ${id} --> B[OK]\n`
+        const graph = parseGraph(source)
+        expect(graph.nodes.has('shape')).toBe(false)
+        expect(graph.nodes.has('label')).toBe(false)
+        expect(graph.nodes.get(id)?.label).toBe(label)
+        expect(graph.nodes.get('B')?.label).toBe('OK')
+        expect(graph.edges).toHaveLength(1)
+        expect(graph.edges[0]!.source).toBe(id)
+        expect(graph.edges[0]!.target).toBe('B')
+      }),
+      { numRuns: 30 },
+    )
+  })
+})

--- a/src/agent/families-builtin.ts
+++ b/src/agent/families-builtin.ts
@@ -85,11 +85,18 @@ function extractFlowchartLabels(source: string): ExtractedLabel[] {
 
 // Flowchart owns the legacy MermaidGraph body: the diagram kind selects the
 // plugin, which binds the flowchart header.
+function containsFlowchartNodeMetadata(source: string): boolean {
+  return /(?:^|[\s;])[\w-]+@\s*\{/m.test(source)
+}
+
 function flowchartFamilyHooks(): Pick<FamilyPlugin, 'parse' | 'buildSourceMap' | 'serialize' | 'mutate'> {
   return {
-    parse: (_lines, _opaqueSource, _meta, canonicalSource) => parseFlowchartBody(canonicalSource),
+    parse: (_lines, opaqueSource, _meta, canonicalSource) => {
+      if (containsFlowchartNodeMetadata(canonicalSource)) return ok<DiagramBody>({ kind: 'opaque', family: 'flowchart', source: opaqueSource })
+      return parseFlowchartBody(canonicalSource)
+    },
     buildSourceMap: (body, canonicalSource) =>
-      buildFlowchartSourceMap(body as FlowchartBody, canonicalSource),
+      body.kind === 'flowchart' ? buildFlowchartSourceMap(body as FlowchartBody, canonicalSource) : { nodes: new Map(), edges: new Map(), groups: new Map() },
     serialize: body => {
       if (body.kind !== 'flowchart') throw new Error(`flowchart serializer received body kind ${body.kind}`)
       return renderFlowchart(body.graph, 'flowchart')

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -49,6 +49,7 @@ import { renderMermaidSVG as _svg } from '../index.ts'
 export { verifyNoExternalRefs } from '../index.ts'
 import { renderMermaidASCII as _ascii } from '../ascii/index.ts'
 import { layoutGraphSync } from '../layout-engine.ts'
+import { parseMermaid as parseFlowchartLegacy } from '../parser.ts'
 import { stateBodyToGraph } from './state-body.ts'
 import { serializeMermaid as _serialize } from './serialize.ts'
 import type { ValidDiagram, RenderedLayout } from './types.ts'
@@ -70,6 +71,13 @@ export function layoutMermaid(d: ValidDiagram, opts: { debug?: boolean } = {}): 
   // so layout reuses the flowchart geometric path.
   if (d.body.kind === 'state') {
     return positionedToRenderedLayout(layoutGraphSync(stateBodyToGraph(d.body), {}), d.kind, opts)
+  }
+  if (d.body.kind === 'opaque' && d.kind === 'flowchart') {
+    try {
+      return positionedToRenderedLayout(layoutGraphSync(parseFlowchartLegacy(d.canonicalSource), {}), d.kind, opts)
+    } catch {
+      return emptyRenderedLayout(d.kind)
+    }
   }
   if (d.body.kind === 'sequence') return layoutSequenceToRendered(d as ValidDiagram & { body: SequenceBody })
   if (d.body.kind === 'timeline') return layoutTimelineToRendered(d as ValidDiagram & { body: TimelineBody })

--- a/src/agent/verify.ts
+++ b/src/agent/verify.ts
@@ -7,6 +7,7 @@
 
 import { parseMermaid as parseValidDiagram } from './parse.ts'
 import { layoutGraphSync } from '../layout-engine.ts'
+import { parseMermaid as parseFlowchartLegacy } from '../parser.ts'
 import { auditRouteContracts, findRouteHitches } from '../route-contracts.ts'
 import type {
   ValidDiagram, VerifyOptions, VerifyResult, LayoutWarning, RenderedLayout,
@@ -126,7 +127,9 @@ export function verifyMermaid(input: ValidDiagram | string, opts: VerifyOptions 
     // class/er/journey/architecture/xychart when unmodeled) still produce a
     // real positioned layout from canonicalSource. layoutFamilyToRendered
     // degrades to an empty layout on render-error, so this never throws.
-    const opaqueLayout = layoutFamilyToRendered(d) ?? emptyRenderedLayout(d.kind)
+    const opaqueLayout = d.kind === 'flowchart'
+      ? layoutOpaqueFlowchart(d)
+      : layoutFamilyToRendered(d) ?? emptyRenderedLayout(d.kind)
     return finalize(dedupedConcat(warnings, pluginWarnings), opaqueLayout, opts)
   }
 
@@ -393,6 +396,14 @@ function verifySequence(body: SequenceBody, kind: ValidDiagram['kind'], cap: num
 }
 
 // ---- helpers --------------------------------------------------------------
+
+function layoutOpaqueFlowchart(d: ValidDiagram): RenderedLayout {
+  try {
+    return positionedToRenderedLayout(layoutGraphSync(parseFlowchartLegacy(d.canonicalSource), {}), d.kind)
+  } catch {
+    return emptyRenderedLayout(d.kind)
+  }
+}
 
 function unwrap(source: string): ValidDiagram | null {
   const r = parseValidDiagram(source)

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -18,7 +18,7 @@ import { normalizeBrTags } from './multiline-utils.ts'
  * Throws on invalid/unsupported input.
  */
 export function parseMermaid(text: string): MermaidGraph {
-  const lines = text.split('\n').map(l => l.trim()).filter(l => l.length > 0 && !l.startsWith('%%'))
+  const lines = coalesceMetadataLines(text.split('\n')).map(l => l.trim()).filter(l => l.length > 0 && !l.startsWith('%%'))
 
   if (lines.length === 0) {
     throw new Error('Empty mermaid diagram')
@@ -34,6 +34,62 @@ export function parseMermaid(text: string): MermaidGraph {
 
   // Flowchart: "graph TD" or "flowchart LR"
   return parseFlowchart(lines)
+}
+
+/**
+ * Mermaid v11 uses `id@{ ... }` metadata blocks for flowchart nodes. The
+ * legacy parser is line-oriented; without this coalescing pass, multiline
+ * metadata keys such as `shape:` and `label:` are treated as standalone node
+ * statements. Keep the whole metadata object attached to its node token so the
+ * node consumer can handle it as one unit.
+ */
+function coalesceMetadataLines(lines: string[]): string[] {
+  const out: string[] = []
+  let current: string[] | null = null
+  let balance = 0
+
+  for (const line of lines) {
+    if (current) {
+      current.push(line.trim())
+      balance += metadataBraceDelta(line)
+      if (balance <= 0) {
+        out.push(current.join(' '))
+        current = null
+        balance = 0
+      }
+      continue
+    }
+
+    if (/(?:^|[\s;])[\w-]+@\s*\{/.test(line)) {
+      balance = metadataBraceDelta(line)
+      if (balance > 0) current = [line.trim()]
+      else out.push(line)
+      continue
+    }
+
+    out.push(line)
+  }
+
+  if (current) out.push(current.join(' '))
+  return out
+}
+
+function metadataBraceDelta(text: string): number {
+  let delta = 0
+  let quote: '"' | "'" | null = null
+  let escaped = false
+  for (const ch of text) {
+    if (escaped) { escaped = false; continue }
+    if (ch === '\\') { escaped = true; continue }
+    if (quote) {
+      if (ch === quote) quote = null
+      continue
+    }
+    if (ch === '"' || ch === "'") { quote = ch; continue }
+    if (ch === '{') delta++
+    else if (ch === '}') delta--
+  }
+  return delta
 }
 
 // ============================================================================
@@ -595,6 +651,65 @@ interface ConsumedNode {
   remaining: string
 }
 
+function consumeMetadataNode(
+  text: string,
+  graph: MermaidGraph,
+  subgraphStack: MermaidSubgraph[]
+): ConsumedNode | null {
+  const start = text.match(/^([\w-]+)@\s*\{/)
+  if (!start) return null
+  const id = start[1]!
+  const objectStart = text.indexOf('{', start[0].indexOf('@'))
+  const objectEnd = findMetadataObjectEnd(text, objectStart)
+  if (objectEnd < 0) return null
+
+  const metadata = text.slice(objectStart + 1, objectEnd)
+  const label = parseMetadataLabel(metadata)
+  // #29 safety floor: we preserve labels/edges for rendering and reserve the
+  // expanded Mermaid v11 shape vocabulary for the follow-up modeled support.
+  const existing = graph.nodes.get(id)
+  if (existing) {
+    if (label !== undefined) graph.nodes.set(id, { ...existing, label: normalizeBrTags(label) })
+    trackInSubgraph(subgraphStack, id)
+  } else {
+    registerNode(graph, subgraphStack, { id, label: normalizeBrTags(label ?? id), shape: 'rectangle' })
+  }
+  return { id, remaining: text.slice(objectEnd + 1) }
+}
+
+function findMetadataObjectEnd(text: string, start: number): number {
+  if (start < 0 || text[start] !== '{') return -1
+  let depth = 0
+  let quote: '"' | "'" | null = null
+  let escaped = false
+  for (let i = start; i < text.length; i++) {
+    const ch = text[i]!
+    if (escaped) { escaped = false; continue }
+    if (ch === '\\') { escaped = true; continue }
+    if (quote) {
+      if (ch === quote) quote = null
+      continue
+    }
+    if (ch === '"' || ch === "'") { quote = ch; continue }
+    if (ch === '{') depth++
+    else if (ch === '}') {
+      depth--
+      if (depth === 0) return i
+    }
+  }
+  return -1
+}
+
+function parseMetadataLabel(metadata: string): string | undefined {
+  const match = metadata.match(/(?:^|,)\s*label\s*:\s*("(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'|[^,}]+)/)
+  if (!match) return undefined
+  const raw = match[1]!.trim()
+  if ((raw.startsWith('"') && raw.endsWith('"')) || (raw.startsWith("'") && raw.endsWith("'"))) {
+    return raw.slice(1, -1).replace(/\\([\\"'])/g, '$1')
+  }
+  return raw.trim()
+}
+
 /**
  * Try to consume a node definition from the start of `text`.
  * If the node has a shape+label (e.g. A[Text]), it's registered in the graph.
@@ -606,6 +721,17 @@ function consumeNode(
   graph: MermaidGraph,
   subgraphStack: MermaidSubgraph[]
 ): ConsumedNode | null {
+  const metadataNode = consumeMetadataNode(text, graph, subgraphStack)
+  if (metadataNode) {
+    let remaining = metadataNode.remaining
+    const classMatch = remaining.match(CLASS_SHORTHAND_REGEX)
+    if (classMatch) {
+      graph.classAssignments.set(metadataNode.id, classMatch[1]!)
+      remaining = remaining.slice(classMatch[0].length)
+    }
+    return { id: metadataNode.id, remaining }
+  }
+
   let id: string | null = null
   let remaining: string = text
 


### PR DESCRIPTION
## What
- Fixes Mermaid flowchart `id@{ ... }` node metadata handling so metadata blocks no longer drop edges/nodes or fabricate `shape` / `label` nodes.
- Adds a brace/quote-aware coalescing pass for multiline metadata blocks in the legacy flowchart parser.
- Registers metadata nodes as labeled rectangle fallbacks for render/layout, including metadata that updates an already-seen implicit node.
- Makes agent flowcharts containing `@{...}` metadata parse as lossless opaque flowcharts, preserving exact source serialization and refusing structured mutations.
- Keeps opaque flowchart `verify` / `layout` truthful by laying out through the legacy parser fallback.

## Why
- Closes #29: `verify.ok: true` must never accompany silent content loss or phantom metadata-key nodes.
- Keeps this PR scoped to the safety floor; full Mermaid v11 typed-shape vocabulary support remains tracked in #44.

## How
- `src/parser.ts`: coalesces multiline metadata blocks and consumes `id@{...}` node tokens before bare-node parsing.
- `src/agent/families-builtin.ts`: detects flowchart node metadata and falls back to an opaque, source-preserving body.
- `src/agent/index.ts` / `src/agent/verify.ts`: lay out opaque flowcharts via the legacy parser instead of reporting empty layouts.
- `src/__tests__/flowchart-metadata.test.ts`: locks inline, standalone, late-standalone, multiline, render/layout, exact-serialization, and generated-key safety behavior.
- `src/__tests__/agent-quality.test.ts`: treats opaque flowchart fallbacks as flowcharts for corpus layout quality coverage.

## Testing
- `bun test src/__tests__/flowchart-metadata.test.ts src/__tests__/agent-quality.test.ts src/__tests__/agent-mermaid-corpus.test.ts`
- `bun x tsc --noEmit`
- `bun test --coverage src/__tests__/` → 3044 pass
- `bun run build`
- `bun run audit:ugly` → 391 diagrams · 1168 format-audits · 0 HARD · 0 soft
- `git diff --check`
- Manual CLI smoke: `am parse` reports `opaque`; `am verify` reports `ok: true` with `A:Spec,B:OK` and `A->B`.
- Sabotage check: disabling `consumeMetadataNode()` made `flowchart-metadata.test.ts` fail (`sabotage_status=1`).

## Screenshots
- N/A — parser/render/layout safety fix covered by tests and audit.

## Risk
- Metadata `shape` values intentionally render as rectangle fallbacks in this PR; #44 will model the full Mermaid v11 shape vocabulary.
- Unknown metadata keys are preserved in opaque agent source but are not structured-mutable until typed metadata support lands.
