### PR TITLE
Pin ELK degradation ladder fallback

### DIFF
--- a/docs/design/issue-26-audit.md
+++ b/docs/design/issue-26-audit.md
@@ -65,22 +65,21 @@ documented; "Test" = where directly tested. Flags note anything lacking either.
 | 10 | **Port-lane alignment** (`alignPortLanes`) + gates (lane clear, bent sibling edges, swept-corridor proof, no group members) + freezes (aligned endpoints frozen) + proofs | §6.2.2 | alignment `it.each` over 4 directions; "includes diamonds"; "feedback out-edge does not veto"; contact sheet K/Q; `lean-shapes.test.ts` PORT_EXACT promotion; property oracles | — |
 | 11 | **Outer feedback** (`elk.layered.feedbackEdges`) + **loop tightening** (cut the forward-side excursion via the channel-facing port) | §6 "Feedback routing" | "labeled feedback routes around through the outer channel"; "feedback retry edges certify as outer-channel"; "TD cycle" channel-lane test; loop exits exact S vertex / enters S midpoint tests; contact sheet R | — |
 | 12 | **Bundling contract** (trunk proved clear of non-endpoint nodes; blocked member falls out; junction re-derived) | §6 "Bundle contract" | "bundle contract — trunks never pass through nodes" block; NEW: unlabeled `&` fan-out certifies `bundle` from the vertex port | — |
-| 13 | **Occlusion-safe layer alignment** (`alignLayerNodes` refuses snaps onto routed corridors) | §6.3 | **indirect only**: rubric hard metric `edgeThroughNode = 0` over the battery + property oracles | **FLAG: no direct unit test** isolating the refusal branch; killable mutants likely survive in `alignLayerNodes` (outside the route-contracts mutation lane) |
+| 13 | **Occlusion-safe layer alignment** (`alignLayerNodes` refuses snaps onto routed corridors) | §6.3 | `heuristic-coverage.test.ts` isolates the refusal branch with a foreign edge corridor that would be occluded by a snap, plus a control where the snap fires | — |
 | 14 | **Through-node Z-repair** (occlusion removal outranks never-increase-crossings) | §6.3 | rubric `edgeThroughNode` gates + "repairs never increase edge crossings" block (the converse rule) | — |
 | 15 | **Never-increase-crossings rule** | §6 | "a back-lane that would cut through a fan-out trunk stays a certified loop" | — |
 | 16 | **On-lane label slots** (midpoint → 1/3 → 2/3; labels only ON their own route) | §6 | `findLabelSlot` unit block; `labelOffRoute` hard metric | — |
 | 17 | **Container repair** (border-to-border under SEPARATE hierarchy) | §6 "Container repair", §11.5 | container blocks incl. axis-selection harvest + perimeter tolerance | reversed-order gaps noted as open in `docs/mutation-testing.md` |
-| 18 | **Cross-hierarchy orthogonalizer** (`orthogonalizeEdgePoints`, SEPARATE-mode only) | §2 claims table | **indirect only**: `diagonalSegments = 0` hard metric over battery/properties; subgraph-direction tests | **FLAG: no direct unit test** |
+| 18 | **Cross-hierarchy orthogonalizer** (`orthogonalizeEdgePoints`, SEPARATE-mode only) | §2 claims table | `heuristic-coverage.test.ts` directly rewrites a bare diagonal into axis-aligned elbows and asserts the identity short-circuit for already-orthogonal paths; subgraph-direction integration keeps `diagonalSegments = 0` | — |
 | 19 | **Residual diagonal orthogonalization** (45° feedback joins → axis-aligned elbow) | §6.3 | indirect via `diagonalSegments = 0` properties (this is the counterexample fix itself) | acceptable: property-pinned |
-| 20 | **ELK crash degradation ladder** (`layoutGraphSync` retries plainer option sets, `layout-engine.ts:1959–1998`) | §6.3 | **none direct** — no test pins the ladder order or that a degraded survivor is repaired; crash-freedom property tests cover parsers, not dense-multigraph ELK crashes | **FLAG: documented but untested.** Known gap — needs a pinned dense-multigraph fixture that triggers the GWT crash |
+| 20 | **ELK crash degradation ladder** (`layoutGraphSync` retries plainer option sets, `layout-engine.ts:1959–1998`) | §6.3 | `heuristic-coverage.test.ts` pins issue #34's 3-node/9-edge dense cyclic multigraph: tier-0 ELK throws `Invalid hitboxes for scanline constraint calculation`, tier 1 (`feedbackEdges=false`) succeeds, and `layoutGraphSync` returns finite geometry | — |
 | 21 | **ASCII longest-path layering** + **widest-segment label choice** + FIFO tie-breaking | §3 principle 5 | ASCII goldens + `ascii-fanout-trunk-labeled.test.ts`, `ascii-pathfinder-units.test.ts`, ASCII mutation lane | — |
 | 22 | **ROUTE_\* tripwires** (six zero-noise post-certification validators) | §7 | tripwire + boundary-harvest blocks; "validation never mutates the layout" | — |
 | 23 | **PORT_EXACT catalog / slanted family ports** (slant midpoints, flag point) | §6.2.2 | `lean-shapes.test.ts`; contact sheet T–V | — |
 
