### PR TITLE
Route mutation testing: survivor harvests + shard the nightly lane (keep bun:test)

### DIFF
--- a/.github/workflows/nightly-route-mutation.yml
+++ b/.github/workflows/nightly-route-mutation.yml
@@ -19,8 +19,25 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: routes
-            command: bun run mutation-test:routes
+          # The broad route-contracts lane (~3.5k mutants) runs on the generic
+          # command runner, which reruns the whole bun test file per mutant — too
+          # slow to finish in one job. Shard it by line range — ranges are
+          # deliberately uneven, balanced by measured mutant density (~870 each,
+          # not by line count) so the longest shard is ~¼ of the total wall-clock.
+          # They run in parallel; each completes inside the cap. Reassemble survivors
+          # by downloading every route-mutation-routes-shard-* artifact and
+          # running scripts/mutation-survivors.ts. See docs/mutation-testing.md.
+          - name: routes-shard-1
+            command: npx stryker run stryker.routes.config.json --mutate 'src/route-contracts.ts:1-606'
+            timeout: 90
+          - name: routes-shard-2
+            command: npx stryker run stryker.routes.config.json --mutate 'src/route-contracts.ts:607-1160'
+            timeout: 90
+          - name: routes-shard-3
+            command: npx stryker run stryker.routes.config.json --mutate 'src/route-contracts.ts:1161-1629'
+            timeout: 90
+          - name: routes-shard-4
+            command: npx stryker run stryker.routes.config.json --mutate 'src/route-contracts.ts:1630-2105'
             timeout: 90
           - name: route-certificates
             command: bun run mutation-test:routes:certs

--- a/docs/mutation-testing.md
+++ b/docs/mutation-testing.md
@@ -45,6 +45,67 @@ run to date has been cancelled at the 90-minute cap before uploading anything
 current scores come from local runs. Run the narrow lane locally
 when you touch ASCII/route core logic and want immediate proof the tests bite.
 
+To turn a JSON report into a triage list — mutation score, survivors grouped by
+mutator, line hotspots, and the full `file:line:col — mutator — replacement`
+list — run `bun run scripts/mutation-survivors.ts` (reads
+`reports/mutation/*-mutation.json`; pass `--out triage.md` to also write a file).
+The June 2026 nightly scored routes ~54.5% (1904 killed+timeout of 3492 mutants,
+command runner, measured across the four nightly shards — up from the 52.15%
+baseline after the harvest passes; the command runner runs every test per mutant so
+it has no "no coverage" class and scores a few points above the vitest-runner's
+50.79%, which counts 383 no-coverage mutants as not-killed). Its `auditRouteContracts`
+region was lifted 75.1% → 83.43% on a scoped re-run, the ninth pass took 7 more in
+`directLaneBlockers`/`findLabelSlot`, and the tenth pinned `tryRepairContainerEdge`'s
+contract guards. Route-certificates scored
+54.04% (74 survivors, up from 27.95%/116 after two harvest batches — vertex-hook
+entry sides and reciprocal/off-port enrollment; most of the residual are
+equivalent mutants, classified below), and subgraph-routing 86.79% (7 survivors).
+
+## Runner & tooling
+
+The route lanes (`stryker.routes.config.json`, `stryker.route-certificates.config.json`) use
+Stryker's generic **command runner** — it reruns the whole `bun test` file per mutant. The full
+`route-contracts.ts` lane is ~3.5k mutants, too slow for a single job (≈3.5 h; it timed out), so
+`.github/workflows/nightly-route-mutation.yml` **shards it by line range**: four parallel jobs,
+each mutating a slice of the file, so every shard finishes inside its cap. To triage a whole run,
+download the `route-mutation-routes-shard-*` artifacts and run `scripts/mutation-survivors.ts` over
+each. `src/__tests__/route-contracts.test.ts` pins the fast-check seed (scoped via
+`before`/`afterAll`) so the lane is reproducible without making the rest of the suite deterministic.
+
+**Why command-runner + sharding (not the vitest-runner).** The official
+`@stryker-mutator/vitest-runner` with `coverageAnalysis: "perTest"` was prototyped and is genuinely
+faster — on one runner it finished the full lane in ~47 min (≈4.4×), running only the tests that
+cover each mutant. The cost is structural: it requires moving the suite off `bun:test` to Vitest and
+carrying a **second test runner** permanently, plus line-range configs that drift when the file
+moves. Sharding the command runner keeps everything on one runner (`bun test`) and completes just as
+reliably by running the slices in parallel — trading cheap nightly runner-minutes for that
+simplicity. The community `@hughescr/stryker-bun-runner` was also rejected: it classified ~86% of
+mutants as **static** and ran them *sequentially*, ~2× *slower* on the full lane.
+
+For harvest iteration, scope the lane with `npx stryker run stryker.routes.config.json --mutate
+'src/route-contracts.ts:L-R'` — a narrow range finishes in a couple of minutes.
+
+Two helper scripts (both read `reports/mutation/*-mutation.json`):
+- `bun run scripts/mutation-survivors.ts` — triage a report (score, survivors by mutator, line
+  hotspots, full survivor list).
+- `bun run scripts/mutation-kill-prompts.ts` — turn survivors into per-mutant LLM "kill
+  prompts" (mutation diff + source-context window + covering tests + a sabotage-verify
+  instruction), with an equivalence-prone prefilter. Semi-automates the harvest loop; drive it
+  from an agent session, then sabotage-verify each generated test before keeping it.
+
+**Suppressing equivalents — prefer prose classification (below) over `// Stryker disable`
+comments.** Disable-comments are line+mutator granularity, but in these survivors the killed
+and equivalent mutations of a mutator routinely share a line (e.g. line 1694 carries 4 killed
+*and* 9 survived `LogicalOperator` mutants), so a disable comment would also drop the real
+kills from the score. Only suppress a line where *every* mutation of that mutator is provably
+equivalent.
+
+**Boundary survivors** (the `< tol` / `±EPS` / `±0.5` family) are best killed as a *class* with
+property-based + metamorphic tests (`fast-check`) rather than pixel-exact fixtures — see the
+"property-based & metamorphic coverage" block in `route-contracts.test.ts`, which probes
+offsets arbitrarily close to each tolerance with `fc.double({min,max})` and asserts the audit
+is translation-invariant.
+
 ## Policy
 
 A SURVIVED mutant is a test gap until shown otherwise. Either kill it with a
@@ -109,8 +170,8 @@ construction — so they were reverted. Only the width-sort tie-break (where
 ties are real) remains. Mutation testing earning its keep: it falsified an
 audit assumption the test suite couldn't.
 
