### PR TITLE
Add diagram-family citizenship ratchet

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -100,6 +100,26 @@ dependents after. IDs are stable names, not an ordering.
     cases/exclusions/README shape so all benches read alike
   - [ ] mindmap, gitgraph: harvest BEFORE implementing (BUILD-5) — the specs
     should be written against upstream's real test semantics, not just docs
+- [ ] **BUILD-22 — Diagram-family citizenship gap backfill** (`todo`). Keep
+  the checked matrix in
+  [`docs/contributing/diagram-family-citizenship.matrix.json`](./docs/contributing/diagram-family-citizenship.matrix.json)
+  honest as older families graduate toward the Gantt bar. The ratchet is in
+  place once issue #41 lands; this item tracks the explicit exceptions the
+  matrix is allowed to name.
+  - [ ] Stable ASCII/TUI/editor region assertions for every non-graph family
+    (issue #26 WS10). Flowchart/sequence/Gantt are pinned; backfill family-
+    specific region tests for state, timeline, class, ER, journey,
+    architecture, xychart, pie, and quadrant.
+  - [ ] Targeted mutation lanes or sabotage scripts for state, sequence,
+    timeline, class, ER, journey, pie, and quadrant. Flowchart/link routing,
+    xychart/architecture, and Gantt already have focused Stryker lanes.
+  - [ ] Executable divergence ledgers for every family with known upstream
+    incompatibilities. This overlaps BUILD-20; update the citizenship matrix
+    from `exception` to `satisfied` as each `eval/mermaid-<family>-bench/`
+    cases/exclusions runner lands.
+  - [ ] Generated-site/sample evidence beyond category coverage: keep site
+    sample categories, gallery affordances, and generated documentation tied
+    to `BUILTIN_FAMILY_METADATA` whenever a new family is added.
 - [x] **BUILD-11 — QuadrantChart family** (`done`). Promoted
   from the PARK-3 fork-audit list. Quadrant charts are missing across the
   entire beautiful-mermaid fork network (no port exists upstream or in any

--- a/docs/README.md
+++ b/docs/README.md
@@ -36,6 +36,7 @@ This directory holds the long-form documentation. The root README is intentional
 | Doc | Purpose |
 |---|---|
 | [`contributing/adding-diagram-types.md`](./contributing/adding-diagram-types.md) | How to add a Mermaid-supported diagram family. |
+| [`contributing/diagram-family-citizenship.md`](./contributing/diagram-family-citizenship.md) | Enforced good-citizen checklist and matrix for family/surface drift (issue #41). |
 | [`contributing/harvesting-upstream-tests.md`](./contributing/harvesting-upstream-tests.md) | How to vendor upstream/fork test suites into an executable compatibility bench. |
 | [`design/architecture.md`](./design/architecture.md) | Architecture diagram implementation notes. |
 | [`design/gantt.md`](./design/gantt.md) | Gantt support specification and compatibility boundaries. |

--- a/docs/contributing/adding-diagram-types.md
+++ b/docs/contributing/adding-diagram-types.md
@@ -18,6 +18,7 @@ That is necessary, but not sufficient for this repo. Agentic Mermaid also needs 
 - Verify the diagram is already supported by Mermaid.
 - Verify it is not already routed in `src/index.ts` or `src/ascii/index.ts`.
 - Add the family to the type-checked built-in family metadata manifest in `src/agent/families.ts` first. `BUILTIN_FAMILY_METADATA` is the reviewer-facing list for shipped families and has a compile-time coverage assertion against `DiagramKind`.
+- Update the [diagram-family citizenship matrix](./diagram-family-citizenship.md) in the same PR: every citizenship surface must be marked `satisfied` with evidence or `exception` with a tracked follow-up.
 - Prefer Mermaid's stable header if Mermaid supports both stable and beta forms.
 - Write down any known Mermaid features you are intentionally not implementing yet. Those gaps must be documented in the PR before merge.
 
@@ -85,6 +86,7 @@ New diagram support should normally include most of these layers:
 - Regression tests for easy-to-break behavior such as ordering, escaping, markers, label normalization, or routing
 - Sample coverage in `scripts/site/samples-data.ts` when the feature should appear on the visual samples page
 - Live editor coverage in `editor/js/examples.js`: add one basic example under the `Supported diagrams` category, add an explicit picker glyph, and let `src/__tests__/editor-examples.test.ts` prove it parses and renders. This is required for every registered built-in family, not just marketing-worthy ones.
+- Citizenship matrix coverage in `docs/contributing/diagram-family-citizenship.matrix.json`, with evidence paths for completed surfaces and tracked exceptions for deferred quality/compatibility work.
 - README updates for the new supported diagram type and any intentional compatibility gaps
 
 Use the existing naming pattern where possible:

--- a/docs/contributing/diagram-family-citizenship.matrix.json
+++ b/docs/contributing/diagram-family-citizenship.matrix.json
@@ -1,0 +1,2282 @@
+{
+  "schemaVersion": 1,
+  "updated": "2026-06-16",
+  "statusValues": [
+    "satisfied",
+    "exception"
+  ],
+  "surfaces": [
+    {
+      "id": "registryDiscovery",
+      "description": "Registry, DiagramKind, plugin registration, CLI capability metadata, and mutation-op projection."
+    },
+    {
+      "id": "detectionParse",
+      "description": "Shared family detection and agent parse route the family consistently."
+    },
+    {
+      "id": "semanticModel",
+      "description": "Modeled subset and source-preservation policy are explicit in code/docs."
+    },
+    {
+      "id": "serializeRoundTrip",
+      "description": "Modeled and opaque/segment-preserved syntax round-trip without silent loss."
+    },
+    {
+      "id": "typedMutation",
+      "description": "A public narrower and mutation ops are exposed; opaque fallback bodies stay source-level only."
+    },
+    {
+      "id": "verifyRenderSeam",
+      "description": "Verification catches render-blocking conditions with named warning/error codes."
+    },
+    {
+      "id": "determinism",
+      "description": "No ambient nondeterminism; repeated renders/layouts are stable or controlled by explicit options."
+    },
+    {
+      "id": "svgRender",
+      "description": "SVG/PNG-capable rendering path is covered."
+    },
+    {
+      "id": "asciiUnicodeRender",
+      "description": "ASCII/Unicode rendering path is covered."
+    },
+    {
+      "id": "layoutProjection",
+      "description": "layoutMermaid/verify layout expose truthful geometry for the family."
+    },
+    {
+      "id": "stableRegions",
+      "description": "Region metadata for editor/TUI/accessibility is covered or tracked."
+    },
+    {
+      "id": "editorExample",
+      "description": "Live editor supported examples and glyphs cover the family."
+    },
+    {
+      "id": "docsAgentSurfaces",
+      "description": "Human docs, agent docs, SDK declarations, llms.txt, and skills are synchronized."
+    },
+    {
+      "id": "evalFixture",
+      "description": "Shared skill benchmark includes a fixture-backed case tagged for the family."
+    },
+    {
+      "id": "upstreamHarvest",
+      "description": "Upstream Mermaid/fork tests are harvested into executable cases/exclusions or tracked."
+    },
+    {
+      "id": "divergenceLedger",
+      "description": "Known compatibility divergences are executable or tracked."
+    },
+    {
+      "id": "domainProperties",
+      "description": "Family-specific semantic/layout invariants are tested beyond render smoke."
+    },
+    {
+      "id": "goldensEvidence",
+      "description": "Goldens, snapshots, or reviewer evidence cover representative output."
+    },
+    {
+      "id": "generatedSite",
+      "description": "Generated site samples/gallery surfaces cover the family."
+    },
+    {
+      "id": "distributionPackage",
+      "description": "Package files/exports/consumer init artifacts expose the family surface."
+    },
+    {
+      "id": "mutationLane",
+      "description": "Targeted mutation/sabotage lane exists or is tracked."
+    }
+  ],
+  "families": {
+    "flowchart": {
+      "label": "Flowchart",
+      "auditLevel": "audited",
+      "role": "route-contract exemplar",
+      "workedExample": false,
+      "cells": {
+        "registryDiscovery": {
+          "status": "satisfied",
+          "evidence": [
+            "src/agent/families.ts",
+            "src/__tests__/agent-doc-sync.test.ts",
+            "src/__tests__/cli-capabilities.test.ts"
+          ]
+        },
+        "detectionParse": {
+          "status": "satisfied",
+          "evidence": [
+            "src/mermaid-source.ts",
+            "src/__tests__/agent-doc-sync.test.ts",
+            "src/__tests__/doc-sync.test.ts"
+          ]
+        },
+        "semanticModel": {
+          "status": "satisfied",
+          "evidence": [
+            "src/agent/flowchart-body.ts",
+            "src/parser.ts",
+            "docs/design/flowchart-parser-conformance.md"
+          ]
+        },
+        "serializeRoundTrip": {
+          "status": "satisfied",
+          "evidence": [
+            "src/__tests__/agent.test.ts",
+            "src/__tests__/link-grammar.test.ts",
+            "src/__tests__/flowchart-metadata.test.ts",
+            "src/__tests__/flowchart-parser-conformance.test.ts"
+          ]
+        },
+        "typedMutation": {
+          "status": "satisfied",
+          "evidence": [
+            "src/cli/index.ts",
+            "src/mcp/sdk-decl.ts",
+            "src/__tests__/agent-doc-sync.test.ts"
+          ]
+        },
+        "verifyRenderSeam": {
+          "status": "satisfied",
+          "evidence": [
+            "src/agent/verify.ts",
+            "src/__tests__/agent-family-layouts.test.ts"
+          ]
+        },
+        "determinism": {
+          "status": "satisfied",
+          "evidence": [
+            "src/__tests__/agent-determinism.test.ts",
+            "src/__tests__/ascii-determinism.test.ts",
+            "src/__tests__/agent-png-determinism.test.ts"
+          ]
+        },
+        "svgRender": {
+          "status": "satisfied",
+          "evidence": [
+            "src/__tests__/doc-sync.test.ts",
+            "src/__tests__/integration.test.ts"
+          ]
+        },
+        "asciiUnicodeRender": {
+          "status": "satisfied",
+          "evidence": [
+            "src/__tests__/ascii.test.ts",
+            "src/__tests__/ascii-determinism.test.ts"
+          ]
+        },
+        "layoutProjection": {
+          "status": "satisfied",
+          "evidence": [
+            "src/agent/family-layouts.ts",
+            "src/__tests__/agent-family-layouts.test.ts",
+            "src/__tests__/layout-compare.test.ts"
+          ]
+        },
+        "stableRegions": {
+          "status": "satisfied",
+          "evidence": [
+            "src/__tests__/agent-ascii-meta.test.ts",
+            "src/ascii/meta.ts"
+          ]
+        },
+        "editorExample": {
+          "status": "satisfied",
+          "evidence": [
+            "editor/js/examples.js",
+            "src/__tests__/editor-examples.test.ts",
+            "e2e/browser.test.ts"
+          ]
+        },
+        "docsAgentSurfaces": {
+          "status": "satisfied",
+          "evidence": [
+            "src/__tests__/agent-doc-sync.test.ts",
+            "src/__tests__/cli-llms-txt.test.ts",
+            "docs/diagram-families.md",
+            "AGENT_NATIVE.md",
+            "Instructions_for_agents.md",
+            "llms.txt"
+          ]
+        },
+        "evalFixture": {
+          "status": "satisfied",
+          "evidence": [
+            "evals/shared-benchmark.json",
+            "src/__tests__/agent-doc-sync.test.ts"
+          ]
+        },
+        "upstreamHarvest": {
+          "status": "exception",
+          "tracked": [
+            "TODO:BUILD-20"
+          ],
+          "evidence": [
+            "TODO.md",
+            "docs/contributing/harvesting-upstream-tests.md"
+          ],
+          "note": "Standardized cases/exclusions harvest is tracked for all non-Gantt families."
+        },
+        "divergenceLedger": {
+          "status": "exception",
+          "tracked": [
+            "TODO:BUILD-20",
+            "TODO:BUILD-22"
+          ],
+          "evidence": [
+            "TODO.md",
+            "docs/contributing/harvesting-upstream-tests.md"
+          ],
+          "note": "Executable divergence ledgers graduate with each upstream harvest."
+        },
+        "domainProperties": {
+          "status": "satisfied",
+          "evidence": [
+            "src/__tests__/route-contracts.test.ts",
+            "src/__tests__/layout-rubric.test.ts",
+            "src/__tests__/property-ascii-routing.test.ts"
+          ]
+        },
+        "goldensEvidence": {
+          "status": "satisfied",
+          "evidence": [
+            "docs/pr-assets/contact-sheet.png",
+            "src/__tests__/contact-sheet.test.ts"
+          ]
+        },
+        "generatedSite": {
+          "status": "satisfied",
+          "evidence": [
+            "scripts/site/samples-data.ts",
+            "scripts/site/generate.ts",
+            "src/__tests__/property-html-generator.test.ts"
+          ]
+        },
+        "distributionPackage": {
+          "status": "satisfied",
+          "evidence": [
+            "package.json",
+            "src/__tests__/doc-sync.test.ts",
+            "src/__tests__/agent-doc-sync.test.ts"
+          ]
+        },
+        "mutationLane": {
+          "status": "satisfied",
+          "evidence": [
+            "stryker.routes.config.json",
+            "stryker.link-grammar.config.json",
+            "stryker.route-certificates.config.json",
+            "package.json"
+          ]
+        }
+      }
+    },
+    "state": {
+      "label": "State",
+      "auditLevel": "inventoried",
+      "role": "dedicated-body follow-up to flowchart",
+      "workedExample": false,
+      "cells": {
+        "registryDiscovery": {
+          "status": "satisfied",
+          "evidence": [
+            "src/agent/families.ts",
+            "src/__tests__/agent-doc-sync.test.ts",
+            "src/__tests__/cli-capabilities.test.ts"
+          ]
+        },
+        "detectionParse": {
+          "status": "satisfied",
+          "evidence": [
+            "src/mermaid-source.ts",
+            "src/__tests__/agent-doc-sync.test.ts",
+            "src/__tests__/doc-sync.test.ts"
+          ]
+        },
+        "semanticModel": {
+          "status": "satisfied",
+          "evidence": [
+            "src/agent/state-body.ts",
+            "src/__tests__/agent-state.test.ts"
+          ]
+        },
+        "serializeRoundTrip": {
+          "status": "satisfied",
+          "evidence": [
+            "src/__tests__/agent-state.test.ts",
+            "src/__tests__/parser.test.ts"
+          ]
+        },
+        "typedMutation": {
+          "status": "satisfied",
+          "evidence": [
+            "src/cli/index.ts",
+            "src/mcp/sdk-decl.ts",
+            "src/__tests__/agent-doc-sync.test.ts"
+          ]
+        },
+        "verifyRenderSeam": {
+          "status": "satisfied",
+          "evidence": [
+            "src/agent/verify.ts",
+            "src/__tests__/agent-family-layouts.test.ts"
+          ]
+        },
+        "determinism": {
+          "status": "satisfied",
+          "evidence": [
+            "src/__tests__/agent-determinism.test.ts",
+            "src/__tests__/ascii-determinism.test.ts",
+            "src/__tests__/agent-png-determinism.test.ts"
+          ]
+        },
+        "svgRender": {
+          "status": "satisfied",
+          "evidence": [
+            "src/__tests__/doc-sync.test.ts",
+            "src/__tests__/integration.test.ts"
+          ]
+        },
+        "asciiUnicodeRender": {
+          "status": "satisfied",
+          "evidence": [
+            "src/__tests__/ascii.test.ts",
+            "src/__tests__/ascii-determinism.test.ts"
+          ]
+        },
+        "layoutProjection": {
+          "status": "satisfied",
+          "evidence": [
+            "src/agent/family-layouts.ts",
+            "src/__tests__/agent-family-layouts.test.ts",
+            "src/__tests__/layout-compare.test.ts"
+          ]
+        },
+        "stableRegions": {
+          "status": "exception",
+          "tracked": [
+            "TODO:BUILD-22"
+          ],
+          "evidence": [
+            "TODO.md",
+            "src/ascii/meta.ts"
+          ],
+          "note": "Family-specific region assertions beyond the pinned graph/sequence/Gantt paths are tracked."
+        },
+        "editorExample": {
+          "status": "satisfied",
+          "evidence": [
+            "editor/js/examples.js",
+            "src/__tests__/editor-examples.test.ts",
+            "e2e/browser.test.ts"
+          ]
+        },
+        "docsAgentSurfaces": {
+          "status": "satisfied",
+          "evidence": [
+            "src/__tests__/agent-doc-sync.test.ts",
+            "src/__tests__/cli-llms-txt.test.ts",
+            "docs/diagram-families.md",
+            "AGENT_NATIVE.md",
+            "Instructions_for_agents.md",
+            "llms.txt"
+          ]
+        },
+        "evalFixture": {
+          "status": "satisfied",
+          "evidence": [
+            "evals/shared-benchmark.json",
+            "src/__tests__/agent-doc-sync.test.ts"
+          ]
+        },
+        "upstreamHarvest": {
+          "status": "exception",
+          "tracked": [
+            "TODO:BUILD-20"
+          ],
+          "evidence": [
+            "TODO.md",
+            "docs/contributing/harvesting-upstream-tests.md"
+          ],
+          "note": "Standardized cases/exclusions harvest is tracked for all non-Gantt families."
+        },
+        "divergenceLedger": {
+          "status": "exception",
+          "tracked": [
+            "TODO:BUILD-20",
+            "TODO:BUILD-22"
+          ],
+          "evidence": [
+            "TODO.md",
+            "docs/contributing/harvesting-upstream-tests.md"
+          ],
+          "note": "Executable divergence ledgers graduate with each upstream harvest."
+        },
+        "domainProperties": {
+          "status": "satisfied",
+          "evidence": [
+            "src/__tests__/agent-state.test.ts",
+            "src/__tests__/subgraph-direction.test.ts"
+          ]
+        },
+        "goldensEvidence": {
+          "status": "satisfied",
+          "evidence": [
+            "src/__tests__/parser.test.ts",
+            "src/__tests__/agent-state.test.ts"
+          ]
+        },
+        "generatedSite": {
+          "status": "satisfied",
+          "evidence": [
+            "scripts/site/samples-data.ts",
+            "scripts/site/generate.ts",
+            "src/__tests__/property-html-generator.test.ts"
+          ]
+        },
+        "distributionPackage": {
+          "status": "satisfied",
+          "evidence": [
+            "package.json",
+            "src/__tests__/doc-sync.test.ts",
+            "src/__tests__/agent-doc-sync.test.ts"
+          ]
+        },
+        "mutationLane": {
+          "status": "exception",
+          "tracked": [
+            "TODO:BUILD-22"
+          ],
+          "evidence": [
+            "TODO.md",
+            "docs/agent-mutation-policy.md"
+          ],
+          "note": "Focused mutation/sabotage lane is not yet family-specific."
+        }
+      }
+    },
+    "sequence": {
+      "label": "Sequence",
+      "auditLevel": "inventoried",
+      "role": "segment-preservation exemplar",
+      "workedExample": false,
+      "cells": {
+        "registryDiscovery": {
+          "status": "satisfied",
+          "evidence": [
+            "src/agent/families.ts",
+            "src/__tests__/agent-doc-sync.test.ts",
+            "src/__tests__/cli-capabilities.test.ts"
+          ]
+        },
+        "detectionParse": {
+          "status": "satisfied",
+          "evidence": [
+            "src/mermaid-source.ts",
+            "src/__tests__/agent-doc-sync.test.ts",
+            "src/__tests__/doc-sync.test.ts"
+          ]
+        },
+        "semanticModel": {
+          "status": "satisfied",
+          "evidence": [
+            "src/agent/sequence-body.ts",
+            "src/__tests__/agent.test.ts"
+          ]
+        },
+        "serializeRoundTrip": {
+          "status": "satisfied",
+          "evidence": [
+            "src/__tests__/agent.test.ts",
+            "src/__tests__/agent-mermaidseqbench.test.ts"
+          ]
+        },
+        "typedMutation": {
+          "status": "satisfied",
+          "evidence": [
+            "src/cli/index.ts",
+            "src/mcp/sdk-decl.ts",
+            "src/__tests__/agent-doc-sync.test.ts"
+          ]
+        },
+        "verifyRenderSeam": {
+          "status": "satisfied",
+          "evidence": [
+            "src/agent/verify.ts",
+            "src/__tests__/agent-family-layouts.test.ts"
+          ]
+        },
+        "determinism": {
+          "status": "satisfied",
+          "evidence": [
+            "src/__tests__/agent-determinism.test.ts",
+            "src/__tests__/ascii-determinism.test.ts",
+            "src/__tests__/agent-png-determinism.test.ts"
+          ]
+        },
+        "svgRender": {
+          "status": "satisfied",
+          "evidence": [
+            "src/__tests__/doc-sync.test.ts",
+            "src/__tests__/integration.test.ts"
+          ]
+        },
+        "asciiUnicodeRender": {
+          "status": "satisfied",
+          "evidence": [
+            "src/__tests__/ascii.test.ts",
+            "src/__tests__/ascii-determinism.test.ts"
+          ]
+        },
+        "layoutProjection": {
+          "status": "satisfied",
+          "evidence": [
+            "src/agent/family-layouts.ts",
+            "src/__tests__/agent-family-layouts.test.ts",
+            "src/__tests__/layout-compare.test.ts"
+          ]
+        },
+        "stableRegions": {
+          "status": "satisfied",
+          "evidence": [
+            "src/__tests__/agent-ascii-meta.test.ts",
+            "src/ascii/meta.ts"
+          ]
+        },
+        "editorExample": {
+          "status": "satisfied",
+          "evidence": [
+            "editor/js/examples.js",
+            "src/__tests__/editor-examples.test.ts",
+            "e2e/browser.test.ts"
+          ]
+        },
+        "docsAgentSurfaces": {
+          "status": "satisfied",
+          "evidence": [
+            "src/__tests__/agent-doc-sync.test.ts",
+            "src/__tests__/cli-llms-txt.test.ts",
+            "docs/diagram-families.md",
+            "AGENT_NATIVE.md",
+            "Instructions_for_agents.md",
+            "llms.txt"
+          ]
+        },
+        "evalFixture": {
+          "status": "satisfied",
+          "evidence": [
+            "evals/shared-benchmark.json",
+            "src/__tests__/agent-doc-sync.test.ts"
+          ]
+        },
+        "upstreamHarvest": {
+          "status": "exception",
+          "tracked": [
+            "TODO:BUILD-20"
+          ],
+          "evidence": [
+            "TODO.md",
+            "docs/contributing/harvesting-upstream-tests.md"
+          ],
+          "note": "Standardized cases/exclusions harvest is tracked for all non-Gantt families."
+        },
+        "divergenceLedger": {
+          "status": "exception",
+          "tracked": [
+            "TODO:BUILD-20",
+            "TODO:BUILD-22"
+          ],
+          "evidence": [
+            "TODO.md",
+            "docs/contributing/harvesting-upstream-tests.md"
+          ],
+          "note": "Executable divergence ledgers graduate with each upstream harvest."
+        },
+        "domainProperties": {
+          "status": "satisfied",
+          "evidence": [
+            "src/__tests__/agent.test.ts",
+            "src/__tests__/agent-mermaidseqbench.test.ts",
+            "src/__tests__/ascii-sequence-blocks.test.ts"
+          ]
+        },
+        "goldensEvidence": {
+          "status": "satisfied",
+          "evidence": [
+            "src/__tests__/journey-svg-snapshot.test.ts",
+            "src/__tests__/agent-mermaidseqbench.test.ts"
+          ]
+        },
+        "generatedSite": {
+          "status": "satisfied",
+          "evidence": [
+            "scripts/site/samples-data.ts",
+            "scripts/site/generate.ts",
+            "src/__tests__/property-html-generator.test.ts"
+          ]
+        },
+        "distributionPackage": {
+          "status": "satisfied",
+          "evidence": [
+            "package.json",
+            "src/__tests__/doc-sync.test.ts",
+            "src/__tests__/agent-doc-sync.test.ts"
+          ]
+        },
+        "mutationLane": {
+          "status": "exception",
+          "tracked": [
+            "TODO:BUILD-22"
+          ],
+          "evidence": [
+            "TODO.md",
+            "docs/agent-mutation-policy.md"
+          ],
+          "note": "Focused mutation/sabotage lane is not yet family-specific."
+        }
+      }
+    },
+    "timeline": {
+      "label": "Timeline",
+      "auditLevel": "inventoried",
+      "role": "ordering/bounds family",
+      "workedExample": false,
+      "cells": {
+        "registryDiscovery": {
+          "status": "satisfied",
+          "evidence": [
+            "src/agent/families.ts",
+            "src/__tests__/agent-doc-sync.test.ts",
+            "src/__tests__/cli-capabilities.test.ts"
+          ]
+        },
+        "detectionParse": {
+          "status": "satisfied",
+          "evidence": [
+            "src/mermaid-source.ts",
+            "src/__tests__/agent-doc-sync.test.ts",
+            "src/__tests__/doc-sync.test.ts"
+          ]
+        },
+        "semanticModel": {
+          "status": "satisfied",
+          "evidence": [
+            "src/agent/timeline-body.ts",
+            "src/timeline/parser.ts"
+          ]
+        },
+        "serializeRoundTrip": {
+          "status": "satisfied",
+          "evidence": [
+            "src/__tests__/agent-timeline.test.ts",
+            "src/__tests__/timeline-parser.test.ts"
+          ]
+        },
+        "typedMutation": {
+          "status": "satisfied",
+          "evidence": [
+            "src/cli/index.ts",
+            "src/mcp/sdk-decl.ts",
+            "src/__tests__/agent-doc-sync.test.ts"
+          ]
+        },
+        "verifyRenderSeam": {
+          "status": "satisfied",
+          "evidence": [
+            "src/agent/verify.ts",
+            "src/__tests__/agent-family-layouts.test.ts"
+          ]
+        },
+        "determinism": {
+          "status": "satisfied",
+          "evidence": [
+            "src/__tests__/agent-determinism.test.ts",
+            "src/__tests__/ascii-determinism.test.ts",
+            "src/__tests__/agent-png-determinism.test.ts"
+          ]
+        },
+        "svgRender": {
+          "status": "satisfied",
+          "evidence": [
+            "src/__tests__/doc-sync.test.ts",
+            "src/__tests__/integration.test.ts"
+          ]
+        },
+        "asciiUnicodeRender": {
+          "status": "satisfied",
+          "evidence": [
+            "src/__tests__/ascii.test.ts",
+            "src/__tests__/ascii-determinism.test.ts"
+          ]
+        },
+        "layoutProjection": {
+          "status": "satisfied",
+          "evidence": [
+            "src/agent/family-layouts.ts",
+            "src/__tests__/agent-family-layouts.test.ts",
+            "src/__tests__/layout-compare.test.ts"
+          ]
+        },
+        "stableRegions": {
+          "status": "exception",
+          "tracked": [
+            "TODO:BUILD-22"
+          ],
+          "evidence": [
+            "TODO.md",
+            "src/ascii/meta.ts"
+          ],
+          "note": "Family-specific region assertions beyond the pinned graph/sequence/Gantt paths are tracked."
+        },
+        "editorExample": {
+          "status": "satisfied",
+          "evidence": [
+            "editor/js/examples.js",
+            "src/__tests__/editor-examples.test.ts",
+            "e2e/browser.test.ts"
+          ]
+        },
+        "docsAgentSurfaces": {
+          "status": "satisfied",
+          "evidence": [
+            "src/__tests__/agent-doc-sync.test.ts",
+            "src/__tests__/cli-llms-txt.test.ts",
+            "docs/diagram-families.md",
+            "AGENT_NATIVE.md",
+            "Instructions_for_agents.md",
+            "llms.txt"
+          ]
+        },
+        "evalFixture": {
+          "status": "satisfied",
+          "evidence": [
+            "evals/shared-benchmark.json",
+            "src/__tests__/agent-doc-sync.test.ts"
+          ]
+        },
+        "upstreamHarvest": {
+          "status": "exception",
+          "tracked": [
+            "TODO:BUILD-20"
+          ],
+          "evidence": [
+            "TODO.md",
+            "docs/contributing/harvesting-upstream-tests.md"
+          ],
+          "note": "Standardized cases/exclusions harvest is tracked for all non-Gantt families."
+        },
+        "divergenceLedger": {
+          "status": "exception",
+          "tracked": [
+            "TODO:BUILD-20",
+            "TODO:BUILD-22"
+          ],
+          "evidence": [
+            "TODO.md",
+            "docs/contributing/harvesting-upstream-tests.md"
+          ],
+          "note": "Executable divergence ledgers graduate with each upstream harvest."
+        },
+        "domainProperties": {
+          "status": "satisfied",
+          "evidence": [
+            "src/__tests__/timeline-layout.test.ts",
+            "src/__tests__/property-layout-bounds.test.ts"
+          ]
+        },
+        "goldensEvidence": {
+          "status": "satisfied",
+          "evidence": [
+            "src/__tests__/timeline-ascii.test.ts",
+            "src/__tests__/testdata/ascii/timeline_multisection_multiline.txt"
+          ]
+        },
+        "generatedSite": {
+          "status": "satisfied",
+          "evidence": [
+            "scripts/site/samples-data.ts",
+            "scripts/site/generate.ts",
+            "src/__tests__/property-html-generator.test.ts"
+          ]
+        },
+        "distributionPackage": {
+          "status": "satisfied",
+          "evidence": [
+            "package.json",
+            "src/__tests__/doc-sync.test.ts",
+            "src/__tests__/agent-doc-sync.test.ts"
+          ]
+        },
+        "mutationLane": {
+          "status": "exception",
+          "tracked": [
+            "TODO:BUILD-22"
+          ],
+          "evidence": [
+            "TODO.md",
+            "docs/agent-mutation-policy.md"
+          ],
+          "note": "Focused mutation/sabotage lane is not yet family-specific."
+        }
+      }
+    },
+    "class": {
+      "label": "Class",
+      "auditLevel": "inventoried",
+      "role": "identity/relation family",
+      "workedExample": false,
+      "cells": {
+        "registryDiscovery": {
+          "status": "satisfied",
+          "evidence": [
+            "src/agent/families.ts",
+            "src/__tests__/agent-doc-sync.test.ts",
+            "src/__tests__/cli-capabilities.test.ts"
+          ]
+        },
+        "detectionParse": {
+          "status": "satisfied",
+          "evidence": [
+            "src/mermaid-source.ts",
+            "src/__tests__/agent-doc-sync.test.ts",
+            "src/__tests__/doc-sync.test.ts"
+          ]
+        },
+        "semanticModel": {
+          "status": "satisfied",
+          "evidence": [
+            "src/agent/class-body.ts",
+            "src/class/parser.ts"
+          ]
+        },
+        "serializeRoundTrip": {
+          "status": "satisfied",
+          "evidence": [
+            "src/__tests__/agent-class.test.ts",
+            "src/__tests__/class-parser.test.ts"
+          ]
+        },
+        "typedMutation": {
+          "status": "satisfied",
+          "evidence": [
+            "src/cli/index.ts",
+            "src/mcp/sdk-decl.ts",
+            "src/__tests__/agent-doc-sync.test.ts"
+          ]
+        },
+        "verifyRenderSeam": {
+          "status": "satisfied",
+          "evidence": [
+            "src/agent/verify.ts",
+            "src/__tests__/agent-family-layouts.test.ts"
+          ]
+        },
+        "determinism": {
+          "status": "satisfied",
+          "evidence": [
+            "src/__tests__/agent-determinism.test.ts",
+            "src/__tests__/ascii-determinism.test.ts",
+            "src/__tests__/agent-png-determinism.test.ts"
+          ]
+        },
+        "svgRender": {
+          "status": "satisfied",
+          "evidence": [
+            "src/__tests__/doc-sync.test.ts",
+            "src/__tests__/integration.test.ts"
+          ]
+        },
+        "asciiUnicodeRender": {
+          "status": "satisfied",
+          "evidence": [
+            "src/__tests__/ascii.test.ts",
+            "src/__tests__/ascii-determinism.test.ts"
+          ]
+        },
+        "layoutProjection": {
+          "status": "satisfied",
+          "evidence": [
+            "src/agent/family-layouts.ts",
+            "src/__tests__/agent-family-layouts.test.ts",
+            "src/__tests__/layout-compare.test.ts"
+          ]
+        },
+        "stableRegions": {
+          "status": "exception",
+          "tracked": [
+            "TODO:BUILD-22"
+          ],
+          "evidence": [
+            "TODO.md",
+            "src/ascii/meta.ts"
+          ],
+          "note": "Family-specific region assertions beyond the pinned graph/sequence/Gantt paths are tracked."
+        },
+        "editorExample": {
+          "status": "satisfied",
+          "evidence": [
+            "editor/js/examples.js",
+            "src/__tests__/editor-examples.test.ts",
+            "e2e/browser.test.ts"
+          ]
+        },
+        "docsAgentSurfaces": {
+          "status": "satisfied",
+          "evidence": [
+            "src/__tests__/agent-doc-sync.test.ts",
+            "src/__tests__/cli-llms-txt.test.ts",
+            "docs/diagram-families.md",
+            "AGENT_NATIVE.md",
+            "Instructions_for_agents.md",
+            "llms.txt"
+          ]
+        },
+        "evalFixture": {
+          "status": "satisfied",
+          "evidence": [
+            "evals/shared-benchmark.json",
+            "src/__tests__/agent-doc-sync.test.ts"
+          ]
+        },
+        "upstreamHarvest": {
+          "status": "exception",
+          "tracked": [
+            "TODO:BUILD-20"
+          ],
+          "evidence": [
+            "TODO.md",
+            "docs/contributing/harvesting-upstream-tests.md"
+          ],
+          "note": "Standardized cases/exclusions harvest is tracked for all non-Gantt families."
+        },
+        "divergenceLedger": {
+          "status": "exception",
+          "tracked": [
+            "TODO:BUILD-20",
+            "TODO:BUILD-22"
+          ],
+          "evidence": [
+            "TODO.md",
+            "docs/contributing/harvesting-upstream-tests.md"
+          ],
+          "note": "Executable divergence ledgers graduate with each upstream harvest."
+        },
+        "domainProperties": {
+          "status": "satisfied",
+          "evidence": [
+            "src/__tests__/class-parser.test.ts",
+            "src/__tests__/class-arrow-directions.test.ts",
+            "src/__tests__/class-er-edge-quality.test.ts"
+          ]
+        },
+        "goldensEvidence": {
+          "status": "satisfied",
+          "evidence": [
+            "src/__tests__/class-integration.test.ts",
+            "src/__tests__/class-er-edge-quality.test.ts"
+          ]
+        },
+        "generatedSite": {
+          "status": "satisfied",
+          "evidence": [
+            "scripts/site/samples-data.ts",
+            "scripts/site/generate.ts",
+            "src/__tests__/property-html-generator.test.ts"
+          ]
+        },
+        "distributionPackage": {
+          "status": "satisfied",
+          "evidence": [
+            "package.json",
+            "src/__tests__/doc-sync.test.ts",
+            "src/__tests__/agent-doc-sync.test.ts"
+          ]
+        },
+        "mutationLane": {
+          "status": "exception",
+          "tracked": [
+            "TODO:BUILD-22"
+          ],
+          "evidence": [
+            "TODO.md",
+            "docs/agent-mutation-policy.md"
+          ],
+          "note": "Focused mutation/sabotage lane is not yet family-specific."
+        }
+      }
+    },
+    "er": {
+      "label": "ER",
+      "auditLevel": "inventoried",
+      "role": "cardinality/relation family",
+      "workedExample": false,
+      "cells": {
+        "registryDiscovery": {
+          "status": "satisfied",
+          "evidence": [
+            "src/agent/families.ts",
+            "src/__tests__/agent-doc-sync.test.ts",
+            "src/__tests__/cli-capabilities.test.ts"
+          ]
+        },
+        "detectionParse": {
+          "status": "satisfied",
+          "evidence": [
+            "src/mermaid-source.ts",
+            "src/__tests__/agent-doc-sync.test.ts",
+            "src/__tests__/doc-sync.test.ts"
+          ]
+        },
+        "semanticModel": {
+          "status": "satisfied",
+          "evidence": [
+            "src/agent/er-body.ts",
+            "src/er/parser.ts"
+          ]
+        },
+        "serializeRoundTrip": {
+          "status": "satisfied",
+          "evidence": [
+            "src/__tests__/agent-er.test.ts",
+            "src/__tests__/er-parser.test.ts"
+          ]
+        },
+        "typedMutation": {
+          "status": "satisfied",
+          "evidence": [
+            "src/cli/index.ts",
+            "src/mcp/sdk-decl.ts",
+            "src/__tests__/agent-doc-sync.test.ts"
+          ]
+        },
+        "verifyRenderSeam": {
+          "status": "satisfied",
+          "evidence": [
+            "src/agent/verify.ts",
+            "src/__tests__/agent-family-layouts.test.ts"
+          ]
+        },
+        "determinism": {
+          "status": "satisfied",
+          "evidence": [
+            "src/__tests__/agent-determinism.test.ts",
+            "src/__tests__/ascii-determinism.test.ts",
+            "src/__tests__/agent-png-determinism.test.ts"
+          ]
+        },
+        "svgRender": {
+          "status": "satisfied",
+          "evidence": [
+            "src/__tests__/doc-sync.test.ts",
+            "src/__tests__/integration.test.ts"
+          ]
+        },
+        "asciiUnicodeRender": {
+          "status": "satisfied",
+          "evidence": [
+            "src/__tests__/ascii.test.ts",
+            "src/__tests__/ascii-determinism.test.ts"
+          ]
+        },
+        "layoutProjection": {
+          "status": "satisfied",
+          "evidence": [
+            "src/agent/family-layouts.ts",
+            "src/__tests__/agent-family-layouts.test.ts",
+            "src/__tests__/layout-compare.test.ts"
+          ]
+        },
+        "stableRegions": {
+          "status": "exception",
+          "tracked": [
+            "TODO:BUILD-22"
+          ],
+          "evidence": [
+            "TODO.md",
+            "src/ascii/meta.ts"
+          ],
+          "note": "Family-specific region assertions beyond the pinned graph/sequence/Gantt paths are tracked."
+        },
+        "editorExample": {
+          "status": "satisfied",
+          "evidence": [
+            "editor/js/examples.js",
+            "src/__tests__/editor-examples.test.ts",
+            "e2e/browser.test.ts"
+          ]
+        },
+        "docsAgentSurfaces": {
+          "status": "satisfied",
+          "evidence": [
+            "src/__tests__/agent-doc-sync.test.ts",
+            "src/__tests__/cli-llms-txt.test.ts",
+            "docs/diagram-families.md",
+            "AGENT_NATIVE.md",
+            "Instructions_for_agents.md",
+            "llms.txt"
+          ]
+        },
+        "evalFixture": {
+          "status": "satisfied",
+          "evidence": [
+            "evals/shared-benchmark.json",
+            "src/__tests__/agent-doc-sync.test.ts"
+          ]
+        },
+        "upstreamHarvest": {
+          "status": "exception",
+          "tracked": [
+            "TODO:BUILD-20"
+          ],
+          "evidence": [
+            "TODO.md",
+            "docs/contributing/harvesting-upstream-tests.md"
+          ],
+          "note": "Standardized cases/exclusions harvest is tracked for all non-Gantt families."
+        },
+        "divergenceLedger": {
+          "status": "exception",
+          "tracked": [
+            "TODO:BUILD-20",
+            "TODO:BUILD-22"
+          ],
+          "evidence": [
+            "TODO.md",
+            "docs/contributing/harvesting-upstream-tests.md"
+          ],
+          "note": "Executable divergence ledgers graduate with each upstream harvest."
+        },
+        "domainProperties": {
+          "status": "satisfied",
+          "evidence": [
+            "src/__tests__/agent-er.test.ts",
+            "src/__tests__/er-parser.test.ts",
+            "src/__tests__/class-er-edge-quality.test.ts"
+          ]
+        },
+        "goldensEvidence": {
+          "status": "satisfied",
+          "evidence": [
+            "src/__tests__/er-integration.test.ts",
+            "src/__tests__/testdata/ascii/er_issue121_labels.txt"
+          ]
+        },
+        "generatedSite": {
+          "status": "satisfied",
+          "evidence": [
+            "scripts/site/samples-data.ts",
+            "scripts/site/generate.ts",
+            "src/__tests__/property-html-generator.test.ts"
+          ]
+        },
+        "distributionPackage": {
+          "status": "satisfied",
+          "evidence": [
+            "package.json",
+            "src/__tests__/doc-sync.test.ts",
+            "src/__tests__/agent-doc-sync.test.ts"
+          ]
+        },
+        "mutationLane": {
+          "status": "exception",
+          "tracked": [
+            "TODO:BUILD-22"
+          ],
+          "evidence": [
+            "TODO.md",
+            "docs/agent-mutation-policy.md"
+          ],
+          "note": "Focused mutation/sabotage lane is not yet family-specific."
+        }
+      }
+    },
+    "journey": {
+      "label": "Journey",
+      "auditLevel": "inventoried",
+      "role": "task/score family",
+      "workedExample": false,
+      "cells": {
+        "registryDiscovery": {
+          "status": "satisfied",
+          "evidence": [
+            "src/agent/families.ts",
+            "src/__tests__/agent-doc-sync.test.ts",
+            "src/__tests__/cli-capabilities.test.ts"
+          ]
+        },
+        "detectionParse": {
+          "status": "satisfied",
+          "evidence": [
+            "src/mermaid-source.ts",
+            "src/__tests__/agent-doc-sync.test.ts",
+            "src/__tests__/doc-sync.test.ts"
+          ]
+        },
+        "semanticModel": {
+          "status": "satisfied",
+          "evidence": [
+            "src/agent/journey-body.ts",
+            "src/journey/parser.ts"
+          ]
+        },
+        "serializeRoundTrip": {
+          "status": "satisfied",
+          "evidence": [
+            "src/__tests__/agent-journey.test.ts",
+            "src/__tests__/journey-parser.test.ts"
+          ]
+        },
+        "typedMutation": {
+          "status": "satisfied",
+          "evidence": [
+            "src/cli/index.ts",
+            "src/mcp/sdk-decl.ts",
+            "src/__tests__/agent-doc-sync.test.ts"
+          ]
+        },
+        "verifyRenderSeam": {
+          "status": "satisfied",
+          "evidence": [
+            "src/agent/verify.ts",
+            "src/__tests__/agent-family-layouts.test.ts"
+          ]
+        },
+        "determinism": {
+          "status": "satisfied",
+          "evidence": [
+            "src/__tests__/agent-determinism.test.ts",
+            "src/__tests__/ascii-determinism.test.ts",
+            "src/__tests__/agent-png-determinism.test.ts"
+          ]
+        },
+        "svgRender": {
+          "status": "satisfied",
+          "evidence": [
+            "src/__tests__/doc-sync.test.ts",
+            "src/__tests__/integration.test.ts"
+          ]
+        },
+        "asciiUnicodeRender": {
+          "status": "satisfied",
+          "evidence": [
+            "src/__tests__/ascii.test.ts",
+            "src/__tests__/ascii-determinism.test.ts"
+          ]
+        },
+        "layoutProjection": {
+          "status": "satisfied",
+          "evidence": [
+            "src/agent/family-layouts.ts",
+            "src/__tests__/agent-family-layouts.test.ts",
+            "src/__tests__/layout-compare.test.ts"
+          ]
+        },
+        "stableRegions": {
+          "status": "exception",
+          "tracked": [
+            "TODO:BUILD-22"
+          ],
+          "evidence": [
+            "TODO.md",
+            "src/ascii/meta.ts"
+          ],
+          "note": "Family-specific region assertions beyond the pinned graph/sequence/Gantt paths are tracked."
+        },
+        "editorExample": {
+          "status": "satisfied",
+          "evidence": [
+            "editor/js/examples.js",
+            "src/__tests__/editor-examples.test.ts",
+            "e2e/browser.test.ts"
+          ]
+        },
+        "docsAgentSurfaces": {
+          "status": "satisfied",
+          "evidence": [
+            "src/__tests__/agent-doc-sync.test.ts",
+            "src/__tests__/cli-llms-txt.test.ts",
+            "docs/diagram-families.md",
+            "AGENT_NATIVE.md",
+            "Instructions_for_agents.md",
+            "llms.txt"
+          ]
+        },
+        "evalFixture": {
+          "status": "satisfied",
+          "evidence": [
+            "evals/shared-benchmark.json",
+            "src/__tests__/agent-doc-sync.test.ts"
+          ]
+        },
+        "upstreamHarvest": {
+          "status": "exception",
+          "tracked": [
+            "TODO:BUILD-20"
+          ],
+          "evidence": [
+            "TODO.md",
+            "docs/contributing/harvesting-upstream-tests.md"
+          ],
+          "note": "Standardized cases/exclusions harvest is tracked for all non-Gantt families."
+        },
+        "divergenceLedger": {
+          "status": "exception",
+          "tracked": [
+            "TODO:BUILD-20",
+            "TODO:BUILD-22"
+          ],
+          "evidence": [
+            "TODO.md",
+            "docs/contributing/harvesting-upstream-tests.md"
+          ],
+          "note": "Executable divergence ledgers graduate with each upstream harvest."
+        },
+        "domainProperties": {
+          "status": "satisfied",
+          "evidence": [
+            "src/__tests__/journey-layout.test.ts",
+            "src/__tests__/property-layout-bounds.test.ts"
+          ]
+        },
+        "goldensEvidence": {
+          "status": "satisfied",
+          "evidence": [
+            "src/__tests__/journey-ascii.test.ts",
+            "src/__tests__/journey-svg-snapshot.test.ts"
+          ]
+        },
+        "generatedSite": {
+          "status": "satisfied",
+          "evidence": [
+            "scripts/site/samples-data.ts",
+            "scripts/site/generate.ts",
+            "src/__tests__/property-html-generator.test.ts"
+          ]
+        },
+        "distributionPackage": {
+          "status": "satisfied",
+          "evidence": [
+            "package.json",
+            "src/__tests__/doc-sync.test.ts",
+            "src/__tests__/agent-doc-sync.test.ts"
+          ]
+        },
+        "mutationLane": {
+          "status": "exception",
+          "tracked": [
+            "TODO:BUILD-22"
+          ],
+          "evidence": [
+            "TODO.md",
+            "docs/agent-mutation-policy.md"
+          ],
+          "note": "Focused mutation/sabotage lane is not yet family-specific."
+        }
+      }
+    },
+    "architecture": {
+      "label": "Architecture",
+      "auditLevel": "audited",
+      "role": "group/service containment audit",
+      "workedExample": false,
+      "cells": {
+        "registryDiscovery": {
+          "status": "satisfied",
+          "evidence": [
+            "src/agent/families.ts",
+            "src/__tests__/agent-doc-sync.test.ts",
+            "src/__tests__/cli-capabilities.test.ts"
+          ]
+        },
+        "detectionParse": {
+          "status": "satisfied",
+          "evidence": [
+            "src/mermaid-source.ts",
+            "src/__tests__/agent-doc-sync.test.ts",
+            "src/__tests__/doc-sync.test.ts"
+          ]
+        },
+        "semanticModel": {
+          "status": "satisfied",
+          "evidence": [
+            "src/agent/architecture-body.ts",
+            "src/architecture/parser.ts"
+          ]
+        },
+        "serializeRoundTrip": {
+          "status": "satisfied",
+          "evidence": [
+            "src/__tests__/agent-architecture.test.ts",
+            "src/__tests__/architecture-parser.test.ts"
+          ]
+        },
+        "typedMutation": {
+          "status": "satisfied",
+          "evidence": [
+            "src/cli/index.ts",
+            "src/mcp/sdk-decl.ts",
+            "src/__tests__/agent-doc-sync.test.ts"
+          ]
+        },
+        "verifyRenderSeam": {
+          "status": "satisfied",
+          "evidence": [
+            "src/agent/verify.ts",
+            "src/__tests__/agent-family-layouts.test.ts"
+          ]
+        },
+        "determinism": {
+          "status": "satisfied",
+          "evidence": [
+            "src/__tests__/agent-determinism.test.ts",
+            "src/__tests__/ascii-determinism.test.ts",
+            "src/__tests__/agent-png-determinism.test.ts"
+          ]
+        },
+        "svgRender": {
+          "status": "satisfied",
+          "evidence": [
+            "src/__tests__/doc-sync.test.ts",
+            "src/__tests__/integration.test.ts"
+          ]
+        },
+        "asciiUnicodeRender": {
+          "status": "satisfied",
+          "evidence": [
+            "src/__tests__/ascii.test.ts",
+            "src/__tests__/ascii-determinism.test.ts"
+          ]
+        },
+        "layoutProjection": {
+          "status": "satisfied",
+          "evidence": [
+            "src/agent/family-layouts.ts",
+            "src/__tests__/agent-family-layouts.test.ts",
+            "src/__tests__/layout-compare.test.ts"
+          ]
+        },
+        "stableRegions": {
+          "status": "exception",
+          "tracked": [
+            "TODO:BUILD-22"
+          ],
+          "evidence": [
+            "TODO.md",
+            "src/ascii/meta.ts"
+          ],
+          "note": "Family-specific region assertions beyond the pinned graph/sequence/Gantt paths are tracked."
+        },
+        "editorExample": {
+          "status": "satisfied",
+          "evidence": [
+            "editor/js/examples.js",
+            "src/__tests__/editor-examples.test.ts",
+            "e2e/browser.test.ts"
+          ]
+        },
+        "docsAgentSurfaces": {
+          "status": "satisfied",
+          "evidence": [
+            "src/__tests__/agent-doc-sync.test.ts",
+            "src/__tests__/cli-llms-txt.test.ts",
+            "docs/diagram-families.md",
+            "AGENT_NATIVE.md",
+            "Instructions_for_agents.md",
+            "llms.txt"
+          ]
+        },
+        "evalFixture": {
+          "status": "satisfied",
+          "evidence": [
+            "evals/shared-benchmark.json",
+            "src/__tests__/agent-doc-sync.test.ts"
+          ]
+        },
+        "upstreamHarvest": {
+          "status": "exception",
+          "tracked": [
+            "TODO:BUILD-20"
+          ],
+          "evidence": [
+            "TODO.md",
+            "docs/contributing/harvesting-upstream-tests.md"
+          ],
+          "note": "Standardized cases/exclusions harvest is tracked for all non-Gantt families."
+        },
+        "divergenceLedger": {
+          "status": "exception",
+          "tracked": [
+            "TODO:BUILD-20",
+            "TODO:BUILD-22"
+          ],
+          "evidence": [
+            "TODO.md",
+            "docs/contributing/harvesting-upstream-tests.md"
+          ],
+          "note": "Executable divergence ledgers graduate with each upstream harvest."
+        },
+        "domainProperties": {
+          "status": "satisfied",
+          "evidence": [
+            "src/__tests__/architecture-layout.test.ts",
+            "src/__tests__/property-layout-bounds.test.ts"
+          ]
+        },
+        "goldensEvidence": {
+          "status": "satisfied",
+          "evidence": [
+            "src/__tests__/architecture-ascii.test.ts",
+            "src/__tests__/architecture-svg-snapshot.test.ts"
+          ]
+        },
+        "generatedSite": {
+          "status": "satisfied",
+          "evidence": [
+            "scripts/site/samples-data.ts",
+            "scripts/site/generate.ts",
+            "src/__tests__/property-html-generator.test.ts"
+          ]
+        },
+        "distributionPackage": {
+          "status": "satisfied",
+          "evidence": [
+            "package.json",
+            "src/__tests__/doc-sync.test.ts",
+            "src/__tests__/agent-doc-sync.test.ts"
+          ]
+        },
+        "mutationLane": {
+          "status": "satisfied",
+          "evidence": [
+            "stryker.families.config.json",
+            "package.json"
+          ]
+        }
+      }
+    },
+    "xychart": {
+      "label": "XY chart",
+      "auditLevel": "audited",
+      "role": "non-Gantt worked audit",
+      "workedExample": false,
+      "cells": {
+        "registryDiscovery": {
+          "status": "satisfied",
+          "evidence": [
+            "src/agent/families.ts",
+            "src/__tests__/agent-doc-sync.test.ts",
+            "src/__tests__/cli-capabilities.test.ts"
+          ]
+        },
+        "detectionParse": {
+          "status": "satisfied",
+          "evidence": [
+            "src/mermaid-source.ts",
+            "src/__tests__/agent-doc-sync.test.ts",
+            "src/__tests__/doc-sync.test.ts"
+          ]
+        },
+        "semanticModel": {
+          "status": "satisfied",
+          "evidence": [
+            "src/agent/xychart-body.ts",
+            "src/xychart/parser.ts"
+          ]
+        },
+        "serializeRoundTrip": {
+          "status": "satisfied",
+          "evidence": [
+            "src/__tests__/agent-xychart.test.ts",
+            "src/__tests__/xychart-parser.test.ts"
+          ]
+        },
+        "typedMutation": {
+          "status": "satisfied",
+          "evidence": [
+            "src/cli/index.ts",
+            "src/mcp/sdk-decl.ts",
+            "src/__tests__/agent-doc-sync.test.ts"
+          ]
+        },
+        "verifyRenderSeam": {
+          "status": "satisfied",
+          "evidence": [
+            "src/agent/verify.ts",
+            "src/__tests__/agent-family-layouts.test.ts"
+          ]
+        },
+        "determinism": {
+          "status": "satisfied",
+          "evidence": [
+            "src/__tests__/agent-determinism.test.ts",
+            "src/__tests__/ascii-determinism.test.ts",
+            "src/__tests__/agent-png-determinism.test.ts"
+          ]
+        },
+        "svgRender": {
+          "status": "satisfied",
+          "evidence": [
+            "src/__tests__/doc-sync.test.ts",
+            "src/__tests__/integration.test.ts"
+          ]
+        },
+        "asciiUnicodeRender": {
+          "status": "satisfied",
+          "evidence": [
+            "src/__tests__/ascii.test.ts",
+            "src/__tests__/ascii-determinism.test.ts"
+          ]
+        },
+        "layoutProjection": {
+          "status": "satisfied",
+          "evidence": [
+            "src/agent/family-layouts.ts",
+            "src/__tests__/agent-family-layouts.test.ts",
+            "src/__tests__/layout-compare.test.ts"
+          ]
+        },
+        "stableRegions": {
+          "status": "exception",
+          "tracked": [
+            "TODO:BUILD-22"
+          ],
+          "evidence": [
+            "TODO.md",
+            "src/ascii/meta.ts"
+          ],
+          "note": "Family-specific region assertions beyond the pinned graph/sequence/Gantt paths are tracked."
+        },
+        "editorExample": {
+          "status": "satisfied",
+          "evidence": [
+            "editor/js/examples.js",
+            "src/__tests__/editor-examples.test.ts",
+            "e2e/browser.test.ts"
+          ]
+        },
+        "docsAgentSurfaces": {
+          "status": "satisfied",
+          "evidence": [
+            "src/__tests__/agent-doc-sync.test.ts",
+            "src/__tests__/cli-llms-txt.test.ts",
+            "docs/diagram-families.md",
+            "AGENT_NATIVE.md",
+            "Instructions_for_agents.md",
+            "llms.txt"
+          ]
+        },
+        "evalFixture": {
+          "status": "satisfied",
+          "evidence": [
+            "evals/shared-benchmark.json",
+            "src/__tests__/agent-doc-sync.test.ts"
+          ]
+        },
+        "upstreamHarvest": {
+          "status": "exception",
+          "tracked": [
+            "TODO:BUILD-20"
+          ],
+          "evidence": [
+            "TODO.md",
+            "docs/contributing/harvesting-upstream-tests.md"
+          ],
+          "note": "Standardized cases/exclusions harvest is tracked for all non-Gantt families."
+        },
+        "divergenceLedger": {
+          "status": "exception",
+          "tracked": [
+            "TODO:BUILD-20",
+            "TODO:BUILD-22"
+          ],
+          "evidence": [
+            "TODO.md",
+            "docs/contributing/harvesting-upstream-tests.md"
+          ],
+          "note": "Executable divergence ledgers graduate with each upstream harvest."
+        },
+        "domainProperties": {
+          "status": "satisfied",
+          "evidence": [
+            "src/__tests__/property-xychart.test.ts",
+            "src/__tests__/xychart-layout.test.ts",
+            "src/__tests__/xychart-integration.test.ts"
+          ]
+        },
+        "goldensEvidence": {
+          "status": "satisfied",
+          "evidence": [
+            "src/__tests__/xychart-ascii.test.ts",
+            "src/__tests__/xychart-svg-snapshot.test.ts"
+          ]
+        },
+        "generatedSite": {
+          "status": "satisfied",
+          "evidence": [
+            "scripts/site/samples-data.ts",
+            "scripts/site/generate.ts",
+            "src/__tests__/property-html-generator.test.ts"
+          ]
+        },
+        "distributionPackage": {
+          "status": "satisfied",
+          "evidence": [
+            "package.json",
+            "src/__tests__/doc-sync.test.ts",
+            "src/__tests__/agent-doc-sync.test.ts"
+          ]
+        },
+        "mutationLane": {
+          "status": "satisfied",
+          "evidence": [
+            "stryker.families.config.json",
+            "package.json"
+          ]
+        }
+      }
+    },
+    "pie": {
+      "label": "Pie",
+      "auditLevel": "inventoried",
+      "role": "slice/percentage family",
+      "workedExample": false,
+      "cells": {
+        "registryDiscovery": {
+          "status": "satisfied",
+          "evidence": [
+            "src/agent/families.ts",
+            "src/__tests__/agent-doc-sync.test.ts",
+            "src/__tests__/cli-capabilities.test.ts"
+          ]
+        },
+        "detectionParse": {
+          "status": "satisfied",
+          "evidence": [
+            "src/mermaid-source.ts",
+            "src/__tests__/agent-doc-sync.test.ts",
+            "src/__tests__/doc-sync.test.ts"
+          ]
+        },
+        "semanticModel": {
+          "status": "satisfied",
+          "evidence": [
+            "src/agent/pie-body.ts",
+            "src/pie/parser.ts"
+          ]
+        },
+        "serializeRoundTrip": {
+          "status": "satisfied",
+          "evidence": [
+            "src/__tests__/agent-pie.test.ts",
+            "src/__tests__/pie.test.ts"
+          ]
+        },
+        "typedMutation": {
+          "status": "satisfied",
+          "evidence": [
+            "src/cli/index.ts",
+            "src/mcp/sdk-decl.ts",
+            "src/__tests__/agent-doc-sync.test.ts"
+          ]
+        },
+        "verifyRenderSeam": {
+          "status": "satisfied",
+          "evidence": [
+            "src/agent/verify.ts",
+            "src/__tests__/agent-family-layouts.test.ts"
+          ]
+        },
+        "determinism": {
+          "status": "satisfied",
+          "evidence": [
+            "src/__tests__/agent-determinism.test.ts",
+            "src/__tests__/ascii-determinism.test.ts",
+            "src/__tests__/agent-png-determinism.test.ts"
+          ]
+        },
+        "svgRender": {
+          "status": "satisfied",
+          "evidence": [
+            "src/__tests__/doc-sync.test.ts",
+            "src/__tests__/integration.test.ts"
+          ]
+        },
+        "asciiUnicodeRender": {
+          "status": "satisfied",
+          "evidence": [
+            "src/__tests__/ascii.test.ts",
+            "src/__tests__/ascii-determinism.test.ts"
+          ]
+        },
+        "layoutProjection": {
+          "status": "satisfied",
+          "evidence": [
+            "src/agent/family-layouts.ts",
+            "src/__tests__/agent-family-layouts.test.ts",
+            "src/__tests__/layout-compare.test.ts"
+          ]
+        },
+        "stableRegions": {
+          "status": "exception",
+          "tracked": [
+            "TODO:BUILD-22"
+          ],
+          "evidence": [
+            "TODO.md",
+            "src/ascii/meta.ts"
+          ],
+          "note": "Family-specific region assertions beyond the pinned graph/sequence/Gantt paths are tracked."
+        },
+        "editorExample": {
+          "status": "satisfied",
+          "evidence": [
+            "editor/js/examples.js",
+            "src/__tests__/editor-examples.test.ts",
+            "e2e/browser.test.ts"
+          ]
+        },
+        "docsAgentSurfaces": {
+          "status": "satisfied",
+          "evidence": [
+            "src/__tests__/agent-doc-sync.test.ts",
+            "src/__tests__/cli-llms-txt.test.ts",
+            "docs/diagram-families.md",
+            "AGENT_NATIVE.md",
+            "Instructions_for_agents.md",
+            "llms.txt"
+          ]
+        },
+        "evalFixture": {
+          "status": "satisfied",
+          "evidence": [
+            "evals/shared-benchmark.json",
+            "src/__tests__/agent-doc-sync.test.ts"
+          ]
+        },
+        "upstreamHarvest": {
+          "status": "exception",
+          "tracked": [
+            "TODO:BUILD-20"
+          ],
+          "evidence": [
+            "TODO.md",
+            "docs/contributing/harvesting-upstream-tests.md"
+          ],
+          "note": "Standardized cases/exclusions harvest is tracked for all non-Gantt families."
+        },
+        "divergenceLedger": {
+          "status": "exception",
+          "tracked": [
+            "TODO:BUILD-20",
+            "TODO:BUILD-22"
+          ],
+          "evidence": [
+            "TODO.md",
+            "docs/contributing/harvesting-upstream-tests.md"
+          ],
+          "note": "Executable divergence ledgers graduate with each upstream harvest."
+        },
+        "domainProperties": {
+          "status": "satisfied",
+          "evidence": [
+            "src/__tests__/pie.test.ts",
+            "src/__tests__/property-color-algebra.test.ts"
+          ]
+        },
+        "goldensEvidence": {
+          "status": "satisfied",
+          "evidence": [
+            "src/__tests__/pie.test.ts",
+            "src/ascii/pie.ts"
+          ]
+        },
+        "generatedSite": {
+          "status": "satisfied",
+          "evidence": [
+            "scripts/site/samples-data.ts",
+            "scripts/site/generate.ts",
+            "src/__tests__/property-html-generator.test.ts"
+          ]
+        },
+        "distributionPackage": {
+          "status": "satisfied",
+          "evidence": [
+            "package.json",
+            "src/__tests__/doc-sync.test.ts",
+            "src/__tests__/agent-doc-sync.test.ts"
+          ]
+        },
+        "mutationLane": {
+          "status": "exception",
+          "tracked": [
+            "TODO:BUILD-22"
+          ],
+          "evidence": [
+            "TODO.md",
+            "docs/agent-mutation-policy.md"
+          ],
+          "note": "Focused mutation/sabotage lane is not yet family-specific."
+        }
+      }
+    },
+    "quadrant": {
+      "label": "Quadrant",
+      "auditLevel": "inventoried",
+      "role": "axis/quadrant-bounds family",
+      "workedExample": false,
+      "cells": {
+        "registryDiscovery": {
+          "status": "satisfied",
+          "evidence": [
+            "src/agent/families.ts",
+            "src/__tests__/agent-doc-sync.test.ts",
+            "src/__tests__/cli-capabilities.test.ts"
+          ]
+        },
+        "detectionParse": {
+          "status": "satisfied",
+          "evidence": [
+            "src/mermaid-source.ts",
+            "src/__tests__/agent-doc-sync.test.ts",
+            "src/__tests__/doc-sync.test.ts"
+          ]
+        },
+        "semanticModel": {
+          "status": "satisfied",
+          "evidence": [
+            "src/agent/quadrant-body.ts",
+            "src/quadrant/parser.ts"
+          ]
+        },
+        "serializeRoundTrip": {
+          "status": "satisfied",
+          "evidence": [
+            "src/__tests__/agent-quadrant.test.ts",
+            "src/__tests__/quadrant.test.ts"
+          ]
+        },
+        "typedMutation": {
+          "status": "satisfied",
+          "evidence": [
+            "src/cli/index.ts",
+            "src/mcp/sdk-decl.ts",
+            "src/__tests__/agent-doc-sync.test.ts"
+          ]
+        },
+        "verifyRenderSeam": {
+          "status": "satisfied",
+          "evidence": [
+            "src/agent/verify.ts",
+            "src/__tests__/agent-family-layouts.test.ts"
+          ]
+        },
+        "determinism": {
+          "status": "satisfied",
+          "evidence": [
+            "src/__tests__/agent-determinism.test.ts",
+            "src/__tests__/ascii-determinism.test.ts",
+            "src/__tests__/agent-png-determinism.test.ts"
+          ]
+        },
+        "svgRender": {
+          "status": "satisfied",
+          "evidence": [
+            "src/__tests__/doc-sync.test.ts",
+            "src/__tests__/integration.test.ts"
+          ]
+        },
+        "asciiUnicodeRender": {
+          "status": "satisfied",
+          "evidence": [
+            "src/__tests__/ascii.test.ts",
+            "src/__tests__/ascii-determinism.test.ts"
+          ]
+        },
+        "layoutProjection": {
+          "status": "satisfied",
+          "evidence": [
+            "src/agent/family-layouts.ts",
+            "src/__tests__/agent-family-layouts.test.ts",
+            "src/__tests__/layout-compare.test.ts"
+          ]
+        },
+        "stableRegions": {
+          "status": "exception",
+          "tracked": [
+            "TODO:BUILD-22"
+          ],
+          "evidence": [
+            "TODO.md",
+            "src/ascii/meta.ts"
+          ],
+          "note": "Family-specific region assertions beyond the pinned graph/sequence/Gantt paths are tracked."
+        },
+        "editorExample": {
+          "status": "satisfied",
+          "evidence": [
+            "editor/js/examples.js",
+            "src/__tests__/editor-examples.test.ts",
+            "e2e/browser.test.ts"
+          ]
+        },
+        "docsAgentSurfaces": {
+          "status": "satisfied",
+          "evidence": [
+            "src/__tests__/agent-doc-sync.test.ts",
+            "src/__tests__/cli-llms-txt.test.ts",
+            "docs/diagram-families.md",
+            "AGENT_NATIVE.md",
+            "Instructions_for_agents.md",
+            "llms.txt"
+          ]
+        },
+        "evalFixture": {
+          "status": "satisfied",
+          "evidence": [
+            "evals/shared-benchmark.json",
+            "src/__tests__/agent-doc-sync.test.ts"
+          ]
+        },
+        "upstreamHarvest": {
+          "status": "exception",
+          "tracked": [
+            "TODO:BUILD-20"
+          ],
+          "evidence": [
+            "TODO.md",
+            "docs/contributing/harvesting-upstream-tests.md"
+          ],
+          "note": "Standardized cases/exclusions harvest is tracked for all non-Gantt families."
+        },
+        "divergenceLedger": {
+          "status": "exception",
+          "tracked": [
+            "TODO:BUILD-20",
+            "TODO:BUILD-22"
+          ],
+          "evidence": [
+            "TODO.md",
+            "docs/contributing/harvesting-upstream-tests.md"
+          ],
+          "note": "Executable divergence ledgers graduate with each upstream harvest."
+        },
+        "domainProperties": {
+          "status": "satisfied",
+          "evidence": [
+            "src/__tests__/quadrant.test.ts",
+            "src/quadrant/layout.ts"
+          ]
+        },
+        "goldensEvidence": {
+          "status": "satisfied",
+          "evidence": [
+            "src/__tests__/quadrant.test.ts",
+            "src/ascii/quadrant.ts"
+          ]
+        },
+        "generatedSite": {
+          "status": "satisfied",
+          "evidence": [
+            "scripts/site/samples-data.ts",
+            "scripts/site/generate.ts",
+            "src/__tests__/property-html-generator.test.ts"
+          ]
+        },
+        "distributionPackage": {
+          "status": "satisfied",
+          "evidence": [
+            "package.json",
+            "src/__tests__/doc-sync.test.ts",
+            "src/__tests__/agent-doc-sync.test.ts"
+          ]
+        },
+        "mutationLane": {
+          "status": "exception",
+          "tracked": [
+            "TODO:BUILD-22"
+          ],
+          "evidence": [
+            "TODO.md",
+            "docs/agent-mutation-policy.md"
+          ],
+          "note": "Focused mutation/sabotage lane is not yet family-specific."
+        }
+      }
+    },
+    "gantt": {
+      "label": "Gantt",
+      "auditLevel": "worked-example",
+      "role": "new-family citizenship exemplar",
+      "workedExample": true,
+      "cells": {
+        "registryDiscovery": {
+          "status": "satisfied",
+          "evidence": [
+            "src/agent/families.ts",
+            "src/__tests__/agent-doc-sync.test.ts",
+            "src/__tests__/cli-capabilities.test.ts"
+          ]
+        },
+        "detectionParse": {
+          "status": "satisfied",
+          "evidence": [
+            "src/mermaid-source.ts",
+            "src/__tests__/agent-doc-sync.test.ts",
+            "src/__tests__/doc-sync.test.ts"
+          ]
+        },
+        "semanticModel": {
+          "status": "satisfied",
+          "evidence": [
+            "src/agent/gantt-body.ts",
+            "src/gantt/parser.ts",
+            "src/gantt/schedule.ts",
+            "docs/design/gantt.md"
+          ]
+        },
+        "serializeRoundTrip": {
+          "status": "satisfied",
+          "evidence": [
+            "src/__tests__/agent-gantt.test.ts",
+            "src/__tests__/gantt-parser.test.ts"
+          ]
+        },
+        "typedMutation": {
+          "status": "satisfied",
+          "evidence": [
+            "src/cli/index.ts",
+            "src/mcp/sdk-decl.ts",
+            "src/__tests__/agent-doc-sync.test.ts"
+          ]
+        },
+        "verifyRenderSeam": {
+          "status": "satisfied",
+          "evidence": [
+            "src/agent/verify.ts",
+            "src/__tests__/agent-family-layouts.test.ts"
+          ]
+        },
+        "determinism": {
+          "status": "satisfied",
+          "evidence": [
+            "src/__tests__/agent-determinism.test.ts",
+            "src/__tests__/ascii-determinism.test.ts",
+            "src/__tests__/agent-png-determinism.test.ts"
+          ]
+        },
+        "svgRender": {
+          "status": "satisfied",
+          "evidence": [
+            "src/__tests__/doc-sync.test.ts",
+            "src/__tests__/integration.test.ts"
+          ]
+        },
+        "asciiUnicodeRender": {
+          "status": "satisfied",
+          "evidence": [
+            "src/__tests__/ascii.test.ts",
+            "src/__tests__/ascii-determinism.test.ts"
+          ]
+        },
+        "layoutProjection": {
+          "status": "satisfied",
+          "evidence": [
+            "src/agent/family-layouts.ts",
+            "src/__tests__/agent-family-layouts.test.ts",
+            "src/__tests__/layout-compare.test.ts"
+          ]
+        },
+        "stableRegions": {
+          "status": "satisfied",
+          "evidence": [
+            "src/__tests__/agent-gantt.test.ts",
+            "src/ascii/meta.ts"
+          ]
+        },
+        "editorExample": {
+          "status": "satisfied",
+          "evidence": [
+            "editor/js/examples.js",
+            "src/__tests__/editor-examples.test.ts",
+            "e2e/browser.test.ts"
+          ]
+        },
+        "docsAgentSurfaces": {
+          "status": "satisfied",
+          "evidence": [
+            "src/__tests__/agent-doc-sync.test.ts",
+            "src/__tests__/cli-llms-txt.test.ts",
+            "docs/diagram-families.md",
+            "AGENT_NATIVE.md",
+            "Instructions_for_agents.md",
+            "llms.txt"
+          ]
+        },
+        "evalFixture": {
+          "status": "satisfied",
+          "evidence": [
+            "evals/shared-benchmark.json",
+            "src/__tests__/agent-doc-sync.test.ts"
+          ]
+        },
+        "upstreamHarvest": {
+          "status": "satisfied",
+          "evidence": [
+            "eval/mermaid-gantt-bench/README.md",
+            "eval/mermaid-gantt-bench/cases.json",
+            "src/__tests__/gantt-upstream-bench.test.ts"
+          ]
+        },
+        "divergenceLedger": {
+          "status": "satisfied",
+          "evidence": [
+            "eval/mermaid-gantt-bench/exclusions.json",
+            "src/__tests__/gantt-upstream-bench.test.ts"
+          ]
+        },
+        "domainProperties": {
+          "status": "satisfied",
+          "evidence": [
+            "src/__tests__/property-gantt-schedule.test.ts",
+            "src/__tests__/gantt-schedule.test.ts",
+            "src/__tests__/gantt-layout.test.ts"
+          ]
+        },
+        "goldensEvidence": {
+          "status": "satisfied",
+          "evidence": [
+            "src/__tests__/gantt-svg-snapshot.test.ts",
+            "src/__tests__/agent-gantt.test.ts",
+            "docs/assets/improvements/gantt-family.png"
+          ]
+        },
+        "generatedSite": {
+          "status": "satisfied",
+          "evidence": [
+            "scripts/site/samples-data.ts",
+            "scripts/site/generate.ts",
+            "src/__tests__/property-html-generator.test.ts"
+          ]
+        },
+        "distributionPackage": {
+          "status": "satisfied",
+          "evidence": [
+            "package.json",
+            "src/__tests__/doc-sync.test.ts",
+            "src/__tests__/agent-doc-sync.test.ts"
+          ]
+        },
+        "mutationLane": {
+          "status": "satisfied",
+          "evidence": [
+            "stryker.gantt.config.json",
+            "package.json"
+          ]
+        }
+      }
+    }
+  }
+}

--- a/docs/contributing/diagram-family-citizenship.md
+++ b/docs/contributing/diagram-family-citizenship.md
@@ -1,0 +1,81 @@
+# Diagram-family citizenship ratchet
+
+Issue: #41. Status: enforced checklist + checked matrix.
+
+A diagram family is a **good citizen** when it is integrated into every runtime, documentation, agent, editor, eval, and distribution surface that teaches users or agents what Agentic Mermaid supports. Rendering is not enough: a family must be discoverable, safely editable when its modeled body narrows, verifiable before render, represented in examples/evals, and either backed by evidence or tracked as an explicit exception.
+
+## Source of truth
+
+`BUILTIN_FAMILY_METADATA` in `src/agent/families.ts` is the canonical shipped-family registry. It records the family id, label, Mermaid headers, typed narrower, live-editor example id/type, and editor glyph. The registry has compile-time coverage against `DiagramKind`; tests then project it into CLI capabilities, MCP/Code Mode, docs, editor examples, eval fixtures, package keywords, and generated discovery docs.
+
+The checked citizenship matrix lives at [`diagram-family-citizenship.matrix.json`](./diagram-family-citizenship.matrix.json). It is intentionally separate from the registry: the registry says “this family ships”; the matrix says “these citizenship surfaces are satisfied, and these remaining gaps are tracked.”
+
+## Semantic correctness vs. system citizenship
+
+Keep these distinct in reviews:
+
+- **Semantic correctness** asks whether a parser/IR/serializer/verifier/renderer preserves the family’s own Mermaid meaning. Examples: Gantt schedule resolution, flowchart route certificates, sequence segment preservation, pie percentage invariants, XY axis/domain laws.
+- **System citizenship** asks whether every supported entry point points to the same typed path. Examples: `am capabilities`, `llms.txt`, `am init-agent`, MCP initialize guidance, SDK declarations, Code Mode sandbox narrowers, editor examples/glyphs, eval fixtures, generated site samples, package exports, and docs tables.
+
+A new family can be semantically good and still fail citizenship if an agent discovering the package through a different surface cannot find the same parse → narrow → mutate → verify → serialize path.
+
+## Checklist surfaces
+
+The matrix has one cell per family for each surface below. A cell is either `satisfied` with concrete evidence paths, or `exception` with a tracked TODO/issue reference. CI fails if a registered family is missing a row, a surface, evidence, or exception tracking.
+
+| Surface | Contract |
+|---|---|
+| `registryDiscovery` | Family appears in `BUILTIN_FAMILY_METADATA`, registered plugins, CLI capability metadata, and typed IDs. |
+| `detectionParse` | Shared detector, agent parse, SVG render, ASCII render, CLI, and MCP paths route consistently; state’s flowchart renderer split is the only documented exception. |
+| `semanticModel` | Modeled syntax subset and opaque/source-preservation ladder are explicit. |
+| `serializeRoundTrip` | Modeled syntax has parse → serialize → parse stability; opaque/segment-preserved syntax round-trips losslessly. |
+| `typedMutation` | A public narrower and mutation ops exist, and opaque fallback bodies do not fake structured mutation. |
+| `verifyRenderSeam` | Modeled syntax has no “verify ok, render throws” path; render-blocking conditions surface as named warnings/errors. |
+| `determinism` | No ambient wall clock/random/locale/process-order dependence; runtime knobs such as `ganttToday` are explicit. |
+| `svgRender` | SVG/PNG-capable rendering path is covered for the family. |
+| `asciiUnicodeRender` | ASCII/Unicode output is covered when advertised. |
+| `layoutProjection` | `layoutMermaid`, quality metrics, and verify layout expose truthful geometry, not placeholder data. |
+| `stableRegions` | Region metadata for editor/TUI/accessibility is present or explicitly tracked as a gap. |
+| `editorExample` | Live editor has a working `Supported diagrams` example and explicit glyph for the family. |
+| `docsAgentSurfaces` | README/docs/spec/skills/agent instructions/SDK declaration/llms surfaces stay in sync. |
+| `evalFixture` | Shared skill benchmark has at least one fixture-backed case tagged `family:<id>`. |
+| `upstreamHarvest` | Upstream Mermaid/fork tests are harvested into executable cases/exclusions, or tracked for harvest. |
+| `divergenceLedger` | Known compatibility divergences are executable and cannot rot, or tracked for ledger work. |
+| `domainProperties` | Family-specific invariants/properties exist beyond “renders without throwing.” |
+| `goldensEvidence` | Text/SVG/visual evidence exists where reviewer judgment needs artifacts. |
+| `generatedSite` | Site samples/gallery/generated docs include the family or have explicit exceptions. |
+| `distributionPackage` | Package exports/files/consumer init artifacts include the public family surface. |
+| `mutationLane` | Targeted mutation/sabotage lane exists, or a tracked exception explains the gap. |
+
+## Worked example: Gantt
+
+Gantt is the bar for a new family entering the system:
+
+- registry + mutation: `BUILTIN_FAMILY_METADATA`, `asGantt`, typed Gantt ops, CLI capabilities, SDK declaration, MCP sandbox, and `am init-agent` all expose the same path;
+- semantics: `src/gantt/parser.ts`, `src/gantt/schedule.ts`, `src/gantt/layout.ts`, and `src/agent/gantt-body.ts` keep scheduling pure and wall-clock-free;
+- verify/render seam: `UNRESOLVABLE_SCHEDULE` turns render-blocking schedule failures into named verification output;
+- compatibility: `eval/mermaid-gantt-bench/` has cases plus executable exclusions; `src/__tests__/gantt-upstream-bench.test.ts` runs it;
+- properties: `src/__tests__/property-gantt-schedule.test.ts` includes the CPM shadow-model property;
+- evidence: SVG snapshots, ASCII/Unicode goldens, `docs/assets/improvements/gantt-family.png`, and `mutation-test:gantt` cover reviewer-visible and sabotage paths;
+- editor/evals/docs: editor examples, eval fixtures, docs, `llms.txt`, and MCP/Code Mode surfaces are all registry-checked.
+
+## Non-Gantt audit: XY chart
+
+XY chart proves the checklist works for an older family that was promoted after the registry existed:
+
+- citizenship surfaces are satisfied for registry, detection, typed mutation (`asXyChart`), CLI/MCP docs, editor examples, eval fixtures, generated site samples, package exposure, SVG/ASCII output, and layout projection;
+- semantic correctness is pinned by parser/integration/layout/renderer tests and `src/__tests__/property-xychart.test.ts`;
+- mutation-testing citizenship is satisfied through `mutation-test:families`, which mutates `src/xychart/*` together with Architecture;
+- remaining exceptions are the standardized upstream-harvest/divergence-ledger work tracked by `TODO.md` BUILD-20 and broader region assertions tracked by BUILD-22.
+
+This is the intended ratchet shape: do not block a PR on every historical gap, but make every gap visible, tracked, and impossible to forget when a new family is added.
+
+## Review workflow
+
+When adding or changing a family:
+
+1. Add/update `BUILTIN_FAMILY_METADATA` first.
+2. Add/update parser, renderer, agent body, mutation ops, verify behavior, and examples.
+3. Update the citizenship matrix row in the same PR. Prefer `satisfied` with evidence; use `exception` only with a concrete TODO/issue reference.
+4. Run `bun test src/__tests__/diagram-family-citizenship.test.ts src/__tests__/agent-doc-sync.test.ts src/__tests__/editor-examples.test.ts src/__tests__/cli-capabilities.test.ts` before wider validation.
+5. For any matrix exception introduced by the PR, add a follow-up issue or `TODO.md` entry before merge.

--- a/scripts/site/generate.ts
+++ b/scripts/site/generate.ts
@@ -143,6 +143,9 @@ export async function generateHtml(options: GenerateHtmlOptions = {}): Promise<s
     Timeline: '#db2777',
     Journey: '#14b8a6',
     'XY Chart': '#f97316',
+    Pie: '#a855f7',
+    Quadrant: '#22c55e',
+    Gantt: '#64748b',
     'Role Styles': '#f97316',
     'Theme Showcase': '#06b6d4',
   }
@@ -156,6 +159,9 @@ export async function generateHtml(options: GenerateHtmlOptions = {}): Promise<s
     'ER': 'ER: ',
     'Journey': 'Journey: ',
     'XY Chart': 'XY: ',
+    'Pie': 'Pie: ',
+    'Quadrant': 'Quadrant: ',
+    'Gantt': 'Gantt: ',
     'Role Styles': 'Style: ',
     'Theme Showcase': 'Theme: ',
   }

--- a/src/__tests__/diagram-family-citizenship.test.ts
+++ b/src/__tests__/diagram-family-citizenship.test.ts
@@ -1,0 +1,269 @@
+import { describe, expect, test } from 'bun:test'
+import { existsSync, readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+import { BUILTIN_FAMILY_METADATA, type BuiltinFamilyId } from '../agent/families.ts'
+import { MUTATION_OPS_BY_FAMILY } from '../cli/index.ts'
+
+const REPO = join(import.meta.dir, '..', '..')
+const MATRIX_PATH = join(REPO, 'docs/contributing/diagram-family-citizenship.matrix.json')
+
+const EXPECTED_SURFACES = [
+  'registryDiscovery',
+  'detectionParse',
+  'semanticModel',
+  'serializeRoundTrip',
+  'typedMutation',
+  'verifyRenderSeam',
+  'determinism',
+  'svgRender',
+  'asciiUnicodeRender',
+  'layoutProjection',
+  'stableRegions',
+  'editorExample',
+  'docsAgentSurfaces',
+  'evalFixture',
+  'upstreamHarvest',
+  'divergenceLedger',
+  'domainProperties',
+  'goldensEvidence',
+  'generatedSite',
+  'distributionPackage',
+  'mutationLane',
+] as const
+
+const TRACKED_EXCEPTION_SURFACES = new Set(['stableRegions', 'upstreamHarvest', 'divergenceLedger', 'mutationLane'])
+
+type SurfaceId = typeof EXPECTED_SURFACES[number]
+
+const REQUIRED_FAMILY_EVIDENCE = {
+  flowchart: {
+    semanticModel: ['src/agent/flowchart-body.ts'],
+    serializeRoundTrip: ['src/__tests__/flowchart-parser-conformance.test.ts'],
+    domainProperties: ['src/__tests__/route-contracts.test.ts'],
+    stableRegions: ['src/__tests__/agent-ascii-meta.test.ts'],
+    mutationLane: ['stryker.link-grammar.config.json'],
+  },
+  state: {
+    semanticModel: ['src/agent/state-body.ts'],
+    serializeRoundTrip: ['src/__tests__/agent-state.test.ts'],
+    domainProperties: ['src/__tests__/agent-state.test.ts'],
+  },
+  sequence: {
+    semanticModel: ['src/agent/sequence-body.ts'],
+    serializeRoundTrip: ['src/__tests__/agent-mermaidseqbench.test.ts'],
+    domainProperties: ['src/__tests__/ascii-sequence-blocks.test.ts'],
+    stableRegions: ['src/__tests__/agent-ascii-meta.test.ts'],
+  },
+  timeline: {
+    semanticModel: ['src/agent/timeline-body.ts'],
+    serializeRoundTrip: ['src/__tests__/timeline-parser.test.ts'],
+    domainProperties: ['src/__tests__/timeline-layout.test.ts'],
+    goldensEvidence: ['src/__tests__/timeline-ascii.test.ts'],
+  },
+  class: {
+    semanticModel: ['src/agent/class-body.ts'],
+    serializeRoundTrip: ['src/__tests__/class-parser.test.ts'],
+    domainProperties: ['src/__tests__/class-er-edge-quality.test.ts'],
+    goldensEvidence: ['src/__tests__/class-integration.test.ts'],
+  },
+  er: {
+    semanticModel: ['src/agent/er-body.ts'],
+    serializeRoundTrip: ['src/__tests__/er-parser.test.ts'],
+    domainProperties: ['src/__tests__/class-er-edge-quality.test.ts'],
+    goldensEvidence: ['src/__tests__/er-integration.test.ts'],
+  },
+  journey: {
+    semanticModel: ['src/agent/journey-body.ts'],
+    serializeRoundTrip: ['src/__tests__/journey-parser.test.ts'],
+    domainProperties: ['src/__tests__/journey-layout.test.ts'],
+    goldensEvidence: ['src/__tests__/journey-svg-snapshot.test.ts'],
+  },
+  architecture: {
+    semanticModel: ['src/agent/architecture-body.ts'],
+    serializeRoundTrip: ['src/__tests__/architecture-parser.test.ts'],
+    domainProperties: ['src/__tests__/architecture-layout.test.ts'],
+    mutationLane: ['stryker.families.config.json'],
+  },
+  xychart: {
+    semanticModel: ['src/agent/xychart-body.ts'],
+    serializeRoundTrip: ['src/__tests__/xychart-parser.test.ts'],
+    domainProperties: ['src/__tests__/property-xychart.test.ts'],
+    mutationLane: ['stryker.families.config.json'],
+  },
+  pie: {
+    semanticModel: ['src/agent/pie-body.ts'],
+    serializeRoundTrip: ['src/__tests__/pie.test.ts'],
+    domainProperties: ['src/__tests__/pie.test.ts'],
+    goldensEvidence: ['src/__tests__/pie.test.ts'],
+  },
+  quadrant: {
+    semanticModel: ['src/agent/quadrant-body.ts'],
+    serializeRoundTrip: ['src/__tests__/quadrant.test.ts'],
+    domainProperties: ['src/__tests__/quadrant.test.ts'],
+    goldensEvidence: ['src/__tests__/quadrant.test.ts'],
+  },
+  gantt: {
+    semanticModel: ['src/gantt/schedule.ts'],
+    serializeRoundTrip: ['src/__tests__/agent-gantt.test.ts'],
+    domainProperties: ['src/__tests__/property-gantt-schedule.test.ts'],
+    stableRegions: ['src/__tests__/agent-gantt.test.ts'],
+    upstreamHarvest: ['eval/mermaid-gantt-bench/cases.json'],
+    divergenceLedger: ['eval/mermaid-gantt-bench/exclusions.json'],
+    goldensEvidence: ['docs/assets/improvements/gantt-family.png'],
+    mutationLane: ['stryker.gantt.config.json'],
+  },
+} satisfies Record<BuiltinFamilyId, Partial<Record<SurfaceId, readonly string[]>>>
+
+const AUDITED_NON_GANTT_EXCEPTIONS = {
+  xychart: {
+    stableRegions: ['TODO:BUILD-22'],
+    upstreamHarvest: ['TODO:BUILD-20'],
+    divergenceLedger: ['TODO:BUILD-20', 'TODO:BUILD-22'],
+  },
+} satisfies Partial<Record<BuiltinFamilyId, Partial<Record<SurfaceId, readonly string[]>>>>
+
+type Cell = { status: 'satisfied' | 'exception'; evidence: string[]; tracked?: string[]; note?: string }
+type FamilyRow = { label: string; auditLevel: string; role: string; workedExample: boolean; cells: Record<SurfaceId, Cell> }
+type Matrix = {
+  schemaVersion: number
+  updated: string
+  statusValues: string[]
+  surfaces: Array<{ id: SurfaceId; description: string }>
+  families: Record<string, FamilyRow>
+}
+
+function loadMatrix(): Matrix {
+  return JSON.parse(readFileSync(MATRIX_PATH, 'utf8')) as Matrix
+}
+
+function repoPathExists(ref: string): boolean {
+  const path = ref.split('#', 1)[0]!
+  return existsSync(join(REPO, path))
+}
+
+describe('diagram-family citizenship ratchet (issue #41)', () => {
+  test('matrix schema and family rows cover the built-in registry exactly', () => {
+    const matrix = loadMatrix()
+    expect(matrix.schemaVersion).toBe(1)
+    expect(matrix.statusValues).toEqual(['satisfied', 'exception'])
+    expect(matrix.surfaces.map(s => s.id)).toEqual([...EXPECTED_SURFACES])
+    for (const surface of matrix.surfaces) expect(surface.description.length).toBeGreaterThan(20)
+
+    const registryIds = BUILTIN_FAMILY_METADATA.map(f => f.id).sort()
+    const matrixIds = Object.keys(matrix.families).sort()
+    expect(matrixIds).toEqual(registryIds)
+    expect(Object.keys(MUTATION_OPS_BY_FAMILY).sort()).toEqual(registryIds)
+
+    for (const family of BUILTIN_FAMILY_METADATA) {
+      const row = matrix.families[family.id]
+      expect({ family: family.id, present: Boolean(row) }).toEqual({ family: family.id, present: true })
+      const checkedRow = row!
+      expect(checkedRow.label).toBe(family.label)
+      expect(new Set(Object.keys(checkedRow.cells))).toEqual(new Set(EXPECTED_SURFACES))
+      expect(checkedRow.role.length).toBeGreaterThan(5)
+    }
+  })
+
+  test('each cell has real evidence, and every exception is tracked', () => {
+    const matrix = loadMatrix()
+    const todo = readFileSync(join(REPO, 'TODO.md'), 'utf8')
+    for (const [family, row] of Object.entries(matrix.families)) {
+      for (const [surface, cell] of Object.entries(row.cells) as Array<[SurfaceId, Cell]>) {
+        expect({ family, surface, status: cell.status }).toEqual({ family, surface, status: expect.stringMatching(/^(satisfied|exception)$/) })
+        expect({ family, surface, evidence: cell.evidence.length }).toEqual({ family, surface, evidence: expect.any(Number) })
+        expect(cell.evidence.length).toBeGreaterThan(0)
+        for (const evidence of cell.evidence) {
+          expect({ family, surface, evidence, exists: repoPathExists(evidence) }).toEqual({ family, surface, evidence, exists: true })
+        }
+        if (cell.status === 'exception') {
+          expect({ family, surface, allowed: TRACKED_EXCEPTION_SURFACES.has(surface) }).toEqual({ family, surface, allowed: true })
+          expect({ family, surface, tracked: cell.tracked?.length ?? 0 }).toEqual({ family, surface, tracked: expect.any(Number) })
+          expect(cell.tracked?.length ?? 0).toBeGreaterThan(0)
+          for (const ref of cell.tracked ?? []) {
+            if (ref.startsWith('TODO:')) {
+              const id = ref.slice('TODO:'.length)
+              expect({ family, surface, ref, present: todo.includes(id) }).toEqual({ family, surface, ref, present: true })
+            } else {
+              expect(ref).toMatch(/^#\d+$/)
+            }
+          }
+        }
+      }
+    }
+  })
+
+  test('core citizenship surfaces cannot be deferred as exceptions', () => {
+    const matrix = loadMatrix()
+    const mustBeSatisfied = EXPECTED_SURFACES.filter(s => !TRACKED_EXCEPTION_SURFACES.has(s))
+    for (const [family, row] of Object.entries(matrix.families)) {
+      for (const surface of mustBeSatisfied) {
+        expect({ family, surface, status: row.cells[surface].status }).toEqual({ family, surface, status: 'satisfied' })
+      }
+    }
+  })
+
+  test('family-sensitive cells cite load-bearing family-specific evidence', () => {
+    const matrix = loadMatrix()
+    for (const family of BUILTIN_FAMILY_METADATA) {
+      const row = matrix.families[family.id]!
+      const required = REQUIRED_FAMILY_EVIDENCE[family.id]
+      for (const [surface, evidencePaths] of Object.entries(required) as Array<[SurfaceId, readonly string[]]>) {
+        const cell = row.cells[surface]
+        expect({ family: family.id, surface, status: cell.status }).toEqual({ family: family.id, surface, status: 'satisfied' })
+        for (const evidence of evidencePaths) {
+          expect({ family: family.id, surface, evidence, listed: cell.evidence.includes(evidence) })
+            .toEqual({ family: family.id, surface, evidence, listed: true })
+        }
+      }
+    }
+  })
+
+  test('satisfied mutation-lane evidence names an executable Stryker lane that mutates the family path', () => {
+    const matrix = loadMatrix()
+    for (const family of BUILTIN_FAMILY_METADATA) {
+      const cell = matrix.families[family.id]!.cells.mutationLane
+      if (cell.status !== 'satisfied') continue
+      const strykerEvidence = cell.evidence.filter(e => e.startsWith('stryker.') && e.endsWith('.config.json'))
+      expect({ family: family.id, strykerEvidence }).toEqual({ family: family.id, strykerEvidence: expect.arrayContaining([expect.any(String)]) })
+      const configs = strykerEvidence.map(e => readFileSync(join(REPO, e), 'utf8').toLowerCase()).join('\n')
+      const familyNeedle = family.id === 'flowchart' ? 'src/parser.ts' : `src/${family.id}`
+      expect({ family: family.id, familyNeedle, covered: configs.includes(familyNeedle) })
+        .toEqual({ family: family.id, familyNeedle, covered: true })
+    }
+  })
+
+  test('Gantt is the worked example and at least one non-Gantt family is audited', () => {
+    const matrix = loadMatrix()
+    const worked = Object.entries(matrix.families).filter(([, row]) => row.workedExample).map(([id]) => id)
+    expect(worked).toEqual(['gantt'])
+    for (const [surface, cell] of Object.entries(matrix.families.gantt!.cells) as Array<[SurfaceId, Cell]>) {
+      expect({ family: 'gantt', surface, status: cell.status }).toEqual({ family: 'gantt', surface, status: 'satisfied' })
+    }
+
+    const auditedNonGantt = Object.entries(matrix.families).filter(([id, row]) => id !== 'gantt' && row.auditLevel === 'audited')
+    expect(auditedNonGantt.map(([id]) => id)).toContain('xychart')
+    const xychart = matrix.families.xychart!
+    expect(xychart.cells.semanticModel.evidence).toContain('src/agent/xychart-body.ts')
+    expect(xychart.cells.domainProperties.evidence).toContain('src/__tests__/property-xychart.test.ts')
+    expect(xychart.cells.mutationLane.evidence).toContain('stryker.families.config.json')
+    for (const [surface, tracked] of Object.entries(AUDITED_NON_GANTT_EXCEPTIONS.xychart) as Array<[SurfaceId, readonly string[]]>) {
+      expect({ family: 'xychart', surface, status: xychart.cells[surface].status }).toEqual({ family: 'xychart', surface, status: 'exception' })
+      expect(xychart.cells[surface].tracked).toEqual([...tracked])
+    }
+  })
+
+  test('reviewer-facing docs link the checklist, matrix, and follow-up ledger', () => {
+    const citizenship = readFileSync(join(REPO, 'docs/contributing/diagram-family-citizenship.md'), 'utf8')
+    const adding = readFileSync(join(REPO, 'docs/contributing/adding-diagram-types.md'), 'utf8')
+    const docsIndex = readFileSync(join(REPO, 'docs/README.md'), 'utf8')
+    const todo = readFileSync(join(REPO, 'TODO.md'), 'utf8')
+
+    expect(citizenship).toContain('Worked example: Gantt')
+    expect(citizenship).toContain('Non-Gantt audit: XY chart')
+    expect(citizenship).toContain('diagram-family-citizenship.matrix.json')
+    expect(adding).toContain('diagram-family citizenship matrix')
+    expect(docsIndex).toContain('diagram-family-citizenship.md')
+    expect(todo).toContain('BUILD-22 — Diagram-family citizenship gap backfill')
+  })
+})

--- a/src/__tests__/property-html-generator.test.ts
+++ b/src/__tests__/property-html-generator.test.ts
@@ -11,6 +11,19 @@ const PROPERTY_RUNS = 5
 
 const ALL_CATEGORIES = BUILTIN_FAMILY_METADATA.map(f => f.editorDiagramType)
 
+const SITE_TOC_PREFIX_BY_FAMILY_ID = {
+  architecture: 'Architecture: ',
+  state: 'State: ',
+  sequence: 'Sequence: ',
+  class: 'Class: ',
+  er: 'ER: ',
+  journey: 'Journey: ',
+  xychart: 'XY: ',
+  pie: 'Pie: ',
+  quadrant: 'Quadrant: ',
+  gantt: 'Gantt: ',
+} as const
+
 /** Count how many samples match a given category set (including Hero). */
 function countSamplesForCategories(cats: Set<string>): number {
   return samples.filter(s => cats.has(s.category ?? 'Other')).length
@@ -47,6 +60,37 @@ describe('HTML generator: default options', () => {
     // The page embeds inline SVG icons (e.g. GitHub logo, Contents button)
     expect(html).toContain('<svg')
     expect(html).toContain('</svg>')
+  }, 30_000)
+
+  it('gives every built-in family category an explicit gallery affordance', async () => {
+    const html = await generateHtml()
+
+    for (const family of BUILTIN_FAMILY_METADATA) {
+      const category = escapeHtml(family.editorDiagramType)
+      const filterStart = html.indexOf(`data-filter="${category}"`)
+      expect({ family: family.id, category, filterStart }).toEqual({ family: family.id, category, filterStart: expect.any(Number) })
+      expect(filterStart).toBeGreaterThanOrEqual(0)
+      const filterHtml = html.slice(filterStart, html.indexOf('</button>', filterStart))
+      expect({ family: family.id, category, usesFallback: filterHtml.includes('background:#71717a') })
+        .toEqual({ family: family.id, category, usesFallback: false })
+    }
+  }, 30_000)
+
+  it('strips duplicate family prefixes from generated table-of-contents titles', async () => {
+    const html = await generateHtml()
+
+    for (const family of BUILTIN_FAMILY_METADATA) {
+      const prefix = SITE_TOC_PREFIX_BY_FAMILY_ID[family.id as keyof typeof SITE_TOC_PREFIX_BY_FAMILY_ID]
+      if (!prefix) continue
+      const heading = `<h3>${escapeHtml(family.editorDiagramType)} (`
+      const sectionStart = html.indexOf(heading)
+      expect({ family: family.id, sectionStart }).toEqual({ family: family.id, sectionStart: expect.any(Number) })
+      expect(sectionStart).toBeGreaterThanOrEqual(0)
+      const sectionEnd = html.indexOf('</div>', sectionStart)
+      const tocSection = html.slice(sectionStart, sectionEnd)
+      expect({ family: family.id, duplicatePrefix: tocSection.includes(escapeHtml(prefix)) })
+        .toEqual({ family: family.id, duplicatePrefix: false })
+    }
   }, 30_000)
 })
 


### PR DESCRIPTION
## What

- Adds `docs/contributing/diagram-family-citizenship.md`, a reviewer-facing good-citizen checklist for renderable diagram families.
- Adds `docs/contributing/diagram-family-citizenship.matrix.json`, a checked matrix covering every `BUILTIN_FAMILY_METADATA` family.
- Adds `src/__tests__/diagram-family-citizenship.test.ts` so CI fails when registry rows, matrix surfaces, evidence, tracked exceptions, Gantt exemplar status, or the non-Gantt XY audit drift.
- Backfills generated-site/gallery ratchets for Pie, Quadrant, and Gantt category affordances and ToC prefix stripping.
- Adds `TODO.md` BUILD-22 for explicit historical gap backfill from matrix exceptions.

## Why

Issue #41 asks for Gantt’s PR #24 integration discipline to become reusable policy, not tribal memory. A family should not be considered “done” just because it parses and renders; every human/agent discovery surface needs to point at the same typed path, and remaining older-family gaps need to be tracked instead of implicit.

## How

- Defines 21 citizenship surfaces: registry/discovery, detection/parse, semantic model, round-trip, typed mutation, verify/render seam, determinism, SVG/ASCII/layout, regions, editor/docs/evals, upstream harvest/divergence, properties, goldens, generated site, distribution, and mutation lane.
- Checks the matrix against `BUILTIN_FAMILY_METADATA` and `MUTATION_OPS_BY_FAMILY` exactly.
- Requires every cell to have existing evidence; only selected gap surfaces may be `exception`, and exceptions must reference a live `TODO.md` item or issue.
- Requires family-sensitive cells to cite load-bearing family-specific evidence instead of generic files.
- Treats Gantt as the fully satisfied worked example and XY chart as the audited non-Gantt proof of process.
- Updates the add-diagram guide and docs index to route future family work through the ratchet.

## Testing

- `bun test src/__tests__/diagram-family-citizenship.test.ts`
- `bun test src/__tests__/property-html-generator.test.ts`
- `bun test src/__tests__/agent-doc-sync.test.ts src/__tests__/diagram-family-citizenship.test.ts src/__tests__/property-html-generator.test.ts src/__tests__/editor-examples.test.ts src/__tests__/cli-capabilities.test.ts`
- `bun test --coverage src/__tests__/` — 3069 pass
- `bun x tsc --noEmit`
- `bun run build`
- `bun run audit:ugly` — 391 diagrams · 1168 format-audits · 0 HARD · 0 soft · 6 expected renderer-unsupported errors
- `git diff --check`

## Screenshots

None. Documentation/test ratchet only; no renderer output changes.

## Risk

Low runtime risk. The largest change is a checked JSON inventory and test suite. Main maintenance cost is intentional: adding a new built-in family now also requires updating the citizenship matrix and either satisfying or explicitly tracking each surface.

Closes #41.
