### PR TITLE
Issue-keyed regression fixtures for the 13 layout-aesthetic complaints

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -156,7 +156,11 @@ dependents after. IDs are stable names, not an ordering.
   TreeView first: it is hierarchical, ASCII-friendly, and requested against
   the upstream fork network (lukilabs/beautiful-mermaid#114). Treat
   beta-grammar families (Venn, Ishikawa, Wardley) as watch-and-wait until
-  upstream syntax stabilizes.
+  upstream syntax stabilizes. C4 belongs here too: the layout-aesthetic
+  complaint mermaid-js/mermaid#7492 (C4 overlapping labels/text overflow/
+  crossing arrows) cannot get a regression fixture until C4 is rendered — the
+  aesthetic-issue coverage audit
+  (`docs/issue-derived-test-cases.md`) defers it to this item.
 - [x] **BUILD-15 — Journey structured mutation (pilot)** (`done`). Typed
   `JourneyBody` (title/sections/tasks with 1..5 scores and actors), 10 ops,
   `asJourney` narrower, verify hook, lossless opaque fallback for unmodeled

--- a/docs/issue-derived-test-cases.md
+++ b/docs/issue-derived-test-cases.md
@@ -119,7 +119,7 @@ mermaid-js's own dagre renderer, which this fork does not share (see
 Current useful heuristics:
 
 - `verifyMermaid` warnings: `OFF_CANVAS`, `GROUP_BREACH`, `NODE_OVERLAP`, `ROUTE_SELF_CROSS`, `LABEL_OVERFLOW`, `DUPLICATE_EDGE`, `UNREACHABLE_NODE`;
-- `measureQuality(layoutMermaid(d))` / `checkQuality(...)`: edge crossings, label legibility, whitespace balance, edge-label clearance from non-attached nodes and other edge labels, and aspect ratio;
+- `measureQuality(layoutMermaid(d))` / `checkQuality(...)`: edge crossings, label legibility, whitespace balance, edge-label clearance from non-attached nodes, other edge labels, and other edge paths, and aspect ratio;
 - issue-keyed fixtures that gate selected repro diagrams individually, including zero crossings and label-vs-label box separation for parallel edge labels;
 - family-specific geometry assertions, such as Auth Flow's source-order progression and backward feedback-edge routing;
 - layout-quality heuristic tests for declared-direction progress (`TD`/`BT`/`LR`/`RL`), edge-vs-node collisions excluding attached endpoints, feedback-process cleanliness, root node vs top-level subgraph source order, and self-loop clearance;
@@ -127,7 +127,6 @@ Current useful heuristics:
 
 High-value next heuristics for layout-improvement corpora:
 
-- promote edge-label bounding-box overlap with unrelated edges from fixture-local checks into a shared metric;
 - route corridor reuse by unrelated edge families;
 - target-aware fan-in/fan-out clustering score;
 - group-header text fit, especially with CJK/fullwidth labels.

