### PR TITLE
[codex] Preserve decision rejoin symmetry

### DIFF
--- a/docs/design/route-contracts.md
+++ b/docs/design/route-contracts.md
@@ -96,7 +96,7 @@ type RouteCertificateBase = {
   routeClass: RouteClass
   bendCount: number
   directLaneClear?: boolean  // primary-forward and feedback
-  directLaneBlockedBy?: Array<{ kind: 'node' | 'label' | 'channel' | 'span' | 'crossing'; id: string }>
+  directLaneBlockedBy?: Array<{ kind: 'node' | 'label' | 'channel' | 'span' | 'crossing' | 'port'; id: string }>
   sourcePort?: AnyPort
   targetPort?: AnyPort
   sourcePortAssignment?: RoutePortAssignment
@@ -224,6 +224,14 @@ If no candidate lane is clear, the certificate records
 with the concrete blockers, e.g. the MFA fixture's `D --No--> G` is blocked
 by node `F` standing in every candidate lane — exactly the explained detour
 issue #25 demands.
+
+Diamond fan-outs have one extra port-constraint case: when sibling decision
+branches share a target rank, branches spread across the diamond's facet/cardinal
+ports and still enter each peer target through its facing cardinal port. If those
+two port lanes differ, a straight segment would have to give up one endpoint
+contract; the branch is therefore certified as an `explained-detour` blocked by
+`kind: 'port'`, and verification treats the Z-route as intentional only while
+the final endpoints still sit on the selected ports.
 
 **Bundle contract (issue #25 Phase 4, first slice):** the fan-out/fan-in
 bundler used to rebuild trunk paths with no obstacle awareness, so a skip

--- a/src/__tests__/route-contracts-syntax-range.test.ts
+++ b/src/__tests__/route-contracts-syntax-range.test.ts
@@ -543,6 +543,44 @@ describe('syntax range — & multi-edge chains hit the same fan heuristics', () 
     zeroHardViolations(source)
   })
 
+  it('a three-way decision rejoin keeps target-port branch labels visually separated', () => {
+    const source = `flowchart TD
+  A[Request] --> B{Route?}
+  B -->|alpha| C[Alpha]
+  B -->|beta| D[Beta]
+  B -->|gamma| E[Gamma]
+  C --> F[Done]
+  D --> F
+  E --> F`
+    const positioned = layoutGraphSync(parseMermaid(source))
+    const style = resolveRenderStyle({})
+    const nodes = new Map(positioned.nodes.map(node => [node.id, node]))
+    const center = nodes.get('B')!.x + nodes.get('B')!.width / 2
+    expect(nodes.get('D')!.x + nodes.get('D')!.width / 2).toBeCloseTo(center, 3)
+    expect(nodes.get('F')!.x + nodes.get('F')!.width / 2).toBeCloseTo(center, 3)
+    const branchEdges = positioned.edges.filter(e => e.source === 'B')
+    const labelRects = branchEdges.map(edge => {
+      expect(edge.routeCertificate?.sourcePort).toBeDefined()
+      expect(edge.routeCertificate?.targetPort).toBe('N')
+      if (edge.label === 'beta') {
+        expect(edge.routeCertificate?.sourcePort).toBe('S')
+        expect(edge.routeCertificate?.invariant).toBe('straight')
+        for (const point of edge.points) expect(point.x).toBeCloseTo(center, 3)
+      } else {
+        expect(edge.routeCertificate?.directLaneBlockedBy).toContainEqual({ kind: 'port', id: `${edge.source}->${edge.target}` })
+      }
+      expect(distanceToPolyline(edge.labelPosition!, edge.points)).toBeLessThanOrEqual(0.001)
+      return labelRect(edge, style)!
+    })
+
+    for (let i = 0; i < labelRects.length; i++) {
+      for (let j = i + 1; j < labelRects.length; j++) {
+        expect(rectsOverlap(labelRects[i]!, labelRects[j]!, readableLabelGap(style))).toBe(false)
+      }
+    }
+    zeroHardViolations(source)
+  })
+
   it('property: labeled decision fan-out labels stay off incident nodes across directions', () => {
     fc.assert(
       fc.property(

--- a/src/__tests__/route-contracts.test.ts
+++ b/src/__tests__/route-contracts.test.ts
@@ -2,10 +2,10 @@ import { describe, expect, it } from 'bun:test'
 import fc from 'fast-check'
 import { buildRoutePortHints, layoutGraphSync } from '../layout-engine.ts'
 import { parseMermaid } from '../parser.ts'
-import { applyRouteContracts, auditRouteContracts, classifyRoutes, directLaneBlockers, findLabelSlot, findRouteHitches, shapePorts, simplifyPolyline } from '../route-contracts.ts'
+import { applyRouteContracts, auditRouteContracts, classifyRoutes, diamondFacetPorts, directLaneBlockers, findLabelSlot, findRouteHitches, shapePorts, simplifyPolyline } from '../route-contracts.ts'
 import { measureMultilineText } from '../text-metrics.ts'
 import { layoutMermaid, parseMermaid as agentParse, verifyMermaid } from '../agent/index.ts'
-import type { PositionedEdge, PositionedGraph, PositionedGroup, PositionedNode } from '../types.ts'
+import type { AnyPort, Point, PositionedEdge, PositionedGraph, PositionedGroup, PositionedNode } from '../types.ts'
 
 /** The MFA/login regression from issue #25 — every dogleg here had a clear direct lane. */
 const MFA_SOURCE = `flowchart LR
@@ -27,6 +27,32 @@ function findEdge(edges: PositionedEdge[], from: string, to: string, label?: str
   const e = edges.find(e => e.source === from && e.target === to && (label === undefined || e.label === label))
   if (!e) throw new Error(`edge ${from}->${to} not found`)
   return e
+}
+
+function legalPorts(node: PositionedNode): Partial<Record<AnyPort, Point>> {
+  return node.shape === 'diamond'
+    ? { ...shapePorts(node), ...diamondFacetPorts(node) }
+    : shapePorts(node)
+}
+
+function expectSourceEndpointAtNamedPort(edge: PositionedEdge, source: PositionedNode): void {
+  const port = edge.routeCertificate?.sourcePort
+  if (!port) throw new Error(`${edge.source}->${edge.target} emitted from a non-port source endpoint`)
+  const expected = legalPorts(source)[port]
+  if (!expected) throw new Error(`${edge.source}->${edge.target} reported invalid source port ${port}`)
+  const actual = edge.points[0]!
+  expect(Math.abs(actual.x - expected.x)).toBeLessThanOrEqual(0.5)
+  expect(Math.abs(actual.y - expected.y)).toBeLessThanOrEqual(0.5)
+}
+
+function expectTargetEndpointAtNamedPort(edge: PositionedEdge, target: PositionedNode): void {
+  const port = edge.routeCertificate?.targetPort
+  if (!port) throw new Error(`${edge.source}->${edge.target} entered a non-port target endpoint`)
+  const expected = legalPorts(target)[port]
+  if (!expected) throw new Error(`${edge.source}->${edge.target} reported invalid target port ${port}`)
+  const actual = edge.points[edge.points.length - 1]!
+  expect(Math.abs(actual.x - expected.x)).toBeLessThanOrEqual(0.5)
+  expect(Math.abs(actual.y - expected.y)).toBeLessThanOrEqual(0.5)
 }
 
 function isStraightHorizontal(e: PositionedEdge): boolean {
@@ -1396,6 +1422,51 @@ describe('port ranking — sharp bits win when a side carries one line (issue #2
       const q = positioned.nodes.find(n => n.id === 'Q')!
       const center = q[cross] + (cross === 'y' ? q.height : q.width) / 2
       expect(Math.abs(Math.abs(a.points[0]![cross] - center) - Math.abs(b.points[0]![cross] - center))).toBeLessThanOrEqual(0.75)
+    }
+  })
+
+  it('a TD decision fork/rejoin exits the diamond through lower facet ports before honoring target lanes', () => {
+    const positioned = layoutGraphSync(parseMermaid(`flowchart TD
+  A[Start] --> B{Decision?}
+  B -->|Yes| C[Do the thing]
+  B -->|No| D[Skip it]
+  C --> E[End]
+  D --> E`))
+    const yes = findEdge(positioned.edges, 'B', 'C', 'Yes')
+    const no = findEdge(positioned.edges, 'B', 'D', 'No')
+    const decision = positioned.nodes.find(n => n.id === 'B')!
+    const center = decision.x + decision.width / 2
+
+    expect(yes.routeCertificate?.sourcePort).toBe('SW')
+    expect(no.routeCertificate?.sourcePort).toBe('SE')
+    expect(yes.points[0]!.x).toBeLessThan(center)
+    expect(no.points[0]!.x).toBeGreaterThan(center)
+    expect(yes.points[0]!.y).toBeCloseTo(no.points[0]!.y, 3)
+  })
+
+  it('a TD decision fork/rejoin emits every line from a named source port', () => {
+    const positioned = layoutGraphSync(parseMermaid(`flowchart TD
+  A[Start] --> B{Decision?}
+  B -->|Yes| C[Do the thing]
+  B -->|No| D[Skip it]
+  C --> E[End]
+  D --> E`))
+    const nodes = new Map(positioned.nodes.map(node => [node.id, node]))
+    for (const edge of positioned.edges) {
+      expectSourceEndpointAtNamedPort(edge, nodes.get(edge.source)!)
+    }
+  })
+
+  it('a TD decision fork/rejoin enters every target through a named target port', () => {
+    const positioned = layoutGraphSync(parseMermaid(`flowchart TD
+  A[Start] --> B{Decision?}
+  B -->|Yes| C[Do the thing]
+  B -->|No| D[Skip it]
+  C --> E[End]
+  D --> E`))
+    const nodes = new Map(positioned.nodes.map(node => [node.id, node]))
+    for (const edge of positioned.edges) {
+      expectTargetEndpointAtNamedPort(edge, nodes.get(edge.target)!)
     }
   })
 

--- a/src/layout-engine.ts
+++ b/src/layout-engine.ts
@@ -956,6 +956,7 @@ function elkToPositioned(
   // pack layers before port-lane alignment so downstream centering/routing sees
   // the symmetric geometry instead of incidental text-size differences.
   equalizePeerNodeDimensions(nodes, edges, groups, graph)
+  alignForkRejoinPeerCenters(nodes, edges, groups, graph, style)
 
   // Port-lane alignment (Rüegg et al. GD'15: straightness THROUGH ports, not
   // through arbitrary attachment points): when a straight edge floats off
@@ -1444,6 +1445,80 @@ function equalizePeerNodeDimensions(nodes: PositionedNode[], edges: PositionedEd
   if (changed) packFlowLayerCrossAxis(nodes, graph.direction)
 }
 
+function alignForkRejoinPeerCenters(
+  nodes: PositionedNode[],
+  edges: PositionedEdge[],
+  groups: PositionedGroup[],
+  graph: MermaidGraph,
+  style: LabelMetricsStyle,
+): void {
+  const nodeMap = new Map(nodes.map(n => [n.id, n]))
+  const bySource = new Map<string, PositionedEdge[]>()
+  for (const edge of edges) {
+    if (!positionedEdgeForwardish(edge, nodeMap, graph.direction)) continue
+    if (!bySource.has(edge.source)) bySource.set(edge.source, [])
+    bySource.get(edge.source)!.push(edge)
+  }
+  const forwardIndegree = (id: string): number => edges.filter(edge =>
+    edge.target === id && positionedEdgeForwardish(edge, nodeMap, graph.direction)).length
+  const forwardOutgoing = (id: string): PositionedEdge[] => edges.filter(edge =>
+    edge.source === id && edge.target !== id && positionedEdgeForwardish(edge, nodeMap, graph.direction))
+  const ownedForwardClosure = (root: PositionedNode, initial: ReadonlySet<string>): PositionedNode[] => {
+    const out: PositionedNode[] = []
+    const seen = new Set(initial)
+    const queue = [root]
+    while (queue.length > 0) {
+      const node = queue.shift()!
+      if (seen.has(node.id)) continue
+      seen.add(node.id)
+      out.push(node)
+      for (const edge of forwardOutgoing(node.id)) {
+        const next = nodeMap.get(edge.target)
+        if (!next || seen.has(next.id)) continue
+        if (forwardIndegree(next.id) === 1) queue.push(next)
+      }
+    }
+    return out
+  }
+
+  for (const [sourceId, outgoing] of bySource) {
+    if (outgoing.length !== 3) continue
+    const source = nodeMap.get(sourceId)
+    if (!source || source.shape !== 'diamond' || nodeInsideGroups(source, groups)) continue
+    const sorted = [...outgoing].sort((a, b) => nodeCrossCenter(nodeMap.get(a.target)!, graph.direction) - nodeCrossCenter(nodeMap.get(b.target)!, graph.direction))
+    const targets = sorted.map(edge => nodeMap.get(edge.target)).filter((node): node is PositionedNode => !!node)
+    if (targets.length !== sorted.length) continue
+    if (!targets.every(target => target.shape === 'rectangle' && !nodeInsideGroups(target, groups))) continue
+    if (!sameFlowLayer(targets, graph.direction, 28)) continue
+    let peer = true
+    for (let i = 0; i < targets.length; i++) for (let j = 0; j < targets.length; j++) {
+      if (i !== j && logicalGraphReaches(graph, targets[i]!.id, targets[j]!.id)) peer = false
+    }
+    if (!peer) continue
+
+    const childOut = targets.map(target => forwardOutgoing(target.id))
+    if (!childOut.every(list => list.length === 1)) continue
+    const rejoinId = childOut[0]![0]!.target
+    if (!childOut.every(list => list[0]!.target === rejoinId)) continue
+    const rejoin = nodeMap.get(rejoinId)
+    if (!rejoin || nodeInsideGroups(rejoin, groups)) continue
+
+    const movedIds = new Set(targets.map(target => target.id))
+    for (const node of ownedForwardClosure(rejoin, movedIds)) movedIds.add(node.id)
+    if ([...movedIds].some(id => {
+      const node = nodeMap.get(id)
+      return !node || nodeInsideGroups(node, groups)
+    })) continue
+
+    const rowCenter = (nodeCrossCenter(targets[0]!, graph.direction) + nodeCrossCenter(targets[targets.length - 1]!, graph.direction)) / 2
+    const delta = nodeCrossCenter(source, graph.direction) - rowCenter
+    if (Math.abs(delta) <= 0.5) continue
+    if (!crossShiftSafe(movedIds, nodes, edges, graph.direction, delta, style)) continue
+    layoutDebug('[fork-rejoin] center', source.id, 'peer island by', delta.toFixed(1))
+    shiftNodeSetCross(movedIds, nodes, edges, graph.direction, delta)
+  }
+}
+
 function connectionPort(node: PositionedNode, side: 'N' | 'E' | 'S' | 'W' | DiamondFacet): Point {
   if (node.shape === 'diamond' && (side === 'NE' || side === 'SE' || side === 'SW' || side === 'NW')) return diamondFacetPorts(node)[side]
   return shapePorts(node)[side as 'N' | 'E' | 'S' | 'W']
@@ -1558,6 +1633,99 @@ function honorLinkRankDistance(nodes: PositionedNode[], edges: PositionedEdge[],
     edge.points = doglegBetween(start, end, graph.direction, elbow)
     if (edge.label) edge.labelPosition = calculatePathMidpoint(edge.points)
   }
+}
+
+function shiftTerminalRunCross(edge: PositionedEdge, direction: Direction, fromEnd: boolean, delta: number): void {
+  if (edge.points.length === 0) return
+  const f = layoutFlow(direction)
+  const idx = fromEnd ? edge.points.length - 1 : 0
+  const step = fromEnd ? -1 : 1
+  const ref = edge.points[idx]![f.cross]
+  let mainLo = Infinity
+  let mainHi = -Infinity
+  for (let i = idx; i >= 0 && i < edge.points.length; i += step) {
+    if (Math.abs(edge.points[i]![f.cross] - ref) > 0.5) break
+    mainLo = Math.min(mainLo, edge.points[i]![f.main])
+    mainHi = Math.max(mainHi, edge.points[i]![f.main])
+    edge.points[i]![f.cross] += delta
+  }
+  if (edge.labelPosition &&
+    Math.abs(edge.labelPosition[f.cross] - ref) <= 12 &&
+    edge.labelPosition[f.main] >= mainLo - 0.5 &&
+    edge.labelPosition[f.main] <= mainHi + 0.5) {
+    edge.labelPosition[f.cross] += delta
+  }
+}
+
+function shiftNodeSetCross(
+  movedIds: ReadonlySet<string>,
+  nodes: PositionedNode[],
+  edges: PositionedEdge[],
+  direction: Direction,
+  delta: number,
+): void {
+  const f = layoutFlow(direction)
+  for (const node of nodes) {
+    if (!movedIds.has(node.id)) continue
+    node[f.cross] += delta
+  }
+  for (const edge of edges) {
+    const srcMoved = movedIds.has(edge.source)
+    const tgtMoved = movedIds.has(edge.target)
+    if (srcMoved && tgtMoved) {
+      for (const point of edge.points) point[f.cross] += delta
+      if (edge.labelPosition) edge.labelPosition[f.cross] += delta
+    } else if (tgtMoved) {
+      shiftTerminalRunCross(edge, direction, true, delta)
+    } else if (srcMoved) {
+      shiftTerminalRunCross(edge, direction, false, delta)
+    }
+  }
+}
+
+function crossShiftSafe(
+  movedIds: ReadonlySet<string>,
+  nodes: PositionedNode[],
+  edges: PositionedEdge[],
+  direction: Direction,
+  delta: number,
+  style: LabelMetricsStyle,
+): boolean {
+  const f = layoutFlow(direction)
+  const moved = nodes.filter(node => movedIds.has(node.id))
+  const shifted = new Map(moved.map(node => [node.id, {
+    x: f.isHorizontal ? node.x : node.x + delta,
+    y: f.isHorizontal ? node.y + delta : node.y,
+    width: node.width,
+    height: node.height,
+  }]))
+  for (const box of shifted.values()) {
+    if (box.x < 0 || box.y < 0) return false
+  }
+  for (let i = 0; i < moved.length; i++) {
+    const a = shifted.get(moved[i]!.id)!
+    for (let j = i + 1; j < moved.length; j++) {
+      if (rectsOverlap(a, shifted.get(moved[j]!.id)!, 8)) return false
+    }
+    for (const other of nodes) {
+      if (movedIds.has(other.id)) continue
+      if (rectsOverlap(a, other, 8)) return false
+    }
+  }
+  for (const node of moved) {
+    const box = shifted.get(node.id)!
+    for (const edge of edges) {
+      if (movedIds.has(edge.source) || movedIds.has(edge.target)) continue
+      for (let i = 1; i < edge.points.length; i++) {
+        const a = edge.points[i - 1]!, b = edge.points[i]!
+        if (Math.max(a.x, b.x) > box.x + 0.5 && Math.min(a.x, b.x) < box.x + box.width - 0.5 &&
+          Math.max(a.y, b.y) > box.y + 0.5 && Math.min(a.y, b.y) < box.y + box.height - 0.5) return false
+      }
+      const rect = labelRect(edge, style)
+      if (rect && rectsOverlap(box, { x: rect.x, y: rect.y, width: rect.w, height: rect.h }, 8)) return false
+    }
+  }
+  return true
 }
 
 function collapseTinyBundledHitches(nodes: PositionedNode[], edges: PositionedEdge[], bundled: Set<PositionedEdge>): void {

--- a/src/route-contracts.ts
+++ b/src/route-contracts.ts
@@ -607,6 +607,137 @@ function portSharpness(shape: PositionedNode['shape']): number {
   return shape === 'diamond' ? 2 : 1
 }
 
+function portPoint(node: PositionedNode, side: PortSide | DiamondFacet): Point {
+  if (node.shape === 'diamond' && (side === 'NE' || side === 'SE' || side === 'SW' || side === 'NW')) {
+    return diamondFacetPorts(node)[side]
+  }
+  return shapePorts(node)[side as PortSide]
+}
+
+function diamondSpreadPortSet(axis: Axis, count: number): Array<PortSide | DiamondFacet> | null {
+  if (axis.main === 'x') {
+    if (axis.sign > 0) {
+      if (count === 2) return ['NE', 'SE']
+      if (count === 3) return ['NE', 'E', 'SE']
+    } else {
+      if (count === 2) return ['NW', 'SW']
+      if (count === 3) return ['NW', 'W', 'SW']
+    }
+  } else if (axis.sign > 0) {
+    if (count === 2) return ['SW', 'SE']
+    if (count === 3) return ['SW', 'S', 'SE']
+  } else {
+    if (count === 2) return ['NW', 'NE']
+    if (count === 3) return ['NW', 'N', 'NE']
+  }
+  return null
+}
+
+interface DiamondSpreadAssignment {
+  sourcePort: PortSide | DiamondFacet
+  sourceLane: number
+}
+
+function diamondSpreadAssignment(
+  edge: PositionedEdge,
+  source: PositionedNode,
+  ctx: LaneContext,
+  axis: Axis,
+): DiamondSpreadAssignment | null {
+  if (source.shape !== 'diamond' || edge.edgeIndex === undefined || ctx.classes?.[edge.edgeIndex] !== 'primary-forward') {
+    return null
+  }
+  const nodeMap = new Map(ctx.nodes.map(node => [node.id, node]))
+  const siblings = ctx.edges
+    .filter(candidate => candidate.source === edge.source &&
+      candidate.edgeIndex !== undefined &&
+      ctx.classes?.[candidate.edgeIndex] === 'primary-forward' &&
+      nodeMap.has(candidate.target))
+    .sort((a, b) => {
+      const aTarget = nodeMap.get(a.target)!
+      const bTarget = nodeMap.get(b.target)!
+      const aCross = aTarget[axis.cross] + (axis.cross === 'y' ? aTarget.height : aTarget.width) / 2
+      const bCross = bTarget[axis.cross] + (axis.cross === 'y' ? bTarget.height : bTarget.width) / 2
+      return aCross - bCross || (a.edgeIndex ?? 0) - (b.edgeIndex ?? 0)
+    })
+  const ports = diamondSpreadPortSet(axis, siblings.length)
+  if (!ports) return null
+  const index = siblings.indexOf(edge)
+  if (index < 0) return null
+  const sourcePort = ports[index]!
+  return { sourcePort, sourceLane: portPoint(source, sourcePort)[axis.cross] }
+}
+
+function diamondSpreadLane(
+  edge: PositionedEdge,
+  source: PositionedNode,
+  ctx: LaneContext,
+  axis: Axis,
+): number | undefined {
+  return diamondSpreadAssignment(edge, source, ctx, axis)?.sourceLane
+}
+
+function diamondSpreadTargetsShareRank(
+  edge: PositionedEdge,
+  source: PositionedNode,
+  ctx: LaneContext,
+  axis: Axis,
+): boolean {
+  if (source.shape !== 'diamond' || edge.edgeIndex === undefined || ctx.classes?.[edge.edgeIndex] !== 'primary-forward') {
+    return false
+  }
+  const nodeMap = new Map(ctx.nodes.map(node => [node.id, node]))
+  const siblings = ctx.edges.filter(candidate => candidate.source === edge.source &&
+    candidate.edgeIndex !== undefined &&
+    ctx.classes?.[candidate.edgeIndex] === 'primary-forward' &&
+    nodeMap.has(candidate.target))
+  if (!diamondSpreadPortSet(axis, siblings.length)) return false
+  const targetMains = siblings.map(candidate => {
+    const target = nodeMap.get(candidate.target)!
+    return target[axis.main] + (axis.main === 'x' ? target.width : target.height) / 2
+  })
+  return Math.max(...targetMains) - Math.min(...targetMains) <= 1
+}
+
+interface DiamondSpreadTargetPortConstraint {
+  sourcePort: PortSide | DiamondFacet
+  sourceLane: number
+  targetPort: PortSide
+  targetLane: number
+}
+
+function diamondSpreadTargetPortConstraint(
+  edge: PositionedEdge,
+  source: PositionedNode,
+  target: PositionedNode,
+  ctx: LaneContext,
+  axis: Axis,
+): DiamondSpreadTargetPortConstraint | null {
+  const spread = diamondSpreadAssignment(edge, source, ctx, axis)
+  if (!spread || !diamondSpreadTargetsShareRank(edge, source, ctx, axis)) return null
+  const targetPort = facingSide(axis, -1)
+  const targetLane = shapePorts(target)[targetPort][axis.cross]
+  if (Math.abs(spread.sourceLane - targetLane) <= PORT_TOLERANCE) return null
+  return { ...spread, targetPort, targetLane }
+}
+
+function satisfiesDiamondSpreadTargetPortConstraint(
+  edge: PositionedEdge,
+  source: PositionedNode,
+  target: PositionedNode,
+  constraint: DiamondSpreadTargetPortConstraint,
+): boolean {
+  if (edge.points.length <= 2) return false
+  const start = edge.points[0]!
+  const end = edge.points[edge.points.length - 1]!
+  const sourcePort = portPoint(source, constraint.sourcePort)
+  const targetPort = shapePorts(target)[constraint.targetPort]
+  return Math.abs(start.x - sourcePort.x) <= PORT_TOLERANCE &&
+    Math.abs(start.y - sourcePort.y) <= PORT_TOLERANCE &&
+    Math.abs(end.x - targetPort.x) <= PORT_TOLERANCE &&
+    Math.abs(end.y - targetPort.y) <= PORT_TOLERANCE
+}
+
 /**
  * Primary edges own the straight lane (spec §5): when proving a primary
  * lane, the reciprocal feedback partner's label is movable decoration —
@@ -929,6 +1060,8 @@ function tryStraighten(
     push(srcPortLane)
     push(tgtPortLane)
   } else {
+    const spreadLane = diamondSpreadLane(edge, source, ctx, axis)
+    if (spreadLane !== undefined) push(spreadLane)
     push(tgtPortLane)
     push(srcPortLane)
   }
@@ -1097,6 +1230,19 @@ export function applyRouteContracts(
         return { applied: false, mutated: JSON.stringify(edge.points) !== beforeGeometry }
       }
     }
+    const portConstraint = diamondSpreadTargetPortConstraint(edge, source!, target!, ctx, edgeAxis)
+    if (portConstraint &&
+      tryZRoute(edge, source!, target!, ctx, edgeAxis, false, {
+        sourceLane: portConstraint.sourceLane,
+        targetLane: portConstraint.targetLane,
+        preferSourceJog: true,
+      })) {
+      cert.invariant = 'explained-detour'
+      cert.directLaneClear = false
+      cert.directLaneBlockedBy = [{ kind: 'port', id: edgeId(edge) }]
+      cert.bendCount = bendCount(edge.points)
+      return { applied: false, mutated: JSON.stringify(edge.points) !== beforeGeometry }
+    }
     const attempt = tryStraighten(edge, source!, target!, ctx, edgeAxis)
     if (attempt.applied) {
       const mutated = JSON.stringify(edge.points) !== beforeGeometry
@@ -1159,6 +1305,7 @@ export function applyRouteContracts(
     ctx: LaneContext,
     axis: Axis,
     sourcePortOnly = false,
+    forcedLanes?: { sourceLane?: number; targetLane?: number; preferSourceJog?: boolean },
   ): boolean {
     if (edge.points.length < 2) return false
     const srcSpan = attachSpan(source, axis)
@@ -1171,13 +1318,21 @@ export function applyRouteContracts(
     const pushTo = (arr: number[], v: number) => {
       if (arr.every(prev => Math.abs(prev - v) > 0.5)) arr.push(v)
     }
-    pushTo(c1s, source[axis.cross] + (axis.cross === 'y' ? source.height : source.width) / 2)
-    if (!sourcePortOnly) {
-      pushTo(c1s, edge.points[0]![axis.cross])
-      for (const v of crossVals) pushTo(c1s, v)
+    if (forcedLanes?.sourceLane !== undefined) {
+      pushTo(c1s, forcedLanes.sourceLane)
+    } else {
+      pushTo(c1s, source[axis.cross] + (axis.cross === 'y' ? source.height : source.width) / 2)
+      if (!sourcePortOnly) {
+        pushTo(c1s, edge.points[0]![axis.cross])
+        for (const v of crossVals) pushTo(c1s, v)
+      }
     }
-    pushTo(c2s, target[axis.cross] + (axis.cross === 'y' ? target.height : target.width) / 2)
-    pushTo(c2s, edge.points[edge.points.length - 1]![axis.cross])
+    if (forcedLanes?.targetLane !== undefined) {
+      pushTo(c2s, forcedLanes.targetLane)
+    } else {
+      pushTo(c2s, target[axis.cross] + (axis.cross === 'y' ? target.height : target.width) / 2)
+      pushTo(c2s, edge.points[edge.points.length - 1]![axis.cross])
+    }
 
     const relaxDiamond = (node: PositionedNode, span: CrossSpan): CrossSpan =>
       node.shape === 'diamond'
@@ -1194,7 +1349,10 @@ export function applyRouteContracts(
         if (Math.abs(c1 - c2) < CLEARANCE) continue // that would be a hitch, not a Z
         const srcMain = anchorMain(source, c1, axis, 1)
         if ((tgtMain - srcMain) * axis.sign <= EPS) continue
-        for (const jog of [tgtMain - axis.sign * 12, (srcMain + tgtMain) / 2, srcMain + axis.sign * 12]) {
+        const jogs = forcedLanes?.preferSourceJog
+          ? [srcMain + axis.sign * 12, (srcMain + tgtMain) / 2, tgtMain - axis.sign * 12]
+          : [tgtMain - axis.sign * 12, (srcMain + tgtMain) / 2, srcMain + axis.sign * 12]
+        for (const jog of jogs) {
           if ((jog - srcMain) * axis.sign <= EPS || (tgtMain - jog) * axis.sign <= EPS) continue
           // The label rides the longest lane only; the other lane and the
           // hop are proved with a label-stripped probe so the own-label
@@ -1670,6 +1828,8 @@ export function findRouteHitches(
     if (!isStraightenable(source.shape)) continue
     if (!isStraightenable(target.shape)) continue
     if (cert.routeClass !== 'feedback' && !isMonotoneStaircase(points, edgeAxis)) continue
+    const portConstraint = diamondSpreadTargetPortConstraint(edge, source, target, ctx, edgeAxis)
+    if (portConstraint && satisfiesDiamondSpreadTargetPortConstraint(edge, source, target, portConstraint)) continue
     // Vertex-emit edges (single-line diamond side) bend deliberately when no
     // straight vertex lane exists; their probe is restricted to that lane.
     const srcSideUse = sideUse.get(`${edge.source}:${facingSide(edgeAxis, 1)}`) ?? 1

--- a/src/types.ts
+++ b/src/types.ts
@@ -194,7 +194,7 @@ export interface RoutePortAssignment {
 }
 
 export interface RouteBlocker {
-  kind: 'node' | 'label' | 'channel' | 'span' | 'crossing'
+  kind: 'node' | 'label' | 'channel' | 'span' | 'crossing' | 'port'
   id: string
 }
 


### PR DESCRIPTION
## Summary

- Preserve centerline symmetry for three-way decision fork/rejoin islands by centering the peer row and rejoin island under the decision diamond.
- Route equal-rank diamond fan-out branches from principled facet/cardinal ports into target facing ports, certifying the non-straight side branches as port-constrained detours.
- Add regression coverage for named source/target ports, readable branch-label separation, and the middle branch staying straight through the decision centerline.

## Root Cause

The previous fixes selected better local ports, but they did not preserve the global fork/rejoin symmetry invariant. That allowed the peer target row and rejoin node to drift off the decision diamond centerline, so the visually central branch could inherit an unnecessary lateral jog even while individual endpoint ports were technically valid.

## Validation

- `bun x tsc --noEmit`
- `bun test src/__tests__/route-contracts.test.ts src/__tests__/route-contracts-syntax-range.test.ts`
- `npm test` — 3769 pass, 7 skip, 0 fail

Refs #26, #38, #42.