-**Killed by `route-contracts.test.ts` survivor harvests** (170 mutants
-across five passes): RL/BT axis orientation (reciprocal-pair regressions in
+**Killed by `route-contracts.test.ts` survivor harvests** (≈260 mutants
+across ten passes): RL/BT axis orientation (reciprocal-pair regressions in
 both reversed directions), every `directLaneBlockers` blocker kind at its
 exact ±4px clearance boundary on both axes (non-square obstacles so a
 swapped width/height changes the verdict), own-label lane capacity in
@@ -120,7 +181,47 @@ stagger and pill-boundary arithmetic, the primary-over-feedback exemption
 asymmetry, the feedback path of `findRouteHitches`, shared-trunk detection
 on both axes at its collinearity/pill-extent boundaries, the ±2px line
 between the stale and shape-misanchor tripwires, container perimeter
-tolerance, and the container repair's horizontal-gap axis selection.
+tolerance, and the container repair's horizontal-gap axis selection. The
+sixth pass (vertex-hook entry side) pinned `tryVertexHook`'s cross-side port
+selection on all four entries — the existing LR/N case plus the LR/S mirror
+(target above the lane) and the TD/W, TD/E rotations — and its two early
+returns (a stub shorter than `HOOK_STUB_MIN`, and a sibling already holding
+the facing entry port so the fan-in merge outranks the hook), lifting the
+`mutation-test:routes:certs` lane from 27.95% to 52.17% (116 → 77 survivors).
+The seventh pass (reciprocal / off-port enrollment) isolated the "already
+straight" branch with hand-built on-port geometry: a reciprocal pair that must
+still split to the symmetric lane (center ± 6), and a straight edge floating off
+its ports that must snap back onto the port lane — taking the lane to 54.04%
+(74 survivors). The eighth pass (route-audit boundary harvest) pinned
+`auditRouteContracts`' exact tolerances — `onRectPerimeter`'s ±1px on every
+border (left/right via LR, top/bottom via TD with an orthogonal approach so no
+spurious `ROUTE_UNEXPLAINED_BEND` fires), the inflated ±2px attached-vs-stale
+split, `ROUTE_UNEXPLAINED_BEND` on a feedback edge (not just primary-forward),
+and the non-incident `ROUTE_STALE_AFTER_NODE_MOVE` overlap with its ±0.5 inset
+and segment-direction min/max — killing 29 of the audit region's survivors
+(lines 1915–2062: 87 → 58, 75.1% → 83.43% on the scoped lane). The residual
+there is the `onRectPerimeter` perpendicular-range guards (always also caught by
+the facing border, so equivalent) and the `ROUTE_LABEL_ON_SHARED_TRUNK`
+collinearity/overlap math (an open gap, partially covered by the boundary test
+above). The ninth pass (label-rect main extent + slot-overlap conjunction) closed
+the two horizontal `directLaneBlockers` label gaps with a wide, short obstacle
+pill placed just past the lane's left end — so the main extent rides on the
+pill's width plus the full 2×CLEARANCE, taking the width/height swap, the zeroed
+extent, and both clearance-arithmetic mutants — and pinned `findLabelSlot`'s
+`rectsOverlap` on its left and both vertical sides (the `+PAD` term on three of
+the four clauses) with pad-band fixtures on a long lane. Scoped lanes 839–842 /
+900–902 reached 89.66% (7 survivors killed); the 6 that remain are the
+strict-vs-non-strict edge comparisons, accepted as equivalent (open-gaps note).
+The tenth pass exported `tryRepairContainerEdge` and unit-tested its contract
+directly — the reversed target-above-source repair, the not-a-rect-endpoint
+decline, and the already-straight no-op — killing the guard/setup survivors
+(function body, not-a-rect guard, already-straight return) the function had no
+direct test for and that the redundant pipeline repair paths had masked. Its
+`gaps` array (the four-direction lane *selection*) stays open: a single-direction
+fixture can't discriminate it (a wrong-but-still-positive gap picks the same
+axis), so it needs two competing positive gaps — and the container integration
+fixtures that used to kill it no longer cover it after main's #32 container-layout
+change.
 
 **Accepted — equivalent on the real input domain** (route-contracts): the
 collinearity cross-product variants in `simplifyPolyline` behave identically
@@ -128,7 +229,15 @@ for the orthogonal polylines ELK produces (several algebraic rearrangements
 preserve the zero/non-zero verdict for axis-aligned triples), and the
 `isMonotoneStaircase` diagonal/backward guards are defensive against passes
 that do not currently exist — real extracted routes are orthogonal and the
-backward case is already excluded by feedback classification upstream.
+backward case is already excluded by feedback classification upstream. The
+residual reciprocal-enrollment survivors (lines 1693–1704) are broadening
+mutations — `reciprocal → true`, the over-matching `.some` predicate, the
+always-true OR-chain, the always-push retry — and are equivalent: re-enrolling
+an edge that is already straight and already on its port re-lanes it to that
+same port (candidate index 0, never added to the retry pool), so widening the
+trigger adds only idempotent no-ops. Only mutations that can turn enrollment
+OFF when it is needed are killable, and the two new enrollment fixtures take
+those.
 
 **Accepted — performance guards** (route-contracts): the `seen`-set and
 stack mechanics inside `classifyRoutes`' DFS change traversal cost, not
@@ -140,18 +249,23 @@ the duplicate-edge regression pins one unblocking round, and constructing
 a graph that needs three chained rounds would be a synthetic-input test.
 
 **Open test gaps** (highest-value first):
-- `directLaneBlockers` label-rect axis ternaries retain a few survivors on
-  rect width/height swaps for near-square pills; a multi-line (taller than
-  wide) label obstacle fixture would discriminate them.
-- `findLabelSlot`'s rect-overlap conjunction retains sign-variant survivors
-  for rects that only graze on one axis; corner-touching fixtures would
-  pin them.
+- `directLaneBlockers` label-rect main extent and `findLabelSlot`'s
+  `rectsOverlap` conjunction are pinned as of the ninth pass. The only residual
+  mutants are the strict-vs-non-strict boundary comparisons (`<`↔`<=`, `>`↔`>=`)
+  at the clearance/pad edges; they differ only when a coordinate lands exactly on
+  an edge — a measure-zero, ULP-fragile case on ELK's float geometry — so they
+  are accepted as equivalent rather than killed with synthetic exact-boundary
+  inputs.
 - The audit's pill-hit prefilter (`hitsPill`) retains inclusive-vs-strict
   comparison survivors for segments that exactly graze the pill border;
   they only widen the prefilter the collinearity check still gates.