-Summary: 20/23 heuristics have both documentation and direct tests. The three
-flagged (occlusion-safe alignment #13, cross-hierarchy orthogonalizer #18,
-degradation ladder #20) are all documented and indirectly gated by the rubric
-hard metrics; #20 is the only one with no failing-mode coverage at all.
+Summary: 23/23 heuristics now have both documentation and direct tests. The
+last historical gap, degradation ladder #20, is pinned by issue #34's
+crash→fallback fixture rather than broad crash-freedom stress tests alone.
 
 ---
 

--- a/docs/design/route-contracts.md
+++ b/docs/design/route-contracts.md
@@ -619,10 +619,12 @@ defect class found by a counterexample, now pinned:
   joins a port with a 45° segment; such segments are replaced with an
   axis-aligned elbow continuing the previous segment's axis.
 - **ELK crash degradation ladder**: the bundled GWT build of ELK throws
-  internal exceptions on rare dense multigraphs (one trigger pre-existing,
-  one via feedbackEdges). `layoutGraphSync` retries through progressively
-  plainer option sets; the route pass repairs whatever the survivor
-  produces. Crash-freedom is part of the renderer's contract.
+  internal exceptions on rare dense multigraphs (issue #34 pins a
+  3-node/9-edge cyclic trigger: tier 0 throws `Invalid hitboxes for
+  scanline constraint calculation`, tier 1 succeeds with feedback routing
+  disabled). `layoutGraphSync` retries through progressively plainer option
+  sets; the route pass repairs whatever the survivor produces.
+  Crash-freedom is part of the renderer's contract.
 
 ## 7. Validation: the ROUTE_* tripwires (issue #25 Phase 1, complete)
 

--- a/src/__tests__/heuristic-coverage.test.ts
+++ b/src/__tests__/heuristic-coverage.test.ts
@@ -21,7 +21,9 @@ import {
   alignLayerNodes,
   orthogonalizeEdgePoints,
   layoutGraphSync,
+  convertToElkFormat,
 } from '../layout-engine.ts'
+import { elkLayoutSync } from '../elk-instance.ts'
 import { parseMermaid } from '../parser.ts'
 import { assessLayout } from '../layout-rubric.ts'
 import type { PositionedNode, PositionedEdge, Point } from '../types.ts'
@@ -217,27 +219,26 @@ describe('cross-hierarchy orthogonalizer — orthogonalizeEdgePoints', () => {
 // rethrows if *every* tier fails. The route-contract pass then repairs
 // whatever the surviving tier produced.
 //
-// SEARCH NOTE (testing-best-practices: do not fake a trigger): the commit that
-// introduced the ladder (93df1ad) documents two real triggers — "one
-// pre-existing, one via feedbackEdges" — but did not check in a fixture. I
-// searched for a deterministic first-tier crash via the public pipeline:
-//   - dense complete digraphs K_n with both directions, n = 7..16
-//   - dense multigraphs n×n with 2..5 parallel duplicate edges per pair
-//   - large simple cycles (n = 20, 50) and self-loop-laden graphs
-// None reproduced a *first-tier* GWT throw on the bundled ELK in this
-// environment (they all succeed on tier 0). So rather than fabricate a crash,
-// the tests below assert the two properties the ladder must guarantee:
-//   (a) the ladder is structurally reachable and well-formed (every tier still
-//       lays a dense diagram out to a valid, non-empty, finite layout), and
-//   (b) `layoutGraphSync` never throws on these dense/cyclic stress inputs and
-//       returns finite positive geometry for every node.
-// If a first-tier trigger is later found, add it here and assert the same
-// post-conditions — the degraded survivor must still be a valid layout.
+// PINNED TRIGGER (issue #34): this 3-node/9-edge dense cyclic multigraph is a
+// deterministic bundled-ELK failure for tier 0 (`elk.layered.feedbackEdges:
+// true`): `java.lang.IllegalStateException: Invalid hitboxes for scanline
+// constraint calculation.` Turning feedbackEdges off (tier 1) succeeds, which
+// pins the actual crash → fallback → valid-layout transition instead of merely
+// asserting broad crash-freedom on stress inputs.
 // ============================================================================
+const ELK_TIER0_HITBOX_CRASH = `flowchart TD
+  N0 --> N2
+  N1 --> N0
+  N2 --> N1
+  N1 --> N2
+  N1 --> N2
+  N2 --> N0
+  N0 --> N1
+  N0 --> N1
+  N0 --> N1`
+
 describe('ELK degradation ladder — layoutGraphSync crash-freedom', () => {
-  const assertValidLayout = (src: string) => {
-    const graph = parseMermaid(src)
-    const positioned = layoutGraphSync(graph)
+  const assertFinitePositionedGraph = (positioned: ReturnType<typeof layoutGraphSync>) => {
     expect(positioned.nodes.length).toBeGreaterThan(0)
     for (const n of positioned.nodes) {
       expect(Number.isFinite(n.x)).toBe(true)
@@ -252,6 +253,33 @@ describe('ELK degradation ladder — layoutGraphSync crash-freedom', () => {
       }
     }
   }
+
+  const assertValidLayout = (src: string) => {
+    const graph = parseMermaid(src)
+    assertFinitePositionedGraph(layoutGraphSync(graph))
+  }
+
+  it('issue #34: tier-0 ELK hitbox crash succeeds via the feedbackEdges-off fallback', () => {
+    const graph = parseMermaid(ELK_TIER0_HITBOX_CRASH)
+
+    // The committed fixture proves the real bundled-ELK crash at the default
+    // option set. This is the edge the older broad stress tests could not pin.
+    expect(() => elkLayoutSync(convertToElkFormat(graph))).toThrow(/Invalid hitboxes|IllegalStateException/)
+
+    // The first degraded option set is sufficient: disabling ELK's feedback
+    // edge router makes the same graph lay out cleanly.
+    const fallbackAttempt = convertToElkFormat(graph)
+    fallbackAttempt.layoutOptions = {
+      ...fallbackAttempt.layoutOptions,
+      'elk.layered.feedbackEdges': 'false',
+    }
+    expect(() => elkLayoutSync(fallbackAttempt)).not.toThrow()
+
+    const positioned = layoutGraphSync(graph)
+    assertFinitePositionedGraph(positioned)
+    expect(positioned.nodes.map(n => n.id).sort()).toEqual(['N0', 'N1', 'N2'])
+    expect(positioned.edges.length).toBe(9)
+  })
 
   it('a dense bidirectional complete digraph (K8 both ways) lays out without throwing', () => {
     // 8 nodes, every ordered pair connected => 56 edges with many feedback


### PR DESCRIPTION
## What
Pin the ELK degradation ladder with a real deterministic fallback fixture.

## Why
Fixes #34. `layoutGraphSync` already retries progressively plainer ELK option sets, but the test suite only proved broad crash-freedom. A maintainer could remove the fallback ladder and existing stress tests might still pass.

Reproduction now captured in the PR: the committed 3-node / 9-edge dense cyclic Mermaid graph throws `java.lang.IllegalStateException: Invalid hitboxes for scanline constraint calculation` when sent directly to bundled ELK with the default tier-0 options.

## How
- Added the minimal Mermaid fixture to `src/__tests__/heuristic-coverage.test.ts`.
- Asserted tier 0 fails via `elkLayoutSync(convertToElkFormat(graph))`.
- Asserted tier 1 succeeds when `elk.layered.feedbackEdges=false`.
- Asserted the public `layoutGraphSync` path returns finite, non-empty geometry for all 3 nodes and 9 edges.
- Updated route-contract/audit docs so the ladder is no longer listed as an untested gap.

## Testing
- [x] New/modified tests pass: `bun test src/__tests__/heuristic-coverage.test.ts`
- [x] Regression guard verified: temporarily sabotaged `layoutGraphSync` to use only tier 0; the new issue #34 test failed with the pinned ELK hitbox exception, then passed again after restoring the ladder.
- [x] Full test suite passes: `bun test --coverage src/__tests__/` → 3088 pass
- [x] Type/build checks pass: `bun x tsc --noEmit`, `bun run build`
- [x] Render audit pass: `bun run audit:ugly` → 391 diagrams · 1168 format-audits · 0 HARD · 0 soft · 6 known render-errors
- [x] Whitespace check: `git diff --check`
- [x] CI on PR #52: `test` pass, `e2e` pass
- [x] Good PR readiness: small focused diff (89 lines), one test file changed, one commit, no new dependencies, no secrets/debug statements, no UI files.

## Screenshots / Recordings
No visual/UI change. This is a regression-test/docs update for an existing layout fallback path.

## Risk
Low. No production code changes; the PR only adds a regression guard and updates documentation. The fixture directly exercises the existing fallback behavior, so future ladder regressions should fail loudly.