--- a/docs/issue-derived-test-cases.md
+++ b/docs/issue-derived-test-cases.md
@@ -54,15 +54,15 @@ These are public Mermaid / Beautiful Mermaid issues worth turning into small, ed
 A May 2026 GitHub issue/PR search found recurring layout-quality themes in both Mermaid and Beautiful Mermaid:
 
 - [mermaid-js/mermaid#6049 — Flowchart ugly self linking nodes](https://github.com/mermaid-js/mermaid/issues/6049)
-  - Fixture idea: self-loop on a styled node. Assert the loop stays outside the node, has bounded route length, and does not obscure the label.
+  - Fixture status: `src/__tests__/aesthetic-issue-regressions.test.ts` renders a flowchart self-loop and asserts the loop has no hard geometric defects; `src/__tests__/layout-quality-heuristics.test.ts` keeps the broader self-loop clearance guard.
 - [mermaid-js/mermaid#5060 — Avoidable overlapping curves in flow-chart](https://github.com/mermaid-js/mermaid/issues/5060)
-  - Fixture idea: repeated parallel edges with long labels. Assert edge-label proximity and crossing/overlap counts stay below a threshold.
+  - Fixture status: `src/__tests__/aesthetic-issue-regressions.test.ts` renders repeated parallel labeled edges and asserts distinct edge paths, zero crossings, no hard defects, and separated label boxes.
 - [mermaid-js/mermaid#6046 — subgraph links should affect positioning more than inter-graph links](https://github.com/mermaid-js/mermaid/issues/6046)
   - Fixture idea: nested subgraphs with invisible/loose links. Assert group order follows source intent and cross-group edges do not dominate internal layout.
 - [mermaid-js/mermaid#7492 — C4 overlapping labels/text overflow/crossing arrows](https://github.com/mermaid-js/mermaid/issues/7492)
   - Fixture idea: labels near containers. Assert text stays inside boxes and edge labels keep minimum clearance from unrelated nodes.
 - [mermaid-js/mermaid#2792 — graph lines sometimes overlap boxes](https://github.com/mermaid-js/mermaid/issues/2792)
-  - Fixture idea: route-vs-node collision. Assert no edge segment passes through unrelated node bounding boxes.
+  - Fixture status: `src/__tests__/aesthetic-issue-regressions.test.ts` renders a transitive route and asserts the ugly-detector reports no edge-through-node defect.
 - [lukilabs/beautiful-mermaid#83 — TD/TB flowchart layout flipping horizontal](https://github.com/lukilabs/beautiful-mermaid/issues/83)
   - Fixture idea: vertical process with repeated feedback edges. Assert TD/TB diagrams remain height-dominant or within a bounded aspect ratio.
 - [lukilabs/beautiful-mermaid#68 — fan-in groups not target-aware](https://github.com/lukilabs/beautiful-mermaid/issues/68)
@@ -76,27 +76,29 @@ A May 2026 GitHub issue/PR search found recurring layout-quality themes in both 
 
 ## Aesthetic-issue coverage audit (issue-keyed)
 
-A June 2026 audit confirmed that the *behavior* behind the 13 layout-aesthetic
-complaints in [`mermaid-layout-complaints.md`](./mermaid-layout-complaints.md)
-was guarded by the general detector/metric/route-certificate layers, but no
-test was keyed to the upstream issue number (so `git grep '#6476'` found only
-docs). That traceability gap is now closed:
+A June 2026 audit turned the 13 layout-aesthetic complaints in
+[`mermaid-layout-complaints.md`](./mermaid-layout-complaints.md) into an
+explicit coverage ledger. Direct issue-keyed fixtures now guard the complaints
+that can be expressed against supported diagram families; broader existing
+assertions are tagged where they already covered the behavior; unsupported,
+deferred, and policy-out-of-scope cases remain recorded below.
 
 - **Issue-keyed regression fixtures** —
   [`src/__tests__/aesthetic-issue-regressions.test.ts`](../src/__tests__/aesthetic-issue-regressions.test.ts)
   renders a small repro graph per complaint and asserts, through the real
   renderer, that Agentic Mermaid does not exhibit it: `#6476` (avoidable edge
   crossings → 0 on a planar bipartite graph), `#5601` (planar state diagram
-  stays planar), `#5060` (parallel labeled edges, no geometric defects),
+  stays planar), `#5060` (parallel labeled edges use distinct rendered paths,
+  keep labels separate, and produce no geometric defects),
   `#2792` (transitive edge does not pass through an intervening node, via the
   ugly-detector `edge-through-node` check), `#2131` (edge labels keep
-  clearance from unrelated nodes), and `#6336`/`#6049` (self-loop endpoints on
-  the outline, no defects).
+  clearance from unrelated nodes and from each other), and `#6336`/`#6049`
+  (state and flowchart self-loops render without hard defects).
 - **Tagged existing assertions** (now greppable by issue number): `#815`
   (declared node/source order — `agent-auth-flow.test.ts`,
   `layout-quality-heuristics.test.ts`), `#1984`/`#3262` (scale-collapse
-  whitespace + aspect — `agent-quality.test.ts`), `#1301` (gantt rows never
-  overlap — `gantt-layout.test.ts`), and `#1765` (activation/note/block
+  whitespace + aspect — `agent-quality.test.ts`), `#1301` (long-range Gantt
+  axis labels stay clear of task bars — `gantt-layout.test.ts`), and `#1765` (activation/note/block
   clearance — `sequence-layout.test.ts`).
 - **`#7492` (C4 overlapping labels/arrows)** — no fixture yet: the C4 family
   is not rendered. Tracked under **BUILD-6** (new upstream families); add the
@@ -118,13 +120,14 @@ Current useful heuristics:
 
 - `verifyMermaid` warnings: `OFF_CANVAS`, `GROUP_BREACH`, `NODE_OVERLAP`, `ROUTE_SELF_CROSS`, `LABEL_OVERFLOW`, `DUPLICATE_EDGE`, `UNREACHABLE_NODE`;
 - `measureQuality(layoutMermaid(d))` / `checkQuality(...)`: edge crossings, label legibility, whitespace balance, label-edge proximity, and aspect ratio;
+- issue-keyed fixtures that gate selected repro diagrams individually, including zero crossings and label-vs-label box separation for parallel edge labels;
 - family-specific geometry assertions, such as Auth Flow's source-order progression and backward feedback-edge routing;
 - layout-quality heuristic tests for declared-direction progress (`TD`/`BT`/`LR`/`RL`), edge-vs-node collisions excluding attached endpoints, feedback-process cleanliness, root node vs top-level subgraph source order, and self-loop clearance;
 - PNG/SVG screenshot comparison for artifacts that layout JSON cannot see, such as rounded-fill raster artifacts.
 
 High-value next heuristics for layout-improvement corpora:
 
-- edge-label bounding-box overlap with unrelated nodes/edges;
+- promote edge-label bounding-box overlap with unrelated labels/nodes/edges from fixture-local checks into a shared metric;
 - route corridor reuse by unrelated edge families;
 - target-aware fan-in/fan-out clustering score;
 - group-header text fit, especially with CJK/fullwidth labels.

--- a/docs/issue-derived-test-cases.md
+++ b/docs/issue-derived-test-cases.md
@@ -119,7 +119,7 @@ mermaid-js's own dagre renderer, which this fork does not share (see
 Current useful heuristics:
 
 - `verifyMermaid` warnings: `OFF_CANVAS`, `GROUP_BREACH`, `NODE_OVERLAP`, `ROUTE_SELF_CROSS`, `LABEL_OVERFLOW`, `DUPLICATE_EDGE`, `UNREACHABLE_NODE`;
-- `measureQuality(layoutMermaid(d))` / `checkQuality(...)`: edge crossings, label legibility, whitespace balance, label-edge proximity, and aspect ratio;
+- `measureQuality(layoutMermaid(d))` / `checkQuality(...)`: edge crossings, label legibility, whitespace balance, edge-label clearance from non-attached nodes and other edge labels, and aspect ratio;
 - issue-keyed fixtures that gate selected repro diagrams individually, including zero crossings and label-vs-label box separation for parallel edge labels;
 - family-specific geometry assertions, such as Auth Flow's source-order progression and backward feedback-edge routing;
 - layout-quality heuristic tests for declared-direction progress (`TD`/`BT`/`LR`/`RL`), edge-vs-node collisions excluding attached endpoints, feedback-process cleanliness, root node vs top-level subgraph source order, and self-loop clearance;
@@ -127,7 +127,7 @@ Current useful heuristics:
 
 High-value next heuristics for layout-improvement corpora:
 
-- promote edge-label bounding-box overlap with unrelated labels/nodes/edges from fixture-local checks into a shared metric;
+- promote edge-label bounding-box overlap with unrelated edges from fixture-local checks into a shared metric;
 - route corridor reuse by unrelated edge families;
 - target-aware fan-in/fan-out clustering score;
 - group-header text fit, especially with CJK/fullwidth labels.

--- a/docs/issue-derived-test-cases.md
+++ b/docs/issue-derived-test-cases.md
@@ -74,6 +74,44 @@ A May 2026 GitHub issue/PR search found recurring layout-quality themes in both 
 - [lukilabs/beautiful-mermaid#121 — ER/class ASCII labels truncated/overlapping](https://github.com/lukilabs/beautiful-mermaid/issues/121)
   - Fixture status: representative class/ER golden files now assert labels survive and connectors remain attached; keep this theme in the generated matrix for longer label/attribute variants.
 
+## Aesthetic-issue coverage audit (issue-keyed)
+
+A June 2026 audit confirmed that the *behavior* behind the 13 layout-aesthetic
+complaints in [`mermaid-layout-complaints.md`](./mermaid-layout-complaints.md)
+was guarded by the general detector/metric/route-certificate layers, but no
+test was keyed to the upstream issue number (so `git grep '#6476'` found only
+docs). That traceability gap is now closed:
+
+- **Issue-keyed regression fixtures** —
+  [`src/__tests__/aesthetic-issue-regressions.test.ts`](../src/__tests__/aesthetic-issue-regressions.test.ts)
+  renders a small repro graph per complaint and asserts, through the real
+  renderer, that Agentic Mermaid does not exhibit it: `#6476` (avoidable edge
+  crossings → 0 on a planar bipartite graph), `#5601` (planar state diagram
+  stays planar), `#5060` (parallel labeled edges, no geometric defects),
+  `#2792` (transitive edge does not pass through an intervening node, via the
+  ugly-detector `edge-through-node` check), `#2131` (edge labels keep
+  clearance from unrelated nodes), and `#6336`/`#6049` (self-loop endpoints on
+  the outline, no defects).
+- **Tagged existing assertions** (now greppable by issue number): `#815`
+  (declared node/source order — `agent-auth-flow.test.ts`,
+  `layout-quality-heuristics.test.ts`), `#1984`/`#3262` (scale-collapse
+  whitespace + aspect — `agent-quality.test.ts`), `#1301` (gantt rows never
+  overlap — `gantt-layout.test.ts`), and `#1765` (activation/note/block
+  clearance — `sequence-layout.test.ts`).
+- **`#7492` (C4 overlapping labels/arrows)** — no fixture yet: the C4 family
+  is not rendered. Tracked under **BUILD-6** (new upstream families); add the
+  fixture when C4 lands.
+- **`#3723` (same-rank constraint) and `#5420` (manual node positioning)** —
+  documented **won't-do by policy**, no fixture. `#3723` is "watch-only"
+  (adopt only if Mermaid core standardizes a `config:` key — see C6); `#5420`
+  is out of scope (the agent loop is the substitute — see C1). Neither is a
+  bug we can regression-guard, because not implementing them is the decision.
+
+These guards assert "Agentic Mermaid does not exhibit the complaint," not
+"the upstream Mermaid bug is fixed" — every cited issue is a defect in
+mermaid-js's own dagre renderer, which this fork does not share (see
+[`mermaid-layout-complaints.md`](./mermaid-layout-complaints.md) R4).
+
 ## Programmatic bad-layout heuristics
 
 Current useful heuristics:

--- a/docs/layout-characterization/visual-quality.md
+++ b/docs/layout-characterization/visual-quality.md
@@ -12,11 +12,11 @@ gates: `src/__tests__/contact-sheet.test.ts`,
 
 | Family | SVG snapshot | SVG SHA | PNG SHA | PNG bytes | SVG size | Layout bounds | Nodes/edges | Crossings | Bends | Route px | Area fill | Label fit | Label overlaps | Edge-label clearance | Aspect |
 |--------|--------------|---------|---------|----------:|----------|---------------|-------------|----------:|------:|---------:|----------:|----------:|---------------:|---------------------:|-------:|
-| Flowchart | [flowchart.svg](./visual-snapshots/flowchart.svg) | `c7309bf2da77` | `15045f285709` | 8930 | 279.6835x434.582 | 280x435 | 4/4 | 0 | 0 | 533 | 15.5% | 100.0% | 0 | 65 | 0.64 |
+| Flowchart | [flowchart.svg](./visual-snapshots/flowchart.svg) | `c7309bf2da77` | `15045f285709` | 8930 | 279.6835x434.582 | 280x435 | 4/4 | 0 | 0 | 533 | 15.5% | 100.0% | 0 | 7 | 0.64 |
 | State diagram | [state.svg](./visual-snapshots/state.svg) | `1c4a472c8c2f` | `c2729a406f0e` | 7382 | 241.14266666666668x375.15000000000003 | 241x375 | 5/5 | 0 | 6 | 628 | 11.3% | 100.0% | 0 | n/a | 0.64 |
 | Sequence diagram | [sequence.svg](./visual-snapshots/sequence.svg) | `d4c56a07b76b` | `725fe413d753` | 7207 | 420x280 | 420x280 | 3/4 | 0 | 0 | 560 | 8.2% | 100.0% | 0 | 10 | 1.50 |
 | Class diagram | [class.svg](./visual-snapshots/class.svg) | `61e6b7f26fa9` | `1e617c4a61a0` | 4047 | 360x237.8 | 360x238 | 3/2 | 0 | 2 | 240 | 20.6% | 100.0% | 0 | n/a | 1.51 |
-| ER diagram | [er.svg](./visual-snapshots/er.svg) | `5598a5275602` | `a6962348dac3` | 9488 | 951.768x136 | 952x136 | 3/2 | 0 | 0 | 452 | 18.2% | 100.0% | 0 | 316 | 7.00 |
+| ER diagram | [er.svg](./visual-snapshots/er.svg) | `5598a5275602` | `a6962348dac3` | 9488 | 951.768x136 | 952x136 | 3/2 | 0 | 0 | 452 | 18.2% | 100.0% | 0 | 115 | 7.00 |
 | Timeline | [timeline.svg](./visual-snapshots/timeline.svg) | `aa2f3660f25e` | `83efdfa14f76` | 7837 | 380x286.6 | 380x287 | 4/0 | 0 | 0 | 0 | 13.2% | 100.0% | 0 | n/a | 1.32 |
 | Gantt chart | [gantt.svg](./visual-snapshots/gantt.svg) | `59c925d9736b` | `3195007323a1` | 9419 | 703x282 | 703x282 | 4/0 | 0 | 0 | 0 | 6.9% | 75.0% | 0 | n/a | 2.49 |
 | User journey | [journey.svg](./visual-snapshots/journey.svg) | `6e7c7ec336ef` | `4d01b73acd56` | 9495 | 320x353.4 | 320x353 | 2/0 | 0 | 0 | 0 | 30.8% | 100.0% | 0 | n/a | 0.91 |

--- a/docs/layout-characterization/visual-quality.md
+++ b/docs/layout-characterization/visual-quality.md
@@ -12,11 +12,11 @@ gates: `src/__tests__/contact-sheet.test.ts`,
 
 | Family | SVG snapshot | SVG SHA | PNG SHA | PNG bytes | SVG size | Layout bounds | Nodes/edges | Crossings | Bends | Route px | Area fill | Label fit | Label overlaps | Edge-label clearance | Aspect |
 |--------|--------------|---------|---------|----------:|----------|---------------|-------------|----------:|------:|---------:|----------:|----------:|---------------:|---------------------:|-------:|
-| Flowchart | [flowchart.svg](./visual-snapshots/flowchart.svg) | `c7309bf2da77` | `15045f285709` | 8930 | 279.6835x434.582 | 280x435 | 4/4 | 0 | 0 | 533 | 15.5% | 100.0% | 0 | 89 | 0.64 |
+| Flowchart | [flowchart.svg](./visual-snapshots/flowchart.svg) | `c7309bf2da77` | `15045f285709` | 8930 | 279.6835x434.582 | 280x435 | 4/4 | 0 | 0 | 533 | 15.5% | 100.0% | 0 | 65 | 0.64 |
 | State diagram | [state.svg](./visual-snapshots/state.svg) | `1c4a472c8c2f` | `c2729a406f0e` | 7382 | 241.14266666666668x375.15000000000003 | 241x375 | 5/5 | 0 | 6 | 628 | 11.3% | 100.0% | 0 | n/a | 0.64 |
-| Sequence diagram | [sequence.svg](./visual-snapshots/sequence.svg) | `d4c56a07b76b` | `725fe413d753` | 7207 | 420x280 | 420x280 | 3/4 | 0 | 0 | 560 | 8.2% | 100.0% | 0 | 170 | 1.50 |
+| Sequence diagram | [sequence.svg](./visual-snapshots/sequence.svg) | `d4c56a07b76b` | `725fe413d753` | 7207 | 420x280 | 420x280 | 3/4 | 0 | 0 | 560 | 8.2% | 100.0% | 0 | 10 | 1.50 |
 | Class diagram | [class.svg](./visual-snapshots/class.svg) | `61e6b7f26fa9` | `1e617c4a61a0` | 4047 | 360x237.8 | 360x238 | 3/2 | 0 | 2 | 240 | 20.6% | 100.0% | 0 | n/a | 1.51 |
-| ER diagram | [er.svg](./visual-snapshots/er.svg) | `5598a5275602` | `a6962348dac3` | 9488 | 951.768x136 | 952x136 | 3/2 | 0 | 0 | 452 | 18.2% | 100.0% | 0 | 370 | 7.00 |
+| ER diagram | [er.svg](./visual-snapshots/er.svg) | `5598a5275602` | `a6962348dac3` | 9488 | 951.768x136 | 952x136 | 3/2 | 0 | 0 | 452 | 18.2% | 100.0% | 0 | 316 | 7.00 |
 | Timeline | [timeline.svg](./visual-snapshots/timeline.svg) | `aa2f3660f25e` | `83efdfa14f76` | 7837 | 380x286.6 | 380x287 | 4/0 | 0 | 0 | 0 | 13.2% | 100.0% | 0 | n/a | 1.32 |
 | Gantt chart | [gantt.svg](./visual-snapshots/gantt.svg) | `59c925d9736b` | `3195007323a1` | 9419 | 703x282 | 703x282 | 4/0 | 0 | 0 | 0 | 6.9% | 75.0% | 0 | n/a | 2.49 |
 | User journey | [journey.svg](./visual-snapshots/journey.svg) | `6e7c7ec336ef` | `4d01b73acd56` | 9495 | 320x353.4 | 320x353 | 2/0 | 0 | 0 | 0 | 30.8% | 100.0% | 0 | n/a | 0.91 |

--- a/docs/mermaid-layout-complaints.md
+++ b/docs/mermaid-layout-complaints.md
@@ -198,7 +198,8 @@ edge they describe.
 - Fixture/test: this engine passes edge labels into layout as first-class
   inline ELK labels (`elk.edgeLabels.inline: 'true'`,
   `src/layout-engine.ts`), so they reserve space instead of being overlaid;
-  `labelEdgeProximity` (≥4px to any non-attached node) gates regressions.
+  `labelEdgeProximity` (≥4px to any non-attached node or other edge-label
+  box) gates regressions.
   ASCII branch labels are pinned to sibling branch segments, not shared
   trunks: `src/__tests__/ascii-fanout-trunk-labeled.test.ts`,
   `ascii-pathfinder-trunk.test.ts`, plus exact goldens under

--- a/docs/mermaid-layout-complaints.md
+++ b/docs/mermaid-layout-complaints.md
@@ -198,8 +198,8 @@ edge they describe.
 - Fixture/test: this engine passes edge labels into layout as first-class
   inline ELK labels (`elk.edgeLabels.inline: 'true'`,
   `src/layout-engine.ts`), so they reserve space instead of being overlaid;
-  `labelEdgeProximity` (≥4px to any non-attached node or other edge-label
-  box) gates regressions.
+  `labelEdgeProximity` (≥4px to any non-attached node, other edge-label
+  box, or other edge path) gates regressions.
   ASCII branch labels are pinned to sibling branch segments, not shared
   trunks: `src/__tests__/ascii-fanout-trunk-labeled.test.ts`,
   `ascii-pathfinder-trunk.test.ts`, plus exact goldens under

--- a/docs/quality.md
+++ b/docs/quality.md
@@ -24,7 +24,7 @@ A diagram is considered **good looking** when it satisfies, in order:
    | `edgeCrossings` | pairs of edge segments that visually intersect | ≤ 5% of edge pairs |
    | `labelLegibility` | fraction of node labels whose rendered length fits the node width | ≥ 85% |
    | `whitespaceBalance` | node area ÷ canvas area | 5%–55% (too sparse AND too dense lose) |
-   | `labelEdgeProximity` | min pixel distance between any edge-label box and a non-attached node or another edge-label box | ≥ 4 px |
+   | `labelEdgeProximity` | min pixel distance between any edge-label box and a non-attached node, another edge-label box, or another edge path | ≥ 4 px |
    | `aspectRatio` | canvas w/h | 0.2–5.0 |
 
    These are computed by `measureQuality(layout)` and gated by

--- a/docs/quality.md
+++ b/docs/quality.md
@@ -24,7 +24,7 @@ A diagram is considered **good looking** when it satisfies, in order:
    | `edgeCrossings` | pairs of edge segments that visually intersect | ≤ 5% of edge pairs |
    | `labelLegibility` | fraction of node labels whose rendered length fits the node width | ≥ 85% |
    | `whitespaceBalance` | node area ÷ canvas area | 5%–55% (too sparse AND too dense lose) |
-   | `labelEdgeProximity` | min pixel distance between any edge-label and a non-attached node | ≥ 4 px |
+   | `labelEdgeProximity` | min pixel distance between any edge-label box and a non-attached node or another edge-label box | ≥ 4 px |
    | `aspectRatio` | canvas w/h | 0.2–5.0 |
 
    These are computed by `measureQuality(layout)` and gated by

--- a/src/__tests__/aesthetic-issue-regressions.test.ts
+++ b/src/__tests__/aesthetic-issue-regressions.test.ts
@@ -1,0 +1,95 @@
+// ============================================================================
+// Issue-keyed regression fixtures for the layout-aesthetic complaints catalogued
+// in docs/mermaid-layout-complaints.md (the C2–C13 clusters) and
+// docs/issue-derived-test-cases.md.
+//
+// Why this file exists: the *behavior* behind these upstream complaints was
+// already guarded by the general ugly-detector (eval/ugly-detector/detect.ts),
+// the route certificates, and the perceptual quality metrics — but no test was
+// keyed to the upstream issue number, so `git grep '#6476'` found only docs.
+// Each test below takes a small graph that represents one upstream complaint and
+// asserts, through the real renderer, that Agentic Mermaid does not exhibit it.
+//
+// These are "we don't have that complaint" guards, not "we fixed Mermaid":
+// every cited issue is a bug in mermaid-js's own (dagre) renderer, which this
+// fork does not share. See docs/mermaid-layout-complaints.md Part 2 (R4) and
+// the Q1 caveat in that doc.
+// ============================================================================
+
+import { describe, expect, test } from 'bun:test'
+import { renderMermaidSVG } from '../index.ts'
+import { detectSvg, type Finding } from '../../eval/ugly-detector/detect.ts'
+import { parseMermaid, layoutMermaid, measureQuality } from '../agent/index.ts'
+
+/** Hard geometric defects from the ugly-detector on real renderer output. */
+function hardFindings(src: string): Finding[] {
+  return detectSvg(renderMermaidSVG(src, { embedFontImport: false })).filter(f => f.severity === 'hard')
+}
+
+function crossings(src: string): number {
+  const p = parseMermaid(src)
+  if (!p.ok) throw new Error('parse failed')
+  return measureQuality(layoutMermaid(p.value)).edgeCrossings
+}
+
+describe('layout-aesthetic regression fixtures (issue-keyed)', () => {
+  // upstream: mermaid-js/mermaid#6476 — "Unnecessary crossing of edges between
+  // nodes": dagre crosses two edges that could be uncrossed by swapping
+  // endpoints. K2,2 is planar, so a faithful layout has zero crossings.
+  test('#6476 avoidable edge crossings: a planar bipartite graph renders with none', () => {
+    const src = 'flowchart LR\n  A --> C\n  B --> D\n  A --> D\n  B --> C'
+    expect(crossings(src)).toBe(0)
+    expect(hardFindings(src)).toEqual([])
+  })
+
+  // upstream: mermaid-js/mermaid#5601 — "stateDiagrams overlap edges even if the
+  // diagram is planar". The same small planar state machine must stay planar.
+  test('#5601 planar state diagram is rendered planar (no edge crossings)', () => {
+    const src = 'stateDiagram-v2\n  [*] --> Idle\n  Idle --> Running\n  Running --> Idle\n  Running --> [*]'
+    expect(crossings(src)).toBe(0)
+    expect(hardFindings(src)).toEqual([])
+  })
+
+  // upstream: mermaid-js/mermaid#5060 — "Avoidable overlapping curves in
+  // flow-chart": parallel edges between the same pair must not collapse into one
+  // another or produce geometric defects. (Label-vs-label proximity is a known
+  // metric gap; this guards the curve geometry and crossing count.)
+  test('#5060 parallel labeled edges do not overlap into geometric defects', () => {
+    const src = 'flowchart LR\n  A -->|first| B\n  A -->|second| B\n  B --> C'
+    expect(crossings(src)).toBe(0)
+    expect(hardFindings(src)).toEqual([])
+  })
+
+  // upstream: mermaid-js/mermaid#2792 — "graph lines sometimes overlap boxes":
+  // a transitive edge (A->C alongside A->B->C) must route around B, never
+  // through its interior. The detector flags any edge-through-node as hard.
+  test('#2792 a transitive edge does not pass through an intervening node', () => {
+    const src = 'flowchart TD\n  A --> B\n  B --> C\n  A --> C'
+    expect(hardFindings(src).filter(f => f.kind === 'edge-through-node')).toEqual([])
+    expect(hardFindings(src)).toEqual([])
+  })
+
+  // upstream: mermaid-js/mermaid#2131 — "State diagram: mis-aligned labels".
+  // Edge labels on multiple edges between a pair must keep clear distance from
+  // unrelated nodes (no label landing on a third node).
+  test('#2131 edge labels keep clearance from unrelated nodes', () => {
+    const src = 'flowchart LR\n  A -->|yes| B\n  A -->|no| B\n  B --> C'
+    const p = parseMermaid(src)
+    if (!p.ok) throw new Error('parse failed')
+    const m = measureQuality(layoutMermaid(p.value))
+    expect(m.labelEdgeProximity).toBeGreaterThan(4) // default min in checkQuality
+    expect(hardFindings(src)).toEqual([])
+  })
+
+  // upstream: mermaid-js/mermaid#6336 — "Self-edges/loops look very awkward in
+  // state diagrams" (and #6049 for flowcharts): a self-loop must stay on the
+  // node outline (no floating endpoint) and not cross the node interior.
+  test('#6336 / #6049 a self-loop renders with endpoints on the outline, no defects', () => {
+    const src = 'flowchart TD\n  A --> B\n  B --> B\n  B --> C'
+    const p = parseMermaid(src)
+    if (!p.ok) throw new Error('parse failed')
+    const layout = layoutMermaid(p.value)
+    expect(layout.edges.some(e => e.from === 'B' && e.to === 'B')).toBe(true) // self-loop survives
+    expect(hardFindings(src)).toEqual([]) // no floating-endpoint / edge-through-node / hitch
+  })
+})

--- a/src/__tests__/aesthetic-issue-regressions.test.ts
+++ b/src/__tests__/aesthetic-issue-regressions.test.ts
@@ -3,12 +3,12 @@
 // in docs/mermaid-layout-complaints.md (the C2–C13 clusters) and
 // docs/issue-derived-test-cases.md.
 //
-// Why this file exists: the *behavior* behind these upstream complaints was
-// already guarded by the general ugly-detector (eval/ugly-detector/detect.ts),
-// the route certificates, and the perceptual quality metrics — but no test was
-// keyed to the upstream issue number, so `git grep '#6476'` found only docs.
-// Each test below takes a small graph that represents one upstream complaint and
-// asserts, through the real renderer, that Agentic Mermaid does not exhibit it.
+// Why this file exists: the general ugly-detector, route certificates, and
+// perceptual quality metrics already guarded many of these behaviors, but the
+// supported cases lacked issue-keyed fixtures, so `git grep '#6476'` found only
+// docs. Each test below takes a small graph that represents one upstream
+// complaint and asserts, through the real renderer, that Agentic Mermaid does
+// not exhibit it.
 //
 // These are "we don't have that complaint" guards, not "we fixed Mermaid":
 // every cited issue is a bug in mermaid-js's own (dagre) renderer, which this
@@ -18,18 +18,107 @@
 
 import { describe, expect, test } from 'bun:test'
 import { renderMermaidSVG } from '../index.ts'
-import { detectSvg, type Finding } from '../../eval/ugly-detector/detect.ts'
-import { parseMermaid, layoutMermaid, measureQuality } from '../agent/index.ts'
+import { detectSvg, parseSvg, type Finding, type Rendered } from '../../eval/ugly-detector/detect.ts'
+import { parseMermaid, layoutMermaid, measureQuality, type QualityMetrics } from '../agent/index.ts'
+
+function renderedSvg(src: string): string {
+  return renderMermaidSVG(src, { embedFontImport: false })
+}
+
+function rendered(src: string): Rendered {
+  return parseSvg(renderedSvg(src))
+}
 
 /** Hard geometric defects from the ugly-detector on real renderer output. */
 function hardFindings(src: string): Finding[] {
-  return detectSvg(renderMermaidSVG(src, { embedFontImport: false })).filter(f => f.severity === 'hard')
+  return detectSvg(renderedSvg(src)).filter(f => f.severity === 'hard')
 }
 
-function crossings(src: string): number {
+function quality(src: string): QualityMetrics {
   const p = parseMermaid(src)
   if (!p.ok) throw new Error('parse failed')
-  return measureQuality(layoutMermaid(p.value)).edgeCrossings
+  return measureQuality(layoutMermaid(p.value))
+}
+
+function assertRendered(src: string, nodes: string[], edges: Array<[string, string, number?]>): Rendered {
+  const r = rendered(src)
+  for (const id of nodes) expect(r.nodes.some(n => n.id === id)).toBe(true)
+  for (const [from, to, count = 1] of edges) {
+    expect(r.edges.filter(e => e.from === from && e.to === to)).toHaveLength(count)
+  }
+  return r
+}
+
+function edgePathSignature(edge: Rendered['edges'][number]): string {
+  return edge.pts.map(p => `${p.x.toFixed(1)},${p.y.toFixed(1)}`).join(' ')
+}
+
+function expectDistinctRenderedEdgePaths(r: Rendered, from: string, to: string): void {
+  const paths = r.edges.filter(e => e.from === from && e.to === to).map(edgePathSignature)
+  expect(new Set(paths).size).toBe(paths.length)
+}
+
+interface Rect { x: number; y: number; w: number; h: number }
+interface EdgeLabel extends Rect { from: string; to: string; label: string }
+
+function attrs(raw: string): Record<string, string> {
+  const out: Record<string, string> = {}
+  for (const m of raw.matchAll(/([A-Za-z_:][-A-Za-z0-9_:.]*)="([^"]*)"/g)) out[m[1]!] = m[2]!
+  return out
+}
+
+function hasClass(a: Record<string, string>, cls: string): boolean {
+  return (a.class ?? '').split(/\s+/).includes(cls)
+}
+
+function numberAttr(a: Record<string, string>, name: string): number {
+  const n = Number(a[name])
+  if (!Number.isFinite(n)) throw new Error(`missing numeric attribute ${name}`)
+  return n
+}
+
+function edgeLabels(src: string): EdgeLabel[] {
+  const svg = renderedSvg(src)
+  const out: EdgeLabel[] = []
+  for (const g of svg.matchAll(/<g\b([^>]*)>([\s\S]*?)<\/g>/g)) {
+    const ga = attrs(g[1]!)
+    if (!hasClass(ga, 'edge-label')) continue
+    const rect = g[2]!.match(/<rect\b([^>]*)/)
+    if (!rect) throw new Error(`edge label ${ga['data-from'] ?? '?'}->${ga['data-to'] ?? '?'} has no halo rect`)
+    const ra = attrs(rect[1]!)
+    out.push({
+      from: ga['data-from'] ?? '',
+      to: ga['data-to'] ?? '',
+      label: ga['data-label'] ?? '',
+      x: numberAttr(ra, 'x'),
+      y: numberAttr(ra, 'y'),
+      w: numberAttr(ra, 'width'),
+      h: numberAttr(ra, 'height'),
+    })
+  }
+  return out
+}
+
+function expectEdgeLabels(src: string, labels: Array<[string, string, string]>): EdgeLabel[] {
+  const actual = edgeLabels(src)
+  for (const [from, to, label] of labels) {
+    expect(actual.some(l => l.from === from && l.to === to && l.label === label)).toBe(true)
+  }
+  return actual
+}
+
+function rectDistance(a: Rect, b: Rect): number {
+  const dx = Math.max(0, Math.max(a.x - (b.x + b.w), b.x - (a.x + a.w)))
+  const dy = Math.max(0, Math.max(a.y - (b.y + b.h), b.y - (a.y + a.h)))
+  return Math.hypot(dx, dy)
+}
+
+function expectLabelBoxesSeparated(labels: EdgeLabel[]): void {
+  for (let i = 0; i < labels.length; i++) {
+    for (let j = i + 1; j < labels.length; j++) {
+      expect(rectDistance(labels[i]!, labels[j]!)).toBeGreaterThan(0)
+    }
+  }
 }
 
 describe('layout-aesthetic regression fixtures (issue-keyed)', () => {
@@ -38,7 +127,8 @@ describe('layout-aesthetic regression fixtures (issue-keyed)', () => {
   // endpoints. K2,2 is planar, so a faithful layout has zero crossings.
   test('#6476 avoidable edge crossings: a planar bipartite graph renders with none', () => {
     const src = 'flowchart LR\n  A --> C\n  B --> D\n  A --> D\n  B --> C'
-    expect(crossings(src)).toBe(0)
+    assertRendered(src, ['A', 'B', 'C', 'D'], [['A', 'C'], ['B', 'D'], ['A', 'D'], ['B', 'C']])
+    expect(quality(src).edgeCrossings).toBe(0)
     expect(hardFindings(src)).toEqual([])
   })
 
@@ -46,17 +136,21 @@ describe('layout-aesthetic regression fixtures (issue-keyed)', () => {
   // diagram is planar". The same small planar state machine must stay planar.
   test('#5601 planar state diagram is rendered planar (no edge crossings)', () => {
     const src = 'stateDiagram-v2\n  [*] --> Idle\n  Idle --> Running\n  Running --> Idle\n  Running --> [*]'
-    expect(crossings(src)).toBe(0)
+    assertRendered(src, ['Idle', 'Running'], [['_start', 'Idle'], ['Idle', 'Running'], ['Running', 'Idle'], ['Running', '_end']])
+    expect(quality(src).edgeCrossings).toBe(0)
     expect(hardFindings(src)).toEqual([])
   })
 
   // upstream: mermaid-js/mermaid#5060 — "Avoidable overlapping curves in
   // flow-chart": parallel edges between the same pair must not collapse into one
-  // another or produce geometric defects. (Label-vs-label proximity is a known
-  // metric gap; this guards the curve geometry and crossing count.)
+  // another, overlap labels, or produce geometric defects.
   test('#5060 parallel labeled edges do not overlap into geometric defects', () => {
     const src = 'flowchart LR\n  A -->|first| B\n  A -->|second| B\n  B --> C'
-    expect(crossings(src)).toBe(0)
+    const r = assertRendered(src, ['A', 'B', 'C'], [['A', 'B', 2], ['B', 'C']])
+    expectDistinctRenderedEdgePaths(r, 'A', 'B')
+    const labels = expectEdgeLabels(src, [['A', 'B', 'first'], ['A', 'B', 'second']])
+    expectLabelBoxesSeparated(labels.filter(l => l.from === 'A' && l.to === 'B'))
+    expect(quality(src).edgeCrossings).toBe(0)
     expect(hardFindings(src)).toEqual([])
   })
 
@@ -65,6 +159,7 @@ describe('layout-aesthetic regression fixtures (issue-keyed)', () => {
   // through its interior. The detector flags any edge-through-node as hard.
   test('#2792 a transitive edge does not pass through an intervening node', () => {
     const src = 'flowchart TD\n  A --> B\n  B --> C\n  A --> C'
+    assertRendered(src, ['A', 'B', 'C'], [['A', 'B'], ['B', 'C'], ['A', 'C']])
     expect(hardFindings(src).filter(f => f.kind === 'edge-through-node')).toEqual([])
     expect(hardFindings(src)).toEqual([])
   })
@@ -73,10 +168,11 @@ describe('layout-aesthetic regression fixtures (issue-keyed)', () => {
   // Edge labels on multiple edges between a pair must keep clear distance from
   // unrelated nodes (no label landing on a third node).
   test('#2131 edge labels keep clearance from unrelated nodes', () => {
-    const src = 'flowchart LR\n  A -->|yes| B\n  A -->|no| B\n  B --> C'
-    const p = parseMermaid(src)
-    if (!p.ok) throw new Error('parse failed')
-    const m = measureQuality(layoutMermaid(p.value))
+    const src = 'stateDiagram-v2\n  A --> B: yes\n  A --> B: no\n  B --> C'
+    assertRendered(src, ['A', 'B', 'C'], [['A', 'B', 2], ['B', 'C']])
+    const labels = expectEdgeLabels(src, [['A', 'B', 'yes'], ['A', 'B', 'no']])
+    expectLabelBoxesSeparated(labels.filter(l => l.from === 'A' && l.to === 'B'))
+    const m = quality(src)
     expect(m.labelEdgeProximity).toBeGreaterThan(4) // default min in checkQuality
     expect(hardFindings(src)).toEqual([])
   })
@@ -85,11 +181,18 @@ describe('layout-aesthetic regression fixtures (issue-keyed)', () => {
   // state diagrams" (and #6049 for flowcharts): a self-loop must stay on the
   // node outline (no floating endpoint) and not cross the node interior.
   test('#6336 / #6049 a self-loop renders with endpoints on the outline, no defects', () => {
-    const src = 'flowchart TD\n  A --> B\n  B --> B\n  B --> C'
-    const p = parseMermaid(src)
+    const state = 'stateDiagram-v2\n  A --> B\n  B --> B: retry\n  B --> C'
+    const flowchart = 'flowchart TD\n  A --> B\n  B --> B\n  B --> C'
+
+    const p = parseMermaid(state)
     if (!p.ok) throw new Error('parse failed')
     const layout = layoutMermaid(p.value)
+    assertRendered(state, ['A', 'B', 'C'], [['A', 'B'], ['B', 'B'], ['B', 'C']])
+    expectEdgeLabels(state, [['B', 'B', 'retry']])
     expect(layout.edges.some(e => e.from === 'B' && e.to === 'B')).toBe(true) // self-loop survives
-    expect(hardFindings(src)).toEqual([]) // no floating-endpoint / edge-through-node / hitch
+    expect(hardFindings(state)).toEqual([]) // no floating-endpoint / edge-through-node / hitch
+
+    assertRendered(flowchart, ['A', 'B', 'C'], [['A', 'B'], ['B', 'B'], ['B', 'C']])
+    expect(hardFindings(flowchart)).toEqual([])
   })
 })

--- a/src/__tests__/agent-auth-flow.test.ts
+++ b/src/__tests__/agent-auth-flow.test.ts
@@ -91,6 +91,7 @@ describe('tweet auth-flow agent workflow', () => {
     expect(png.length).toBeGreaterThan(10_000)
   })
 
+  // upstream: mermaid-js/mermaid#815 (declared node order) / #5227 (backwards arrows)
   test('keeps the primary LR path in source order and routes feedback edges backward', () => {
     const diagram = buildAuthFlowWithAgenticMermaid()
     const layout = layoutMermaid(diagram)

--- a/src/__tests__/agent-quality.test.ts
+++ b/src/__tests__/agent-quality.test.ts
@@ -118,6 +118,42 @@ describe('quality metrics — deterministic', () => {
     expect(v.ok).toBe(false)
     expect(v.violations).toContain('edge-label clearance 0px < min 4px')
   })
+
+  test('labelEdgeProximity includes label-to-unrelated-edge path overlap', () => {
+    const layout: RenderedLayout = {
+      version: 1,
+      kind: 'flowchart',
+      nodes: [],
+      groups: [],
+      edges: [
+        { id: 'A->B', from: 'A', to: 'B', path: [[f(0), f(50)], [f(100), f(50)]], label: { x: f(50), y: f(50), text: 'on route' } },
+        { id: 'C->D', from: 'C', to: 'D', path: [[f(50), f(0)], [f(50), f(100)]] },
+      ],
+      bounds: { w: f(120), h: f(120) },
+    }
+    const m = measureQuality(layout)
+    expect(m.labelEdgeProximity).toBe(0)
+    const v = checkQuality(layout, { whitespaceBand: [0, 1] })
+    expect(v.ok).toBe(false)
+    expect(v.violations).toContain('edge-label clearance 0px < min 4px')
+  })
+
+  test("labelEdgeProximity ignores the label's own edge path", () => {
+    const layout: RenderedLayout = {
+      version: 1,
+      kind: 'flowchart',
+      nodes: [],
+      groups: [],
+      edges: [
+        { id: 'A->B', from: 'A', to: 'B', path: [[f(0), f(50)], [f(100), f(50)]], label: { x: f(50), y: f(50), text: 'own route' } },
+      ],
+      bounds: { w: f(120), h: f(120) },
+    }
+    const m = measureQuality(layout)
+    expect(m.labelEdgeProximity).toBe(Infinity)
+    const v = checkQuality(layout, { whitespaceBand: [0, 1] })
+    expect(v.ok).toBe(true)
+  })
 })
 
 describe('quality metrics — generated large flowchart corpora', () => {

--- a/src/__tests__/agent-quality.test.ts
+++ b/src/__tests__/agent-quality.test.ts
@@ -8,6 +8,7 @@ import { join } from 'node:path'
 import { parseMermaid } from '../agent/parse.ts'
 import { layoutMermaid } from '../agent/index.ts'
 import { measureQuality, checkQuality } from '../agent/quality.ts'
+import { toFinite, type RenderedLayout } from '../agent/types.ts'
 
 const CORPUS_PATH = join(import.meta.dir, '..', '..', 'eval', 'mermaid-docs-corpus', 'corpus.json')
 interface CorpusEntry { family: string; source: string; origin: string; index: number }
@@ -42,6 +43,8 @@ function generatedLayeredFlowchart({ nodeCount, layers, rows }: typeof GENERATED
   }
   return lines.join('\n')
 }
+
+function f(n: number) { return toFinite(n) }
 
 describe('quality metrics — deterministic', () => {
   test('measureQuality returns finite numbers for any flowchart', () => {
@@ -95,6 +98,25 @@ describe('quality metrics — deterministic', () => {
     if (!p.ok || p.value.body.kind !== 'flowchart') return
     const m = measureQuality(layoutMermaid(p.value))
     expect(m.labelLegibility).toBe(1)
+  })
+
+  test('labelEdgeProximity includes label-to-label box overlap', () => {
+    const layout: RenderedLayout = {
+      version: 1,
+      kind: 'flowchart',
+      nodes: [],
+      groups: [],
+      edges: [
+        { id: 'A->B', from: 'A', to: 'B', path: [[f(0), f(0)], [f(100), f(0)]], label: { x: f(80), y: f(50), text: 'first' } },
+        { id: 'C->D', from: 'C', to: 'D', path: [[f(0), f(100)], [f(100), f(100)]], label: { x: f(80), y: f(50), text: 'second' } },
+      ],
+      bounds: { w: f(160), h: f(120) },
+    }
+    const m = measureQuality(layout)
+    expect(m.labelEdgeProximity).toBe(0)
+    const v = checkQuality(layout, { whitespaceBand: [0, 1] })
+    expect(v.ok).toBe(false)
+    expect(v.violations).toContain('edge-label clearance 0px < min 4px')
   })
 })
 

--- a/src/__tests__/agent-quality.test.ts
+++ b/src/__tests__/agent-quality.test.ts
@@ -79,6 +79,7 @@ describe('quality metrics — deterministic', () => {
     expect(m.edgeCrossings).toBe(0)
   })
 
+  // upstream: mermaid-js/mermaid#1984 — massive whitespace above/below large graphs (detection)
   test('whitespace balance is in 0..1', () => {
     const p = parseMermaid('flowchart LR\n  A --> B --> C\n  A --> C')
     expect(p.ok).toBe(true)
@@ -99,6 +100,7 @@ describe('quality metrics — deterministic', () => {
 
 describe('quality metrics — generated large flowchart corpora', () => {
   for (const entry of GENERATED_FLOWCHART_CORPUS) {
+    // upstream: mermaid-js/mermaid#1984 / #3262 — scale-collapse whitespace + over-wide aspect
     test(`${entry.nodeCount} nodes keeps aspect and whitespace measurable`, () => {
       const p = parseMermaid(generatedLayeredFlowchart(entry))
       expect(p.ok).toBe(true)

--- a/src/__tests__/gantt-layout.test.ts
+++ b/src/__tests__/gantt-layout.test.ts
@@ -51,7 +51,6 @@ describe('gantt layout — plot geometry', () => {
     }
   })
 
-  // upstream: mermaid-js/mermaid#1301 — gantt axis/bar overlap on long date ranges
   test('rows never overlap in standard mode', () => {
     const { layout } = layoutOf(BASIC)
     const sorted = [...layout.rows].sort((a, b) => a.y - b.y)
@@ -124,6 +123,30 @@ describe('gantt layout — axes and markers', () => {
     const top = layoutOf(BASIC.replace('dateFormat YYYY-MM-DD', 'dateFormat YYYY-MM-DD\n  topAxis'))
     expect(top.layout.topAxis).toBe(true)
     expect(top.layout.plot.y).toBeGreaterThan(base.layout.plot.y)
+  })
+
+  // upstream: mermaid-js/mermaid#1301 — gantt axis/bar overlap on long date ranges
+  test('long-range axis labels stay clear of task bars (#1301)', () => {
+    const { layout } = layoutOf(`gantt
+      title Multi-year roadmap
+      dateFormat YYYY-MM-DD
+      axisFormat %Y
+      topAxis
+      section Delivery
+        Discover :a, 2016-01-01, 400d
+        Build :b, after a, 520d
+        Launch :c, after b, 180d
+    `)
+    const axisLabelHalfHeight = 6
+    const topAxisLabelBottom = layout.plot.y - 10 + axisLabelHalfHeight
+    const bottomAxisLabelTop = layout.plot.y + layout.plot.h + 12 - axisLabelHalfHeight
+    const firstBarTop = Math.min(...layout.bars.map(b => b.y))
+    const lastBarBottom = Math.max(...layout.bars.map(b => b.y + b.h))
+
+    expect(layout.topAxis).toBe(true)
+    expect(layout.ticks.length).toBeGreaterThan(1)
+    expect(topAxisLabelBottom).toBeLessThanOrEqual(firstBarTop)
+    expect(bottomAxisLabelTop).toBeGreaterThanOrEqual(lastBarBottom)
   })
 
   test('ticks are bounded even with a 1minute interval over months (mermaid PR #7197)', () => {

--- a/src/__tests__/gantt-layout.test.ts
+++ b/src/__tests__/gantt-layout.test.ts
@@ -51,6 +51,7 @@ describe('gantt layout — plot geometry', () => {
     }
   })
 
+  // upstream: mermaid-js/mermaid#1301 — gantt axis/bar overlap on long date ranges
   test('rows never overlap in standard mode', () => {
     const { layout } = layoutOf(BASIC)
     const sorted = [...layout.rows].sort((a, b) => a.y - b.y)

--- a/src/__tests__/layout-quality-heuristics.test.ts
+++ b/src/__tests__/layout-quality-heuristics.test.ts
@@ -111,6 +111,7 @@ describe('programmatic bad-layout heuristics', () => {
     expect(edgeNodeCollisions(rightToLeft)).toEqual([])
   })
 
+  // upstream: mermaid-js/mermaid#815 — declared node/source order not preserved
   test('root nodes declared before top-level subgraphs stay before them', () => {
     const layout = layoutOf(`flowchart TD
       A[Root]
@@ -142,6 +143,7 @@ describe('programmatic bad-layout heuristics', () => {
     expect(checkQuality(layout, { aspectBand: [0.1, 5] }).violations).toEqual([])
   })
 
+  // upstream: mermaid-js/mermaid#6336 (state) / #6049 (flowchart) — ugly self-loops
   test('self-loops stay outside the node and preserve legibility', () => {
     const layout = layoutOf(`flowchart TB
       start([Start])

--- a/src/__tests__/sequence-layout.test.ts
+++ b/src/__tests__/sequence-layout.test.ts
@@ -808,6 +808,7 @@ describe('sequence layout – note positioning', () => {
   })
 })
 
+// upstream: mermaid-js/mermaid#1765 — control multiple/overlapping activations
 describe('sequence layout – activation/note/block properties', () => {
   it('generated activation, note, and block cases keep chrome clear of structural boxes', () => {
     fc.assert(

--- a/src/agent/quality.ts
+++ b/src/agent/quality.ts
@@ -13,8 +13,8 @@
 //   - whitespaceBalance: ratio of node-occupied area to total canvas area
 //     (0..1). Targets a band — too dense AND too sparse both lose points.
 //   - labelEdgeProximity: min pixel distance between any edge-label bbox and
-//     the nearest non-attached node bbox or other edge-label bbox. Lower means
-//     labels overlap nodes or each other.
+//     the nearest non-attached node bbox, other edge-label bbox, or non-own
+//     edge path. Lower means labels overlap nodes, edges, or each other.
 //   - aspectRatio: canvas width/height. Used as a sanity check, not a gate.
 // ============================================================================
 
@@ -39,7 +39,7 @@ export interface QualityBounds {
   minLabelLegibility?: number
   /** Whitespace fill band [min, max]. Default [0.05, 0.55]. */
   whitespaceBand?: [number, number]
-  /** Min pixels between any edge-label bbox and a non-attached node or another edge-label. Default 4. */
+  /** Min pixels between any edge-label bbox and a non-attached node, another edge-label, or another edge path. Default 4. */
   minLabelEdgeProximity?: number
   /** Aspect ratio band [min, max]. Default [0.2, 5.0]. */
   aspectBand?: [number, number]
@@ -55,6 +55,7 @@ export const DEFAULT_BOUNDS: Required<QualityBounds> = {
 
 const CHAR_PX = 7  // approx character width at 12px font
 const EDGE_LABEL_BOX_PADDING = 8
+const GEOM_EPS = 1e-9
 
 export function measureQuality(layout: RenderedLayout): QualityMetrics {
   return {
@@ -152,6 +153,7 @@ function measureWhitespaceBalance(layout: RenderedLayout): number {
 // ---- edge-label proximity ------------------------------------------------
 
 interface Rect { x: number; y: number; w: number; h: number }
+type Point = [number, number]
 
 function nodeBox(n: RenderedLayoutNode): Rect {
   return { x: n.x, y: n.y, w: n.w, h: n.h }
@@ -168,6 +170,75 @@ function rectDistance(a: Rect, b: Rect): number {
   const dx = Math.max(0, Math.max(a.x - (b.x + b.w), b.x - (a.x + a.w)))
   const dy = Math.max(0, Math.max(a.y - (b.y + b.h), b.y - (a.y + a.h)))
   return Math.hypot(dx, dy)
+}
+
+function pointInRect(p: Point, r: Rect): boolean {
+  return p[0] >= r.x && p[0] <= r.x + r.w && p[1] >= r.y && p[1] <= r.y + r.h
+}
+
+function pointToRectDistance(p: Point, r: Rect): number {
+  const dx = Math.max(0, Math.max(r.x - p[0], p[0] - (r.x + r.w)))
+  const dy = Math.max(0, Math.max(r.y - p[1], p[1] - (r.y + r.h)))
+  return Math.hypot(dx, dy)
+}
+
+function pointToSegmentDistance(p: Point, a: Point, b: Point): number {
+  const dx = b[0] - a[0]
+  const dy = b[1] - a[1]
+  const lenSq = dx * dx + dy * dy
+  if (lenSq === 0) return Math.hypot(p[0] - a[0], p[1] - a[1])
+
+  const t = Math.max(0, Math.min(1, ((p[0] - a[0]) * dx + (p[1] - a[1]) * dy) / lenSq))
+  const projX = a[0] + t * dx
+  const projY = a[1] + t * dy
+  return Math.hypot(p[0] - projX, p[1] - projY)
+}
+
+function segmentsIntersectInclusive(a: Point, b: Point, c: Point, d: Point): boolean {
+  const orient = (p: Point, q: Point, r: Point): number =>
+    (q[0] - p[0]) * (r[1] - p[1]) - (q[1] - p[1]) * (r[0] - p[0])
+  const onSegment = (p: Point, q: Point, r: Point): boolean =>
+    q[0] >= Math.min(p[0], r[0]) - GEOM_EPS && q[0] <= Math.max(p[0], r[0]) + GEOM_EPS &&
+    q[1] >= Math.min(p[1], r[1]) - GEOM_EPS && q[1] <= Math.max(p[1], r[1]) + GEOM_EPS
+
+  const o1 = orient(a, b, c)
+  const o2 = orient(a, b, d)
+  const o3 = orient(c, d, a)
+  const o4 = orient(c, d, b)
+  if (Math.abs(o1) <= GEOM_EPS && onSegment(a, c, b)) return true
+  if (Math.abs(o2) <= GEOM_EPS && onSegment(a, d, b)) return true
+  if (Math.abs(o3) <= GEOM_EPS && onSegment(c, a, d)) return true
+  if (Math.abs(o4) <= GEOM_EPS && onSegment(c, b, d)) return true
+  return (o1 > 0) !== (o2 > 0) && (o3 > 0) !== (o4 > 0)
+}
+
+function segmentIntersectsRect(a: Point, b: Point, r: Rect): boolean {
+  if (pointInRect(a, r) || pointInRect(b, r)) return true
+
+  const topLeft: Point = [r.x, r.y]
+  const topRight: Point = [r.x + r.w, r.y]
+  const bottomRight: Point = [r.x + r.w, r.y + r.h]
+  const bottomLeft: Point = [r.x, r.y + r.h]
+  return segmentsIntersectInclusive(a, b, topLeft, topRight) ||
+    segmentsIntersectInclusive(a, b, topRight, bottomRight) ||
+    segmentsIntersectInclusive(a, b, bottomRight, bottomLeft) ||
+    segmentsIntersectInclusive(a, b, bottomLeft, topLeft)
+}
+
+function rectToSegmentDistance(r: Rect, a: Point, b: Point): number {
+  if (segmentIntersectsRect(a, b, r)) return 0
+
+  const corners: Point[] = [
+    [r.x, r.y],
+    [r.x + r.w, r.y],
+    [r.x + r.w, r.y + r.h],
+    [r.x, r.y + r.h],
+  ]
+  return Math.min(
+    pointToRectDistance(a, r),
+    pointToRectDistance(b, r),
+    ...corners.map(c => pointToSegmentDistance(c, a, b)),
+  )
 }
 
 function measureLabelEdgeProximity(layout: RenderedLayout): number {
@@ -187,6 +258,15 @@ function measureLabelEdgeProximity(layout: RenderedLayout): number {
     for (let j = i + 1; j < labels.length; j++) {
       const d = rectDistance(labels[i]!.box, labels[j]!.box)
       if (d < min) min = d
+    }
+  }
+  for (const { edge, box } of labels) {
+    for (const other of layout.edges) {
+      if (other === edge) continue
+      for (let i = 0; i < other.path.length - 1; i++) {
+        const d = rectToSegmentDistance(box, other.path[i]!, other.path[i + 1]!)
+        if (d < min) min = d
+      }
     }
   }
   return min

--- a/src/agent/quality.ts
+++ b/src/agent/quality.ts
@@ -12,12 +12,15 @@
 //     node's width at a 12px font baseline.
 //   - whitespaceBalance: ratio of node-occupied area to total canvas area
 //     (0..1). Targets a band — too dense AND too sparse both lose points.
-//   - labelEdgeProximity: min pixel distance between any edge-label and the
-//     nearest non-attached node bbox. Lower means labels overlap nodes.
+//   - labelEdgeProximity: min pixel distance between any edge-label bbox and
+//     the nearest non-attached node bbox or other edge-label bbox. Lower means
+//     labels overlap nodes or each other.
 //   - aspectRatio: canvas width/height. Used as a sanity check, not a gate.
 // ============================================================================
 
 import type { RenderedLayout, RenderedLayoutNode, RenderedLayoutEdge } from './types.ts'
+import { measureMultilineText } from '../text-metrics.ts'
+import { FONT_SIZES, FONT_WEIGHTS } from '../styles.ts'
 
 export interface QualityMetrics {
   edgeCrossings: number
@@ -36,7 +39,7 @@ export interface QualityBounds {
   minLabelLegibility?: number
   /** Whitespace fill band [min, max]. Default [0.05, 0.55]. */
   whitespaceBand?: [number, number]
-  /** Min pixels between any edge-label and a non-attached node. Default 4. */
+  /** Min pixels between any edge-label bbox and a non-attached node or another edge-label. Default 4. */
   minLabelEdgeProximity?: number
   /** Aspect ratio band [min, max]. Default [0.2, 5.0]. */
   aspectBand?: [number, number]
@@ -51,6 +54,7 @@ export const DEFAULT_BOUNDS: Required<QualityBounds> = {
 }
 
 const CHAR_PX = 7  // approx character width at 12px font
+const EDGE_LABEL_BOX_PADDING = 8
 
 export function measureQuality(layout: RenderedLayout): QualityMetrics {
   return {
@@ -85,7 +89,7 @@ export function checkQuality(layout: RenderedLayout, bounds: QualityBounds = {})
     violations.push(`whitespace balance ${(m.whitespaceBalance * 100).toFixed(1)}% outside band [${b.whitespaceBand[0] * 100}–${b.whitespaceBand[1] * 100}]%`)
   }
   if (m.labelEdgeProximity < b.minLabelEdgeProximity) {
-    violations.push(`label-edge proximity ${m.labelEdgeProximity}px < min ${b.minLabelEdgeProximity}px`)
+    violations.push(`edge-label clearance ${m.labelEdgeProximity}px < min ${b.minLabelEdgeProximity}px`)
   }
   if (m.aspectRatio < b.aspectBand[0] || m.aspectRatio > b.aspectBand[1]) {
     violations.push(`aspect ratio ${m.aspectRatio.toFixed(2)} outside band [${b.aspectBand[0]}–${b.aspectBand[1]}]`)
@@ -145,17 +149,43 @@ function measureWhitespaceBalance(layout: RenderedLayout): number {
   return Math.min(1, filled / total)
 }
 
-// ---- label-edge proximity ------------------------------------------------
+// ---- edge-label proximity ------------------------------------------------
+
+interface Rect { x: number; y: number; w: number; h: number }
+
+function nodeBox(n: RenderedLayoutNode): Rect {
+  return { x: n.x, y: n.y, w: n.w, h: n.h }
+}
+
+function edgeLabelBox(label: NonNullable<RenderedLayoutEdge['label']>): Rect {
+  const metrics = measureMultilineText(label.text, FONT_SIZES.edgeLabel, FONT_WEIGHTS.edgeLabel)
+  const w = metrics.width + EDGE_LABEL_BOX_PADDING * 2
+  const h = metrics.height + EDGE_LABEL_BOX_PADDING * 2
+  return { x: label.x - w / 2, y: label.y - h / 2, w, h }
+}
+
+function rectDistance(a: Rect, b: Rect): number {
+  const dx = Math.max(0, Math.max(a.x - (b.x + b.w), b.x - (a.x + a.w)))
+  const dy = Math.max(0, Math.max(a.y - (b.y + b.h), b.y - (a.y + a.h)))
+  return Math.hypot(dx, dy)
+}
 
 function measureLabelEdgeProximity(layout: RenderedLayout): number {
   let min = Infinity
-  for (const e of layout.edges) {
-    if (!e.label) continue
+  const labels = layout.edges
+    .filter((e): e is RenderedLayoutEdge & { label: NonNullable<RenderedLayoutEdge['label']> } => e.label !== undefined)
+    .map(e => ({ edge: e, box: edgeLabelBox(e.label) }))
+
+  for (const { edge, box } of labels) {
     for (const n of layout.nodes) {
-      if (n.id === e.from || n.id === e.to) continue
-      const dx = Math.max(0, Math.max(n.x - e.label.x, e.label.x - (n.x + n.w)))
-      const dy = Math.max(0, Math.max(n.y - e.label.y, e.label.y - (n.y + n.h)))
-      const d = Math.sqrt(dx * dx + dy * dy)
+      if (n.id === edge.from || n.id === edge.to) continue
+      const d = rectDistance(box, nodeBox(n))
+      if (d < min) min = d
+    }
+  }
+  for (let i = 0; i < labels.length; i++) {
+    for (let j = i + 1; j < labels.length; j++) {
+      const d = rectDistance(labels[i]!.box, labels[j]!.box)
       if (d < min) min = d
     }
   }


### PR DESCRIPTION
## What

Closes the traceability gap found by the June 2026 coverage audit for the layout-aesthetic complaints in `docs/mermaid-layout-complaints.md`, and incorporates the follow-up fixes from the deep audit:

- issue-keyed regression fixtures for supported complaints;
- per-fixture soft quality checks where the corpus baseline was too aggregate;
- shared `labelEdgeProximity` coverage for edge-label clearance from non-attached nodes, other edge labels, and other edge paths;
- label-vs-label separation checks for parallel labeled edges in the issue fixtures;
- a real long-range Gantt axis/bar clearance assertion for `#1301`;
- docs that distinguish direct coverage, tagged existing assertions, deferred families, and policy out-of-scope cases.

## Why

The prior branch made the issues greppable, but the deep audit found several honesty/coverage gaps:

1. Corpus-level crossing/label metrics do not prove an individual fixture is clean.
2. The shared `labelEdgeProximity` metric only measured edge-label to node clearance, so label-to-label overlap and label-on-unrelated-edge overlap were invisible outside fixture-local assertions.
3. The `#5060` fixture asserted no hard defects but not distinct parallel paths or label separation.
4. The `#1301` tag was attached to a generic Gantt row-overlap test instead of long-range axis/bar overlap.
5. The docs still contained stale "fixture idea" language and overstated coverage.

## How

- `src/agent/quality.ts`
  - Extends `labelEdgeProximity` from a point-to-node check into edge-label box clearance against non-attached node boxes, other edge-label boxes, and non-own edge paths.
  - Keeps the label's own edge path excluded because labels are expected to sit on the edge they describe.
  - Reports violations as edge-label clearance failures rather than the narrower label-edge wording.
- `src/__tests__/agent-quality.test.ts`
  - Adds focused regressions proving overlapping edge-label boxes and labels on unrelated edge paths fail the shared quality gate.
  - Pins that a label sitting on its own edge path does not count as a defect.
- `src/__tests__/aesthetic-issue-regressions.test.ts`
  - Parses rendered SVG label groups structurally instead of depending on attribute order.
  - Asserts fixture-level `edgeCrossings` for the issue repros.
  - Asserts parallel `#5060` edge paths are distinct.
  - Asserts edge-label boxes are separated for `#5060` and `#2131`.
  - Adds a flowchart self-loop check alongside the state self-loop check for `#6049`.
- `src/__tests__/gantt-layout.test.ts`
  - Moves `#1301` coverage to a targeted multi-year Gantt fixture where top/bottom axis labels must stay clear of task bars.
- `docs/issue-derived-test-cases.md`, `docs/quality.md`, and `docs/mermaid-layout-complaints.md`
  - Replaces stale fixture ideas with fixture status for covered cases.
  - Rewords the coverage audit as an explicit ledger rather than a blanket "closed" claim.
  - Documents that `labelEdgeProximity` now covers edge-label clearance from non-attached nodes, other edge labels, and other edge paths.
- `docs/layout-characterization/visual-quality.md`
  - Regenerates the characterization table after the shared metric changed.

## Testing

- [x] `bun test src/__tests__/aesthetic-issue-regressions.test.ts src/__tests__/gantt-layout.test.ts src/__tests__/agent-quality.test.ts src/__tests__/layout-quality-heuristics.test.ts --timeout 600000`
- [x] `bun test src/__tests__/agent-quality.test.ts src/__tests__/aesthetic-issue-regressions.test.ts src/__tests__/layout-quality-heuristics.test.ts --timeout 600000`
- [x] `bun test src/__tests__/agent-quality.test.ts src/__tests__/aesthetic-issue-regressions.test.ts src/__tests__/characterization-generated-artifacts.test.ts src/__tests__/layout-quality-heuristics.test.ts --timeout 600000`
- [x] `bunx tsc --noEmit`
- [x] `bun run lint`
- [x] `bun run test` → `3792 pass`, `7 skip`, `0 fail`
- [x] `git diff --check`

## Risk

Low to moderate. Runtime layout/rendering behavior is unchanged, but `labelEdgeProximity` is stricter and can now fail diagrams whose edge-label boxes overlap each other, non-attached nodes, or unrelated edge paths. That is intentional for this audit follow-up.