-- The container repair's reversed-order gaps (target above / left of
-  source) lack fixtures; the gap arithmetic is symmetric with the two
-  covered directions.
+- `tryRepairContainerEdge` is now unit-tested directly (tenth pass): the reversed
+  target-above-source repair, the not-a-rect decline, and the already-straight
+  no-op, killing the guard/setup survivors the function lacked direct coverage
+  for. Residual: the four-direction `gaps` *selection* (needs two competing
+  positive gaps to discriminate — the container integration fixtures stopped
+  covering it after main's #32 layout change) and the group/diamond-endpoint
+  rect synthesis.
 - `grid.ts` `ensureSubgraphSpacing` (~48 survivors): the overlap/min-spacing
   resolution between root subgraphs is never triggered by the corpus —
   placement upstream appears to avoid overlaps already. Needs either a

--- a/scripts/mutation-kill-prompts.ts
+++ b/scripts/mutation-kill-prompts.ts
@@ -1,0 +1,128 @@
+#!/usr/bin/env bun
+/**
+ * Turn surviving Stryker mutants into ready-to-use "kill prompts" for an LLM.
+ *
+ * For each SURVIVED mutant this emits a self-contained block — the mutation
+ * diff, a window of surrounding source, the tests that already cover the line
+ * (from perTest reports), and an instruction to write ONE minimal killing test
+ * and sabotage-verify it (revert the prod line, confirm the test goes red).
+ * This is the semi-automation of the manual harvest loop (cf. Meta's ACH:
+ * mutation-guided LLM test generation): generate prompts -> LLM drafts a test ->
+ * run a scoped lane / sabotage-verify -> keep what bites.
+ *
+ *   bun run scripts/mutation-kill-prompts.ts reports/mutation/routes-mutation.json
+ *   bun run scripts/mutation-kill-prompts.ts --range 1915-2062 --limit 20 --out prompts.md
+ *   bun run scripts/mutation-kill-prompts.ts --skip-suspected-equivalent
+ *
+ * Flags:
+ *   --out <file>                 also write the prompt pack to a file
+ *   --range <lo-hi>              only mutants whose start line is in [lo,hi]
+ *   --mutator <Name>             only this mutator (repeatable, comma-separated)
+ *   --limit <n>                  cap the number of prompts
+ *   --context <n>                source lines of context each side (default 8)
+ *   --skip-suspected-equivalent  drop broadening mutants (see EQUIVALENCE_PRONE)
+ */
+import { existsSync, readFileSync, readdirSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+interface Mutant {
+  id: string
+  mutatorName: string
+  status: string
+  replacement?: string
+  coveredBy?: string[]
+  location: { start: { line: number; column: number }; end: { line: number; column: number } }
+}
+interface Report {
+  files: Record<string, { source?: string; mutants: Mutant[] }>
+  testFiles?: Record<string, { tests: Array<{ id: string; name: string }> }>
+}
+
+// Mutators whose mutations frequently only *broaden* an already-true-in-domain
+// condition, which is often equivalent (re-enrolling/over-matching is a no-op).
+// Worth a 30-second equivalence check before writing a test.
+const EQUIVALENCE_PRONE = new Set(['BooleanLiteral', 'LogicalOperator', 'ConditionalExpression'])
+
+const args = process.argv.slice(2)
+const opt = { out: '', range: '', mutators: new Set<string>(), limit: Infinity, context: 8, skipEquiv: false }
+const paths: string[] = []
+for (let i = 0; i < args.length; i++) {
+  const a = args[i]!
+  if (a === '--out') opt.out = args[++i]!
+  else if (a === '--range') opt.range = args[++i]!
+  else if (a === '--mutator') args[++i]!.split(',').forEach(m => opt.mutators.add(m))
+  else if (a === '--limit') opt.limit = Number(args[++i])
+  else if (a === '--context') opt.context = Number(args[++i])
+  else if (a === '--skip-suspected-equivalent') opt.skipEquiv = true
+  else paths.push(a)
+}
+if (paths.length === 0) {
+  const dir = 'reports/mutation'
+  if (existsSync(dir)) for (const f of readdirSync(dir).sort()) if (f.endsWith('-mutation.json')) paths.push(join(dir, f))
+}
+if (paths.length === 0) { console.error('No report given and reports/mutation/*-mutation.json not found.'); process.exit(1) }
+
+let [lo, hi] = [0, Infinity]
+if (opt.range) { const m = opt.range.split('-'); lo = Number(m[0]); hi = Number(m[1] ?? m[0]) }
+
+const out: string[] = []
+const emit = (s = '') => out.push(s)
+emit('# Mutation kill-prompts')
+emit('')
+emit(`Generated ${new Date().toISOString()}. One block per surviving mutant. Paste a block into an`)
+emit('LLM session, let it draft the test, then **sabotage-verify**: revert the production line and')
+emit('confirm the new test fails, then restore. Re-run a scoped lane to confirm the kill.')
+emit('')
+
+let count = 0
+for (const path of paths) {
+  if (!existsSync(path)) continue
+  const report = JSON.parse(readFileSync(path, 'utf8')) as Report
+  const testNames = new Map<string, string>()
+  for (const tf of Object.values(report.testFiles ?? {})) for (const t of tf.tests) testNames.set(t.id, t.name)
+
+  for (const [file, info] of Object.entries(report.files)) {
+    const srcLines = (info.source ?? (existsSync(file) ? readFileSync(file, 'utf8') : '')).split('\n')
+    const survivors = info.mutants
+      .filter(m => m.status === 'Survived')
+      .filter(m => m.location.start.line >= lo && m.location.start.line <= hi)
+      .filter(m => opt.mutators.size === 0 || opt.mutators.has(m.mutatorName))
+      .filter(m => !(opt.skipEquiv && EQUIVALENCE_PRONE.has(m.mutatorName)))
+      .sort((a, b) => a.location.start.line - b.location.start.line || a.location.start.column - b.location.start.column)
+
+    for (const m of survivors) {
+      if (count >= opt.limit) break
+      count++
+      const ln = m.location.start.line
+      const from = Math.max(1, ln - opt.context)
+      const to = Math.min(srcLines.length, ln + opt.context)
+      const window = srcLines.slice(from - 1, to)
+        .map((line, i) => `${String(from + i).padStart(4)}${from + i === ln ? ' >' : '  '} ${line}`)
+        .join('\n')
+      const covering = (m.coveredBy ?? []).map(id => testNames.get(id) ?? id)
+      const suspect = EQUIVALENCE_PRONE.has(m.mutatorName)
+
+      emit(`## ${file}:${ln}:${m.location.start.column} — ${m.mutatorName}${suspect ? '  ⚠ check equivalence first' : ''}`)
+      emit('')
+      emit(`- Mutation: replace the code at this location with: \`${(m.replacement ?? '').replace(/\s+/g, ' ').slice(0, 120)}\``)
+      emit(`- Covering tests (${covering.length}): ${covering.length ? covering.slice(0, 8).map(t => `\`${t}\``).join(', ') : '(none reported — report lacks perTest data)'}`)
+      if (suspect) emit(`- ⚠ This mutator often only *broadens* a condition that is already true in its reachable domain. First decide if it is **equivalent** (then suppress with \`// Stryker disable next-line ${m.mutatorName}: <reason>\`); only write a test if a real input distinguishes it.`)
+      emit('')
+      emit('```ts')
+      emit(window)
+      emit('```')
+      emit('')
+      emit('> Task: write ONE minimal test (hand-built geometry via `applyRouteContracts`/`layoutGraphSync`,')
+      emit('> matching the existing style) whose assertion changes value under the mutation above. Then')
+      emit('> sabotage-verify: apply the mutation to the prod line, confirm the test fails, revert.')
+      emit('')
+    }
+  }
+}
+
+emit(`---`)
+emit(`${count} prompt(s) emitted.${opt.skipEquiv ? ' (broadening/equivalence-prone mutators skipped)' : ''}`)
+
+const text = out.join('\n')
+if (opt.out) { writeFileSync(opt.out, text); console.error(`wrote ${opt.out} (${count} prompts)`) }
+console.log(text)

--- a/scripts/mutation-survivors.ts
+++ b/scripts/mutation-survivors.ts
@@ -1,0 +1,143 @@
+#!/usr/bin/env bun
+/**
+ * Summarize SURVIVED mutants from Stryker JSON reports into a triage list.
+ *
+ * A survivor is a test gap until shown otherwise (docs/mutation-testing.md), so
+ * the nightly route lanes are only useful if their survivors are legible. This
+ * reads the Stryker JSON reports and prints, per lane: the mutation score,
+ * status counts, survivors grouped by mutator, the worst line hotspots, and the
+ * full survivor list (line:col — mutator — replacement).
+ *
+ *   bun run scripts/mutation-survivors.ts                    # all reports/mutation/*-mutation.json
+ *   bun run scripts/mutation-survivors.ts --out triage.md    # also write to a file
+ *   bun run scripts/mutation-survivors.ts reports/mutation/routes-mutation.json
+ */
+import { existsSync, readdirSync, readFileSync, writeFileSync } from 'node:fs'
+import { basename, join } from 'node:path'
+
+interface Mutant {
+  mutatorName: string
+  status: string
+  replacement?: string
+  location: { start: { line: number; column: number }; end: { line: number; column: number } }
+}
+interface Report { files: Record<string, { mutants: Mutant[] }> }
+
+const REPORT_DIR = 'reports/mutation'
+const HOTSPOT_LIMIT = 30
+
+const args = process.argv.slice(2)
+let outFile: string | undefined
+const paths: string[] = []
+for (let i = 0; i < args.length; i++) {
+  if (args[i] === '--out') { outFile = args[++i]; continue }
+  paths.push(args[i]!)
+}
+if (paths.length === 0) {
+  if (!existsSync(REPORT_DIR)) {
+    console.error(`No reports given and ${REPORT_DIR}/ does not exist. Run a mutation lane first.`)
+    process.exit(1)
+  }
+  for (const f of readdirSync(REPORT_DIR).sort()) {
+    if (f.endsWith('-mutation.json')) paths.push(join(REPORT_DIR, f))
+  }
+}
+
+// Stryker's "total" mutation score: detected / valid, where detected counts
+// kills and timeouts and valid excludes ignored / compile / runtime errors.
+const DETECTED = new Set(['Killed', 'Timeout'])
+const VALID = new Set(['Killed', 'Timeout', 'Survived', 'NoCoverage'])
+
+function sanitize(s: string | undefined): string {
+  return (s ?? '').replace(/\s+/g, ' ').trim().slice(0, 80)
+}
+
+function laneName(path: string): string {
+  return basename(path).replace(/-mutation\.json$/, '').replace(/\.json$/, '')
+}
+
+const out: string[] = []
+const emit = (line = '') => out.push(line)
+
+emit(`# Mutation survivor triage`)
+emit('')
+emit(`Generated ${new Date().toISOString()} from ${paths.length} report(s).`)
+emit('')
+
+for (const path of paths) {
+  if (!existsSync(path)) { console.error(`skip (missing): ${path}`); continue }
+  const report = JSON.parse(readFileSync(path, 'utf8')) as Report
+  const counts: Record<string, number> = {}
+  const survivors: { file: string; line: number; col: number; mutator: string; replacement: string }[] = []
+  for (const [file, { mutants }] of Object.entries(report.files)) {
+    for (const m of mutants) {
+      counts[m.status] = (counts[m.status] ?? 0) + 1
+      if (m.status === 'Survived') {
+        survivors.push({
+          file,
+          line: m.location.start.line,
+          col: m.location.start.column,
+          mutator: m.mutatorName,
+          replacement: sanitize(m.replacement),
+        })
+      }
+    }
+  }
+  const detected = Object.entries(counts).filter(([s]) => DETECTED.has(s)).reduce((a, [, n]) => a + n, 0)
+  const valid = Object.entries(counts).filter(([s]) => VALID.has(s)).reduce((a, [, n]) => a + n, 0)
+  const score = valid ? (detected / valid * 100) : 0
+
+  emit(`## ${laneName(path)} — ${score.toFixed(2)}%`)
+  emit('')
+  emit(`\`${path}\``)
+  emit('')
+  const order = ['Killed', 'Timeout', 'Survived', 'NoCoverage', 'CompileError', 'RuntimeError', 'Ignored']
+  const shown = order.filter(s => counts[s]).map(s => `${s} ${counts[s]}`)
+  for (const s of Object.keys(counts)) if (!order.includes(s)) shown.push(`${s} ${counts[s]}`)
+  emit(`Status: ${shown.join(' · ')}`)
+  emit('')
+
+  if (survivors.length === 0) { emit('No survivors. 🎉'); emit(''); continue }
+
+  // Survivors by mutator.
+  const byMutator: Record<string, number> = {}
+  for (const s of survivors) byMutator[s.mutator] = (byMutator[s.mutator] ?? 0) + 1
+  emit(`### Survivors by mutator (${survivors.length} total)`)
+  emit('')
+  emit('| Mutator | Count |')
+  emit('| --- | ---: |')
+  for (const [mut, n] of Object.entries(byMutator).sort((a, b) => b[1] - a[1])) emit(`| ${mut} | ${n} |`)
+  emit('')
+
+  // Line hotspots.
+  const byLine = new Map<string, { count: number; mutators: Set<string> }>()
+  for (const s of survivors) {
+    const key = `${s.file}:${s.line}`
+    const e = byLine.get(key) ?? { count: 0, mutators: new Set<string>() }
+    e.count++; e.mutators.add(s.mutator); byLine.set(key, e)
+  }
+  const hotspots = [...byLine.entries()].sort((a, b) => b[1].count - a[1].count)
+  emit(`### Line hotspots (top ${Math.min(HOTSPOT_LIMIT, hotspots.length)} of ${hotspots.length})`)
+  emit('')
+  emit('| Location | Survivors | Mutators |')
+  emit('| --- | ---: | --- |')
+  for (const [loc, e] of hotspots.slice(0, HOTSPOT_LIMIT)) {
+    emit(`| ${loc} | ${e.count} | ${[...e.mutators].join(', ')} |`)
+  }
+  emit('')
+
+  // Full survivor list.
+  survivors.sort((a, b) => a.file.localeCompare(b.file) || a.line - b.line || a.col - b.col)
+  emit(`<details><summary>Full survivor list (${survivors.length})</summary>`)
+  emit('')
+  emit('```')
+  for (const s of survivors) emit(`${s.file}:${s.line}:${s.col}  ${s.mutator}  →  ${s.replacement}`)
+  emit('```')
+  emit('')
+  emit('</details>')
+  emit('')
+}
+
+const text = out.join('\n')
+if (outFile) { writeFileSync(outFile, text); console.error(`wrote ${outFile}`) }
+console.log(text)

--- a/src/__tests__/route-contracts.test.ts
+++ b/src/__tests__/route-contracts.test.ts
@@ -2,12 +2,20 @@ import { afterAll, beforeAll, describe, expect, it } from 'bun:test'
 import fc from 'fast-check'
 import { buildRoutePortHints, layoutGraphSync } from '../layout-engine.ts'
 import { parseMermaid } from '../parser.ts'
-import { applyRouteContracts, auditRouteContracts, classifyRoutes, diamondFacetPorts, directLaneBlockers, findLabelSlot, findRouteHitches, shapePorts, simplifyPolyline } from '../route-contracts.ts'
+import { applyRouteContracts, auditRouteContracts, classifyRoutes, diamondFacetPorts, directLaneBlockers, findLabelSlot, findRouteHitches, shapePorts, simplifyPolyline, tryRepairContainerEdge } from '../route-contracts.ts'
 import { onShapeOutline } from '../layout-rubric.ts'
 import { measureMultilineText } from '../text-metrics.ts'
 import { layoutMermaid, parseMermaid as agentParse, verifyMermaid } from '../agent/index.ts'
 import type { AnyPort, Point, PositionedEdge, PositionedGraph, PositionedGroup, PositionedNode } from '../types.ts'
 import { EDGE_FORMS, renderEdgeLine } from './helpers/edge-vocabulary.ts'
+
+// Pin fast-check for THIS file only (restored afterwards) so the command-runner
+// mutation lane is reproducible — a mutant must be killed/survive deterministically
+// rather than depend on the run's RNG seed. Scoped via before/afterAll so the
+// suite's other ~29 fast-check files keep their default (random) seeds.
+const priorFastCheck = fc.readConfigureGlobal()
+beforeAll(() => fc.configureGlobal({ ...priorFastCheck, seed: 20260620 }))
+afterAll(() => fc.configureGlobal(priorFastCheck))
 
 /** The MFA/login regression from issue #25 — every dogleg here had a clear direct lane. */
 const MFA_SOURCE = `flowchart LR
@@ -628,6 +636,26 @@ describe('directLaneBlockers (unit)', () => {
     expect(directLaneBlockers(labeled, 50, 0, pillW + 8 + 1, ctx())).toEqual([])
   })
 
+  it('a non-square label pill blocks via its true main extent: width (not height), with the full 2x clearance', () => {
+    // The label-rect main extent uses rect.w on a horizontal lane plus
+    // 2*CLEARANCE (lines ~804-805). A near-square 'No' pill cannot discriminate
+    // width from height, so the w/h swap, the zeroed extent, and the clearance
+    // term all survive there. A wide, short pill placed just past the lane's
+    // LEFT end reaches back into [0,100] ONLY through rect.w + the full
+    // clearance: swapping in the (small) height, zeroing the extent, negating
+    // 2*CLEARANCE, or turning it into a division all retract the pill clear.
+    const m2 = measureMultilineText('wide wide wide wide', 12, 400)
+    const w2 = m2.width + 16
+    const wideLabel = (lx: number) =>
+      edge('P', 'Q', [{ x: 500, y: 500 }, { x: 520, y: 500 }], { label: 'wide wide wide wide', labelPosition: { x: lx, y: 50 } })
+    // rMainHi(correct) = rect.x + rect.w + CLEARANCE; this lx puts it a hair past 0.
+    const lx = -w2 / 2 - 2
+    expect(directLaneBlockers(probe, 50, 0, 100, ctx({ edges: [wideLabel(lx)] })))
+      .toEqual([{ kind: 'label', id: 'P->Q' }])
+    // One pill-width further left and even the true extent falls short of the lane.
+    expect(directLaneBlockers(probe, 50, 0, 100, ctx({ edges: [wideLabel(lx - w2)] }))).toEqual([])
+  })
+
   describe('vertical axis (TD): same proofs with main/cross swapped', () => {
     const vAxis = { main: 'y', cross: 'x', sign: 1 } as const
     const vProbe = edge('A', 'B', [{ x: 50, y: 0 }, { x: 50, y: 100 }])
@@ -998,6 +1026,30 @@ describe('findLabelSlot (unit)', () => {
     const a = { id: 'A', label: 'A', shape: 'rectangle' as const, x: 150, y: 20, width: 100, height: 60 }
     expect(findLabelSlot(mkEdge({ label: 'No' }), start, end, ctx({ nodes: [a] }))).toEqual({ x: 200, y: 50 })
   })
+
+  it('the slot-overlap test is pinned on all four sides, not just +x: a pill grazing the 2px pad band on the left or on either vertical side staggers the label', () => {
+    // rectsOverlap (line ~867) is a four-clause conjunction; the existing
+    // boundary test only exercises the +x clause. A blocker pill nudged one
+    // pill-extent toward the midpoint slot on each remaining side overlaps it by
+    // exactly the +PAD term, forcing a stagger — mutating that +PAD to -PAD on
+    // the left / above / below clause would leave the midpoint clear. A long
+    // lane keeps the 1/3 fallback slot far from every blocker so the stagger
+    // target is unambiguous.
+    const pillH = m.height + 16
+    const long0 = { x: 0, y: 50 }, long1 = { x: 900, y: 50 } // midpoint 450, 1/3 at 300
+    const blockerAt = (cx: number, cy: number) => mkEdge({
+      source: 'P', target: 'Q', edgeIndex: 1, label: 'No', labelPosition: { x: cx, y: cy },
+      points: [{ x: 5000, y: 5000 }, { x: 5020, y: 5000 }],
+    })
+    const staggers = (cx: number, cy: number) => {
+      const s = findLabelSlot(mkEdge({ label: 'No' }), long0, long1, ctx({ edges: [blockerAt(cx, cy)] }))
+      expect(s!.x).toBeCloseTo(900 / 3, 6)
+      expect(s!.y).toBe(50)
+    }
+    staggers(450 - pillW, 50) // left clause (-x)
+    staggers(450, 50 + pillH) // below clause (+y)
+    staggers(450, 50 - pillH) // above clause (-y)
+  })
 })
 
 describe('primary-over-feedback priority (unit)', () => {
@@ -1242,6 +1294,131 @@ describe('route audit — boundary harvest', () => {
   })
 })
 
+describe('route audit — exact-boundary harvest (mutation survivors)', () => {
+  // The audit tripwires are gated on exact tolerances (onRectPerimeter's ±1px,
+  // the ±2px "still attached" inflation, the non-incident ±0.5 inset). These
+  // pin each boundary on every border/axis, approaching endpoints orthogonally
+  // so no spurious ROUTE_UNEXPLAINED_BEND fires.
+  function auditAfter(dir: 'LR' | 'TD', mutate: (e: PositionedEdge, b: PositionedNode, a: PositionedNode) => void): string[] {
+    const graph = parseMermaid(`flowchart ${dir}\n  A --> B`)
+    const p = layoutGraphSync(graph)
+    const a = p.nodes.find(n => n.id === 'A')!, b = p.nodes.find(n => n.id === 'B')!
+    mutate(findEdge(p.edges, 'A', 'B'), b, a)
+    return auditRouteContracts(p, graph).map(f => f.code)
+  }
+
+  it('ROUTE_SHAPE_MISANCHOR: a point exactly 1px off any border is still on the perimeter (silent)', () => {
+    const cy = (b: PositionedNode) => b.y + b.height / 2
+    const cx = (b: PositionedNode) => b.x + b.width / 2
+    // left / right via LR (horizontal approach)
+    expect(auditAfter('LR', (e, b) => { e.points = [e.points[0]!, { x: b.x - 1, y: cy(b) }] })).toEqual([])
+    expect(auditAfter('LR', (e, b) => { e.points = [e.points[0]!, { x: b.x + b.width + 1, y: cy(b) }] })).toEqual([])
+    // top / bottom via TD (vertical approach)
+    expect(auditAfter('TD', (e, b, a) => { e.points = [{ x: cx(b), y: a.y + a.height }, { x: cx(b), y: b.y - 1 }] })).toEqual([])
+    expect(auditAfter('TD', (e, b, a) => { e.points = [{ x: cx(b), y: a.y + a.height }, { x: cx(b), y: b.y + b.height + 1 }] })).toEqual([])
+  })
+
+  it('ROUTE_SHAPE_MISANCHOR vs STALE: exactly 2px off a border is still attached (misanchor, not stale)', () => {
+    const check = (codes: string[]) => {
+      expect(codes).toContain('ROUTE_SHAPE_MISANCHOR')
+      expect(codes).not.toContain('ROUTE_STALE_AFTER_NODE_MOVE')
+    }
+    const cy = (b: PositionedNode) => b.y + b.height / 2
+    const cx = (b: PositionedNode) => b.x + b.width / 2
+    check(auditAfter('LR', (e, b) => { e.points = [e.points[0]!, { x: b.x - 2, y: cy(b) }] }))
+    check(auditAfter('LR', (e, b) => { e.points = [e.points[0]!, { x: b.x + b.width + 2, y: cy(b) }] }))
+    check(auditAfter('TD', (e, b, a) => { e.points = [{ x: cx(b), y: a.y + a.height }, { x: cx(b), y: b.y - 2 }] }))
+    check(auditAfter('TD', (e, b, a) => { e.points = [{ x: cx(b), y: a.y + a.height }, { x: cx(b), y: b.y + b.height + 2 }] }))
+  })
+
+  it('ROUTE_UNEXPLAINED_BEND: fires on a FEEDBACK edge, not only primary-forward', () => {
+    const graph = parseMermaid('flowchart LR\n  A --> B\n  B --> A')
+    const p = layoutGraphSync(graph)
+    const fb = findEdge(p.edges, 'B', 'A')
+    expect(fb.routeCertificate?.routeClass).toBe('feedback')
+    const s = fb.points[0]!, t = fb.points[fb.points.length - 1]!
+    fb.points = [s, { x: (s.x + t.x) / 2, y: s.y + 25 }, t] // inject a diagonal
+    expect(auditRouteContracts(p, graph).map(f => f.code)).toContain('ROUTE_UNEXPLAINED_BEND')
+  })
+
+  it('ROUTE_STALE_AFTER_NODE_MOVE: non-incident overlap respects segment direction and the ±0.5 inset', () => {
+    // A cert-less edge isolates the non-incident scan: every other tripwire is
+    // cert-gated. C's inner bbox is x(100.5, 159.5), y(100.5, 139.5).
+    const stale = (points: Point[]): string[] => {
+      const graph = parseMermaid('flowchart LR\n  X --> Y')
+      const positioned = {
+        nodes: [
+          { id: 'X', label: 'X', shape: 'rectangle', x: 0, y: 0, width: 20, height: 20 },
+          { id: 'Y', label: 'Y', shape: 'rectangle', x: 400, y: 400, width: 20, height: 20 },
+          { id: 'C', label: 'C', shape: 'rectangle', x: 100, y: 100, width: 60, height: 40 },
+        ] as PositionedNode[],
+        edges: [{ source: 'X', target: 'Y', edgeIndex: 0, points }] as PositionedEdge[],
+        groups: [] as PositionedGroup[],
+      }
+      return auditRouteContracts(positioned, graph).map(f => f.code)
+    }
+    const STALE = 'ROUTE_STALE_AFTER_NODE_MOVE'
+    // entering from the left (only max-x inside) and from the right (only min-x
+    // inside) — pins both ends of the segment-direction min/max.
+    expect(stale([{ x: 50, y: 120 }, { x: 130, y: 120 }])).toContain(STALE)
+    expect(stale([{ x: 130, y: 120 }, { x: 250, y: 120 }])).toContain(STALE)
+    expect(stale([{ x: 120, y: 50 }, { x: 120, y: 120 }])).toContain(STALE) // vertical, min/max on y
+    // grazing exactly the ±0.5 inset on each axis is NOT an overlap (silent).
+    expect(stale([{ x: 50, y: 120 }, { x: 100.5, y: 120 }])).toEqual([])
+    expect(stale([{ x: 159.5, y: 120 }, { x: 250, y: 120 }])).toEqual([])
+    expect(stale([{ x: 120, y: 50 }, { x: 120, y: 100.5 }])).toEqual([])
+  })
+})
+
+describe('route audit — property-based & metamorphic coverage (fast-check)', () => {
+  // Kill the boundary-tolerance survivors as a CLASS instead of one pixel
+  // fixture at a time: fc.double probes offsets arbitrarily close to the ±tol
+  // and ±2 thresholds. Plus a metamorphic relation — audit findings must be
+  // invariant under whole-diagram translation (catches absolute-coordinate
+  // / sign mutants that example-based fixtures miss).
+  it('SHAPE_MISANCHOR/STALE trichotomy holds for any offset off a vertical border', () => {
+    const graph = parseMermaid('flowchart LR\n  A --> B')
+    const base = layoutGraphSync(graph)
+    const b = base.nodes.find(n => n.id === 'B')!
+    const cy = b.y + b.height / 2
+    fc.assert(fc.property(
+      fc.constantFrom('left' as const, 'right' as const),
+      fc.double({ min: 0, max: 5, noNaN: true }),
+      (border, off) => {
+        const p = structuredClone(base)
+        const e = findEdge(p.edges, 'A', 'B')
+        const x = border === 'left' ? b.x - off : b.x + b.width + off
+        e.points = [e.points[0]!, { x, y: cy }]
+        const codes = auditRouteContracts(p, graph).map(f => f.code)
+        const misanchor = codes.includes('ROUTE_SHAPE_MISANCHOR')
+        const stale = codes.includes('ROUTE_STALE_AFTER_NODE_MOVE')
+        if (off <= 1) return !misanchor && !stale // within tol → on perimeter
+        if (off <= 2) return misanchor && !stale  // off perimeter, still attached
+        return stale && !misanchor                // detached
+      },
+    ), { numRuns: 300 })
+  })
+
+  it('audit findings are invariant under whole-diagram translation (metamorphic)', () => {
+    const graph = parseMermaid(MFA_SOURCE)
+    const base = layoutGraphSync(graph)
+    const baseCodes = JSON.stringify(auditRouteContracts(base, graph).map(f => f.code).sort())
+    fc.assert(fc.property(
+      fc.integer({ min: -1000, max: 1000 }),
+      fc.integer({ min: -1000, max: 1000 }),
+      (dx, dy) => {
+        const p = structuredClone(base)
+        for (const n of p.nodes) { n.x += dx; n.y += dy }
+        for (const e of p.edges) {
+          e.points = e.points.map(pt => ({ x: pt.x + dx, y: pt.y + dy }))
+          if (e.labelPosition) e.labelPosition = { x: e.labelPosition.x + dx, y: e.labelPosition.y + dy }
+        }
+        return JSON.stringify(auditRouteContracts(p, graph).map(f => f.code).sort()) === baseCodes
+      },
+    ), { numRuns: 100 })
+  })
+})
+
 describe('container repair — axis selection harvest', () => {
   function flat(groups: PositionedGraph['groups'], out: PositionedGraph['groups'] = []): PositionedGraph['groups'] {
     for (const g of groups) { out.push(g); flat(g.children, out) }
@@ -1302,6 +1479,42 @@ describe('container repair — axis selection harvest', () => {
     const positioned = layoutGraphSync(graph)
     const e = findEdge(positioned.edges, 'S', 'Pipeline')
     expect(e.routeCertificate?.invariant).toBe('container-attach')
+  })
+})
+
+describe('tryRepairContainerEdge (unit)', () => {
+  const style = { edgeLabelFontSize: 12, edgeLabelFontWeight: 400 }
+  const rect = (id: string, x: number, y: number, shape = 'rectangle') =>
+    ({ id, label: id, shape, x, y, width: 40, height: 40 })
+  const mkEdge = (points: Array<{ x: number; y: number }>): PositionedEdge =>
+    ({ source: 'S', target: 'T', style: 'solid', hasArrowStart: false, hasArrowEnd: true, points, edgeIndex: 0 }) as PositionedEdge
+  const repair = (edge: PositionedEdge, nodes: ReturnType<typeof rect>[]) =>
+    tryRepairContainerEdge(
+      edge,
+      new Map() as Parameters<typeof tryRepairContainerEdge>[1],
+      new Map(nodes.map(n => [n.id, n])) as unknown as Parameters<typeof tryRepairContainerEdge>[2],
+      { nodes, edges: [edge], axis: { main: 'x', cross: 'y', sign: 1 }, style } as unknown as Parameters<typeof tryRepairContainerEdge>[3],
+    )
+
+  // S sits below T (gap 60px in y), so the only positive gap is the reversed
+  // lane (target-above-source, sign:-1) — the direction the integration suite
+  // never exercised. A clear vertical channel at the shared x straightens it.
+  it('repairs a dog-legged container edge in the reversed direction (target above source)', () => {
+    const edge = mkEdge([{ x: 20, y: 100 }, { x: 70, y: 100 }, { x: 70, y: 40 }, { x: 20, y: 40 }])
+    const ok = repair(edge, [rect('S', 0, 100), rect('T', 0, 0)])
+    expect(ok).toBe(true)
+    expect(edge.points.length).toBe(2)
+    expect(Math.abs(edge.points[0]!.x - edge.points[1]!.x)).toBeLessThan(0.01)
+  })
+
+  it('declines (returns false) when an endpoint is not a rect-like shape', () => {
+    const edge = mkEdge([{ x: 20, y: 100 }, { x: 70, y: 100 }, { x: 70, y: 40 }, { x: 20, y: 40 }])
+    expect(repair(edge, [rect('S', 0, 100, 'circle'), rect('T', 0, 0)])).toBe(false)
+  })
+
+  it('leaves an already-straight border-to-border lane untouched', () => {
+    const edge = mkEdge([{ x: 20, y: 100 }, { x: 20, y: 40 }])
+    expect(repair(edge, [rect('S', 0, 100), rect('T', 0, 0)])).toBe(false)
   })
 })
 
@@ -1761,6 +1974,178 @@ describe('port ranking — sharp bits win when a side carries one line (issue #2
     const e = findEdge(positioned.edges, 'Q1', 'Q2')
     expect(e.routeCertificate?.sourcePort).toBe('E')
     expect(e.points.length).toBeLessThanOrEqual(4)
+  })
+})
+
+describe('vertex hook — entry side across axes and suppression guards (route-certificate harvest)', () => {
+  // Hand-built geometry (like the issue #26 hook test above) makes
+  // tryVertexHook deterministic. The existing test pins LR with the target
+  // BELOW the lane (entry side N); these pin the mirror (S) and the rotated
+  // cross axis (W/E under TD), plus the two early-return guards — the survivor
+  // harvest for src/route-contracts.ts lines 1422-1451.
+  const FONT = { edgeLabelFontSize: 11, edgeLabelFontWeight: 400 }
+
+  it('LR with the target ABOVE the lane hooks into the exact South port (mirror of the North case)', () => {
+    const graph = parseMermaid('flowchart LR\n  Q{Decide} --> T[Target]')
+    const positioned = {
+      nodes: [
+        { id: 'Q', label: 'Decide', shape: 'diamond', x: 40, y: 150, width: 100, height: 100 },
+        { id: 'T', label: 'Target', shape: 'rectangle', x: 300, y: 40, width: 80, height: 36 },
+      ] as PositionedNode[],
+      edges: [{
+        source: 'Q', target: 'T',
+        points: [{ x: 140, y: 200 }, { x: 220, y: 200 }, { x: 220, y: 58 }, { x: 300, y: 58 }],
+      }] as PositionedEdge[],
+      groups: [] as PositionedGroup[],
+    }
+    applyRouteContracts(positioned, graph, new Set(), FONT)
+    const e = positioned.edges[0]!
+    expect(e.points.length).toBe(3)
+    expect(e.routeCertificate?.sourcePort).toBe('E')
+    expect(e.routeCertificate?.targetPort).toBe('S')
+    expect(e.points[e.points.length - 1]).toEqual({ x: 340, y: 76 })
+  })
+
+  it('TD with the target to the lower-RIGHT hooks into the exact West port', () => {
+    const graph = parseMermaid('flowchart TD\n  Q{Decide} --> T[Target]')
+    const positioned = {
+      nodes: [
+        { id: 'Q', label: 'Decide', shape: 'diamond', x: 40, y: 40, width: 100, height: 100 },
+        { id: 'T', label: 'Target', shape: 'rectangle', x: 200, y: 300, width: 80, height: 36 },
+      ] as PositionedNode[],
+      edges: [{
+        source: 'Q', target: 'T',
+        points: [{ x: 90, y: 140 }, { x: 90, y: 200 }, { x: 240, y: 200 }, { x: 240, y: 300 }],
+      }] as PositionedEdge[],
+      groups: [] as PositionedGroup[],
+    }
+    applyRouteContracts(positioned, graph, new Set(), FONT)
+    const e = positioned.edges[0]!
+    expect(e.points.length).toBe(3)
+    expect(e.routeCertificate?.sourcePort).toBe('S')
+    expect(e.routeCertificate?.targetPort).toBe('W')
+    expect(e.points[e.points.length - 1]).toEqual({ x: 200, y: 318 })
+  })
+
+  it('TD with the target to the lower-LEFT hooks into the exact East port', () => {
+    const graph = parseMermaid('flowchart TD\n  Q{Decide} --> T[Target]')
+    const positioned = {
+      nodes: [
+        { id: 'Q', label: 'Decide', shape: 'diamond', x: 300, y: 40, width: 100, height: 100 },
+        { id: 'T', label: 'Target', shape: 'rectangle', x: 120, y: 300, width: 80, height: 36 },
+      ] as PositionedNode[],
+      edges: [{
+        source: 'Q', target: 'T',
+        points: [{ x: 350, y: 140 }, { x: 350, y: 200 }, { x: 160, y: 200 }, { x: 160, y: 300 }],
+      }] as PositionedEdge[],
+      groups: [] as PositionedGroup[],
+    }
+    applyRouteContracts(positioned, graph, new Set(), FONT)
+    const e = positioned.edges[0]!
+    expect(e.points.length).toBe(3)
+    expect(e.routeCertificate?.sourcePort).toBe('S')
+    expect(e.routeCertificate?.targetPort).toBe('E')
+    expect(e.points[e.points.length - 1]).toEqual({ x: 200, y: 318 })
+  })
+
+  it('a stub shorter than HOOK_STUB_MIN suppresses the hook (no 1-bend into the facing port)', () => {
+    // entryCross - lane = 3 px (< HOOK_STUB_MIN = 8): the hook would be a
+    // degenerate near-zero stub, so tryVertexHook bails and the Z is used.
+    const graph = parseMermaid('flowchart LR\n  Q{Decide} --> T[Target]')
+    const positioned = {
+      nodes: [
+        { id: 'Q', label: 'Decide', shape: 'diamond', x: 40, y: 40, width: 100, height: 100 },
+        { id: 'T', label: 'Target', shape: 'rectangle', x: 300, y: 93, width: 80, height: 36 },
+      ] as PositionedNode[],
+      edges: [{
+        source: 'Q', target: 'T',
+        points: [{ x: 140, y: 90 }, { x: 220, y: 90 }, { x: 220, y: 111 }, { x: 300, y: 111 }],
+      }] as PositionedEdge[],
+      groups: [] as PositionedGroup[],
+    }
+    applyRouteContracts(positioned, graph, new Set(), FONT)
+    const e = positioned.edges[0]!
+    const hookedIntoNorth = e.points.length === 3 && Math.abs(e.points[2]!.y - 93) < 0.5
+    expect(hookedIntoNorth).toBe(false)
+  })
+
+  it('a sibling already holding the facing entry port suppresses the hook (fan-in merge wins)', () => {
+    // S -> T already lands on T's West (flow-side) port, so the merge outranks
+    // the hook: Q -> T must NOT take the 1-bend North hook.
+    const graph = parseMermaid('flowchart LR\n  Q{Decide} --> T[Target]\n  S[Side] --> T')
+    const positioned = {
+      nodes: [
+        { id: 'Q', label: 'Decide', shape: 'diamond', x: 40, y: 40, width: 100, height: 100 },
+        { id: 'T', label: 'Target', shape: 'rectangle', x: 300, y: 120, width: 80, height: 36 },
+        { id: 'S', label: 'Side', shape: 'rectangle', x: 40, y: 120, width: 80, height: 36 },
+      ] as PositionedNode[],
+      edges: [
+        { source: 'Q', target: 'T', points: [{ x: 140, y: 90 }, { x: 220, y: 90 }, { x: 220, y: 138 }, { x: 300, y: 138 }] },
+        { source: 'S', target: 'T', points: [{ x: 120, y: 138 }, { x: 300, y: 138 }] },
+      ] as PositionedEdge[],
+      groups: [] as PositionedGroup[],
+    }
+    applyRouteContracts(positioned, graph, new Set(), FONT)
+    const qt = positioned.edges[0]!
+    const hookedIntoNorth = qt.points.length === 3 && Math.abs(qt.points[2]!.y - 120) < 0.5
+    expect(hookedIntoNorth).toBe(false)
+    expect(qt.routeCertificate?.targetPort).not.toBe('N')
+  })
+})
+
+describe('reciprocal & off-port enrollment — straight edges still re-lane (route-certificate harvest)', () => {
+  // The "already straight" branch (route-contracts.ts lines 1681-1705) must
+  // still enroll two kinds of straight edge: one floating off its ports, and a
+  // reciprocal-pair member sitting on the shared centerline. Hand-built,
+  // straight-on-entry geometry isolates each enrollment trigger so the survivor
+  // harvest for lines 1693-1704 has something to bite.
+  const FONT = { edgeLabelFontSize: 11, edgeLabelFontWeight: 400 }
+
+  it('a straight, on-port reciprocal pair still enrolls and splits to the symmetric lane (center ± 6)', () => {
+    // Both edges enter already straight AND on the shared port lane (y=120);
+    // the ONLY reason to re-lane is the reciprocal flag. Drop it and they stay
+    // overlapping on y=120.
+    const graph = parseMermaid('flowchart LR\n  A --> B\n  B --> A')
+    const positioned = {
+      nodes: [
+        { id: 'A', label: 'A', shape: 'rectangle', x: 40, y: 100, width: 80, height: 40 },
+        { id: 'B', label: 'B', shape: 'rectangle', x: 300, y: 100, width: 80, height: 40 },
+      ] as PositionedNode[],
+      edges: [
+        { source: 'A', target: 'B', edgeIndex: 0, points: [{ x: 120, y: 120 }, { x: 300, y: 120 }] },
+        { source: 'B', target: 'A', edgeIndex: 1, points: [{ x: 300, y: 120 }, { x: 120, y: 120 }] },
+      ] as PositionedEdge[],
+      groups: [] as PositionedGroup[],
+    }
+    applyRouteContracts(positioned, graph, new Set(), FONT)
+    const ab = positioned.edges[0]!, ba = positioned.edges[1]!
+    expect(isStraightHorizontal(ab)).toBe(true)
+    expect(isStraightHorizontal(ba)).toBe(true)
+    expect(ab.points[0]!.y).toBeCloseTo(114, 5) // primary takes the low side
+    expect(ba.points[0]!.y).toBeCloseTo(126, 5) // feedback the high side
+    expect(Math.abs(ab.points[0]!.y - ba.points[0]!.y)).toBeCloseTo(12, 5)
+  })
+
+  it('a straight edge floating off the ports enrolls and snaps onto the exact port lane', () => {
+    // Straight but 10px below both port midpoints (ELK FREE placement). The
+    // off-port check must enroll it so it re-lanes onto the E->W port lane.
+    const graph = parseMermaid('flowchart LR\n  A --> B')
+    const positioned = {
+      nodes: [
+        { id: 'A', label: 'A', shape: 'rectangle', x: 40, y: 100, width: 80, height: 40 },
+        { id: 'B', label: 'B', shape: 'rectangle', x: 300, y: 100, width: 80, height: 40 },
+      ] as PositionedNode[],
+      edges: [
+        { source: 'A', target: 'B', edgeIndex: 0, points: [{ x: 120, y: 130 }, { x: 300, y: 130 }] },
+      ] as PositionedEdge[],
+      groups: [] as PositionedGroup[],
+    }
+    applyRouteContracts(positioned, graph, new Set(), FONT)
+    const e = positioned.edges[0]!
+    expect(isStraightHorizontal(e)).toBe(true)
+    expect(e.points[0]!.y).toBeCloseTo(120, 5)
+    expect(e.routeCertificate?.sourcePort).toBe('E')
+    expect(e.routeCertificate?.targetPort).toBe('W')
   })
 })
 

--- a/src/route-contracts.ts
+++ b/src/route-contracts.ts
@@ -2227,7 +2227,7 @@ export function findRouteHitches(
  * — the same machinery as node straightening, with the container rect
  * standing in as a rectangle. Returns true when the route was repaired.
  */
-function tryRepairContainerEdge(
+export function tryRepairContainerEdge(
   edge: PositionedEdge,
   groupMap: Map<string, PositionedGroup>,
   nodeMap: Map<string, PositionedNode>,

--- a/stryker.route-certificates.config.json
+++ b/stryker.route-certificates.config.json
@@ -1,9 +1,9 @@
 {
   "$schema": "https://raw.githubusercontent.com/stryker-mutator/stryker/master/packages/core/schema/stryker-core.schema.json",
-  "_comment": "Narrow mutation lane for route-certificate finality and stale-route audit tripwires. Complements, but does not replace, the broader mutation-test:routes lane.",
+  "_comment": "Narrow mutation lane for route-certificate finality and stale-route audit tripwires. Complements, but does not replace, the broader mutation-test:routes lane. Generic command runner (bun test). Line ranges track src/route-contracts.ts and need re-pointing if the file shifts.",
   "mutate": [
-    "src/route-contracts.ts:1420-1452",
-    "src/route-contracts.ts:1688-1704"
+    "src/route-contracts.ts:1456-1488",
+    "src/route-contracts.ts:1724-1740"
   ],
   "ignorePatterns": ["/site/**", "/dist/**", "/coverage/**", "/index.html", "/editor.html", "/.stryker-tmp-*/**"],
   "testRunner": "command",

--- a/stryker.route-certificates.config.json
+++ b/stryker.route-certificates.config.json
@@ -2,8 +2,8 @@
   "$schema": "https://raw.githubusercontent.com/stryker-mutator/stryker/master/packages/core/schema/stryker-core.schema.json",
   "_comment": "Narrow mutation lane for route-certificate finality and stale-route audit tripwires. Complements, but does not replace, the broader mutation-test:routes lane. Generic command runner (bun test). Line ranges track src/route-contracts.ts and need re-pointing if the file shifts.",
   "mutate": [
-    "src/route-contracts.ts:1456-1488",
-    "src/route-contracts.ts:1724-1740"
+    "src/route-contracts.ts:1743-1775",
+    "src/route-contracts.ts:2011-2027"
   ],
   "ignorePatterns": ["/site/**", "/dist/**", "/coverage/**", "/index.html", "/editor.html", "/.stryker-tmp-*/**"],
   "testRunner": "command",

--- a/stryker.routes.config.json
+++ b/stryker.routes.config.json
@@ -1,10 +1,10 @@
 {
   "$schema": "https://raw.githubusercontent.com/stryker-mutator/stryker/master/packages/core/schema/stryker-core.schema.json",
-  "_comment": "Scoped mutation testing for the route-contracts module (docs/design/system/route-contracts.md). A surviving mutant in the direct-lane proof would mean the certifying straightener can straighten without proof.",
+  "_comment": "Scoped mutation testing for the route-contracts module (docs/design/system/route-contracts.md). A surviving mutant in the direct-lane proof would mean the certifying straightener can straighten without proof. Generic command runner (reruns the bun test file per mutant); the nightly shards this lane by line range so each shard finishes inside the cap — see .github/workflows/nightly-route-mutation.yml and docs/mutation-testing.md.",
   "mutate": [
     "src/route-contracts.ts"
   ],
-  "ignorePatterns": ["/site/**", "/dist/**", "/coverage/**"],
+  "ignorePatterns": ["/site/**", "/dist/**", "/coverage/**", "/.stryker-tmp-*/**"],
   "testRunner": "command",
   "commandRunner": {
     "command": "bun test src/__tests__/route-contracts.test.ts"


### PR DESCRIPTION
## Summary

Two threads on route-contracts mutation testing. **Everything here is tests / CI / docs except a single `export` keyword — shipped behavior is unchanged; no diagram renders differently.**

1. **Fix the nightly route mutation lane**, which was timing out. The broad `route-contracts.ts` lane (~3.5k mutants) can't finish in one job on the command runner (≈3.5 h → DNF). **Shard it** into four parallel line-range jobs so each finishes inside its cap — no test-runner change.
2. **Harvest mutation survivors** across several passes (and classify the genuine equivalents), strengthening regression coverage of the route-geometry core.

> A `@stryker-mutator/vitest-runner` migration (perTest, faster on one runner) was prototyped and then **rejected** in favor of sharding: it would have meant moving the suite off `bun:test` and carrying a permanent second runner. Sharding keeps everything on `bun test` and completes just as reliably. (The branch was rebased + **squashed** onto current `main` — it's a single bun-only commit, no vitest in the diff.)

## CI fix — shard the nightly lane

`nightly-route-mutation.yml`: the single `routes` job becomes `routes-shard-1..4`, each `npx stryker run stryker.routes.config.json --mutate 'src/route-contracts.ts:<range>'`, run in parallel. Ranges are balanced by **measured mutant density** (1-606 / 607-1160 / 1161-1629 / 1630-2105, ~870 mutants each), not line count, so the longest shard is ~¼ of the total. Reassemble survivors by downloading the `route-mutation-routes-shard-*` artifacts and running `scripts/mutation-survivors.ts` over each.

## Performance (measured on a 4-core box ≈ one CI runner)

| | result |
|---|---|
| **Old** — unsharded command runner | **DNF** on GitHub (timed out at the 180-min cap); = **165 min** of total work on one machine |
| **New** — 4 shards, 4 parallel runners | wall-clock ≈ the longest shard, and it **completes** |

Honest framing: sharding does **not** reduce total work (165 min either way) — it parallelizes. Longest shard was 61 min before rebalancing (2.7×); the density-balanced ranges project to ~41 min (**≈4×**), confirmed by the next nightly. Full-lane score on the command runner is **~54.5%** (1904 killed+timeout / 3492) — a few points above the vitest-runner's 50.79%, which counts 383 no-coverage mutants as not-killed.

## Survivor harvests (+ equivalence classification)

Each pass adds tests that kill survivors and **sabotage-verifies** them; genuine equivalents are classified in `docs/mutation-testing.md` rather than chased to 100%:

- **vertex-hook entry sides** + early-return guards: route-certificates 27.95% → 52.17%.
- **reciprocal / off-port enrollment** and **route-audit exact-boundary** fixtures.
- **fast-check** property tests that kill the boundary-tolerance survivors as a *class*. The seed is pinned (scoped via `before`/`afterAll`) so the lane is reproducible without making the other ~29 fast-check suites deterministic.
- **`directLaneBlockers` / `findLabelSlot`** label geometry: a non-square obstacle pill + pad-band fixtures kill the width/height-swap, zeroed-extent, clearance-arithmetic, and slot-overlap `+PAD` mutants. The strict-vs-non-strict residual (differs only at exact float equality) is classified equivalent.
- **`tryRepairContainerEdge` contract**: exported (**the one shipped-code change**) and unit-tested directly (reversed-direction repair, non-rect decline, already-straight no-op). Honest residual: the four-direction gap *selection* still needs a competing-positive-gap fixture — documented as open.

## Tooling

- `scripts/mutation-survivors.ts` — triage a Stryker JSON report (score, survivors by mutator, line hotspots, full list).
- `scripts/mutation-kill-prompts.ts` — per-mutant "kill prompts" with an equivalence-prone prefilter.

## Verification (rebased onto current `main`)

- `bun test` **4141 pass / 0 fail** (180 files — route-contracts is in bun's discovery); `bun x tsc --noEmit` clean.
- `bun run sabotage:routes` — all 5 one-line-revert checks fail as expected, against main's reworked `layout-engine.ts` / `route-contracts.ts`.
- Full sharded set run end-to-end (3492 mutants, ~54.5%); the `route-certificates` line ranges verified on target after the rebase.

## Notes for reviewers

- **No second test runner** — the suite stays entirely on `bun test`. The only shipped-code change is one `export` keyword (for the container-repair unit test); behavior is identical to `main`.
- Broad route mutation lanes stay **nightly** (now sharded), not a PR gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01357m6WfZGNfkoUYsmZwBSN