### PR TITLE
test: lift five curated example tests to properties over generators

### DIFF
--- a/src/__tests__/architecture-layout.test.ts
+++ b/src/__tests__/architecture-layout.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'bun:test'
+import fc from 'fast-check'
 import { layoutArchitectureDiagram } from '../architecture/layout.ts'
 import { architectureToMermaidGraph, parseArchitectureDiagram } from '../architecture/parser.ts'
 import { convertToElkFormat } from '../layout-engine.ts'
@@ -65,6 +66,52 @@ describe('layoutArchitectureDiagram', () => {
     expect(junction.y).toBeGreaterThan(group.y)
     expect(junction.x + junction.width).toBeLessThanOrEqual(groupRight)
     expect(junction.y + junction.height).toBeLessThanOrEqual(groupBottom)
+  })
+
+  // Property: containment is a structural invariant, not a property of one
+  // example — for ANY architecture, every service/junction declared `in` a group
+  // must lie within that group's frame. Generates random multi-group diagrams.
+  it('every grouped service/junction stays inside its parent frame (property)', () => {
+    const sides = ['L', 'R', 'T', 'B']
+    const arb = fc.record({
+      groups: fc.integer({ min: 1, max: 2 }),
+      svcPerGroup: fc.array(fc.integer({ min: 2, max: 3 }), { minLength: 2, maxLength: 2 }),
+      junctions: fc.array(fc.boolean(), { minLength: 2, maxLength: 2 }),
+      edges: fc.array(fc.record({ a: fc.nat(5), b: fc.nat(5), sa: fc.nat(3), sb: fc.nat(3) }), { maxLength: 5 }),
+    }).map(({ groups, svcPerGroup, junctions, edges }) => {
+      const lines = ['architecture-beta']
+      const svc: string[] = []
+      for (let g = 0; g < groups; g++) {
+        lines.push(`  group g${g}(cloud)[Group ${g}]`)
+        for (let s = 0; s < svcPerGroup[g]!; s++) {
+          const id = `s${g}_${s}`
+          svc.push(id)
+          lines.push(`  service ${id}(server)[Svc ${id}] in g${g}`)
+        }
+        if (junctions[g]) lines.push(`  junction j${g} in g${g}`)
+      }
+      for (const e of edges) {
+        const A = svc[e.a % svc.length]!, B = svc[e.b % svc.length]!
+        if (A !== B) lines.push(`  ${A}:${sides[e.sa]} --> ${sides[e.sb]}:${B}`)
+      }
+      return lines.join('\n')
+    })
+
+    const EPS = 0.5
+    fc.assert(
+      fc.property(arb, source => {
+        const result = layout(source)
+        const groupById = new Map(result.groups.map(g => [g.id, g]))
+        const contained = (n: { parentId?: string; x: number; y: number; width: number; height: number }) => {
+          const g = n.parentId ? groupById.get(n.parentId) : undefined
+          if (!g) return true
+          return n.x >= g.x - EPS && n.y >= g.y - EPS
+            && n.x + n.width <= g.x + g.width + EPS && n.y + n.height <= g.y + g.height + EPS
+        }
+        return result.services.every(contained) && result.junctions.every(contained)
+      }),
+      { numRuns: 300 },
+    )
   })
 
   it('routes group-boundary edges from the enclosing group frame', () => {

--- a/src/__tests__/ascii-edge-styles.test.ts
+++ b/src/__tests__/ascii-edge-styles.test.ts
@@ -3,6 +3,7 @@
 // ============================================================================
 
 import { describe, it, expect } from 'bun:test'
+import fc from 'fast-check'
 import { renderMermaidAscii } from '../ascii/index.ts'
 
 function rowContaining(rendered: string, ...tokens: string[]): string {
@@ -43,6 +44,39 @@ describe('ASCII edge styles', () => {
       const row = rowContaining(renderMermaidAscii('graph LR\n  A o--x B'), 'A', 'B')
       expect(row).toContain('◯────✕')
       expect(row.indexOf('◯')).toBeLessThan(row.indexOf('✕'))
+    })
+
+    // Property: for ANY single LR edge with random labels, the chosen line style
+    // renders its own glyph and never leaks another style's dashed/thick glyph
+    // (the solid glyph aliases box borders, so it is only asserted present). Holds
+    // in both unicode and ascii modes.
+    it('renders the chosen LR line-style glyph without leaking another style (property)', () => {
+      const GLYPH = {
+        unicode: { solid: '─', dotted: '┄', thick: '━' },
+        ascii: { solid: '-', dotted: '.', thick: '=' },
+      } as const
+      const OP = { solid: '-->', dotted: '-.->', thick: '==>' } as const
+      const labelArb = fc.array(fc.constantFrom(...'abcXYZ012'.split('')), { minLength: 1, maxLength: 5 })
+        .map(cs => cs.join('') || 'N')
+      fc.assert(
+        fc.property(
+          labelArb, labelArb,
+          fc.constantFrom('solid', 'dotted', 'thick'),
+          fc.boolean(),
+          (a, b, style, ascii) => {
+            if (a === b) return true
+            const out = renderMermaidAscii(`graph LR\n  ${a} ${OP[style]} ${b}`, ascii ? { useAscii: true } : undefined)
+            const glyph = ascii ? GLYPH.ascii : GLYPH.unicode
+            if (!out.includes(glyph[style])) return false
+            // No OTHER style's special (dashed/thick) glyph leaks in.
+            for (const other of ['dotted', 'thick'] as const) {
+              if (other !== style && out.includes(glyph[other])) return false
+            }
+            return true
+          },
+        ),
+        { numRuns: 500 },
+      )
     })
   })
 

--- a/src/__tests__/multiline-labels.test.ts
+++ b/src/__tests__/multiline-labels.test.ts
@@ -9,6 +9,7 @@
  * - Integration: full SVG output with multi-line labels
  */
 import { describe, it, expect } from 'bun:test'
+import fc from 'fast-check'
 import { parseMermaid } from '../parser.ts'
 import { parseSequenceDiagram } from '../sequence/parser.ts'
 import { parseClassDiagram } from '../class/parser.ts'
@@ -843,3 +844,42 @@ function extractFirstRectWidth(svg: string): number {
   const match = svg.match(/<rect[^>]*width="(\d+(?:\.\d+)?)"/)
   return match ? parseFloat(match[1]!) : 0
 }
+
+// Properties over random multi-line labels. The metrics are a pure function of
+// the lines, so they have exact invariants (height is line-count × line-height)
+// and metamorphic ones (adding a line adds exactly one line-height and never
+// shrinks the width).
+describe('measureMultilineText – properties over random labels', () => {
+  const lineArb = fc.array(fc.constantFrom(...'abcDEF 123,.!()'.split('')), { maxLength: 24 }).map(cs => cs.join(''))
+  const labelArb = fc.array(lineArb, { minLength: 1, maxLength: 8 }).map(ls => ls.join('\n'))
+  const fontSizeArb = fc.integer({ min: 8, max: 40 })
+  const fontWeightArb = fc.constantFrom(400, 600, 700)
+
+  it('height is exactly line-count × line-height; width is the widest line; all finite', () => {
+    fc.assert(
+      fc.property(labelArb, fontSizeArb, fontWeightArb, (text, fontSize, fontWeight) => {
+        const m = measureMultilineText(text, fontSize, fontWeight)
+        const lines = text.split('\n')
+        if (m.lines.length !== lines.length) return false
+        if (m.lineHeight !== fontSize * LINE_HEIGHT_RATIO) return false
+        if (m.height !== lines.length * m.lineHeight) return false
+        const widest = Math.max(...lines.map(l => measureTextWidth(stripFormattingTags(l), fontSize, fontWeight)))
+        if (Math.abs(m.width - widest) > 1e-6) return false
+        return Number.isFinite(m.width) && Number.isFinite(m.height) && m.width >= 0 && m.height >= 0
+      }),
+      { numRuns: 400 },
+    )
+  })
+
+  it('adding a line adds exactly one line-height and never shrinks the width', () => {
+    fc.assert(
+      fc.property(labelArb, lineArb, fontSizeArb, fontWeightArb, (text, extra, fontSize, fontWeight) => {
+        const before = measureMultilineText(text, fontSize, fontWeight)
+        const after = measureMultilineText(`${text}\n${extra}`, fontSize, fontWeight)
+        if (Math.abs(after.height - before.height - fontSize * LINE_HEIGHT_RATIO) > 1e-6) return false
+        return after.width >= before.width - 1e-6
+      }),
+      { numRuns: 400 },
+    )
+  })
+})

--- a/src/__tests__/route-contracts.test.ts
+++ b/src/__tests__/route-contracts.test.ts
@@ -262,6 +262,40 @@ describe('simplifyPolyline', () => {
     expect(simplifyPolyline([{ x: 0, y: 0 }, { x: 0.005, y: 0.005 }, { x: 10, y: 0 }]))
       .toEqual([{ x: 0, y: 0 }, { x: 10, y: 0 }])
   })
+
+  // Properties over random polylines (small integer coords so collinear runs and
+  // duplicates occur often). simplifyPolyline is a pure normalizer, so it has
+  // strong invariants: it never grows the line, preserves the endpoints, leaves
+  // no removable point behind (idempotent), and emits no consecutive duplicates.
+  it('is an idempotent, endpoint-preserving, non-growing normalizer', () => {
+    const EPS = 1e-6
+    const ptArb = fc.record({ x: fc.integer({ min: -8, max: 8 }), y: fc.integer({ min: -8, max: 8 }) })
+    fc.assert(
+      fc.property(fc.array(ptArb, { maxLength: 12 }), points => {
+        const out = simplifyPolyline(points)
+        // never grows
+        if (out.length > points.length) return false
+        // endpoints preserved (value-equal) when there is anything to preserve
+        if (points.length > 0) {
+          if (out[0]!.x !== points[0]!.x || out[0]!.y !== points[0]!.y) return false
+          const pe = points[points.length - 1]!, oe = out[out.length - 1]!
+          if (oe.x !== pe.x || oe.y !== pe.y) return false
+        }
+        // no consecutive duplicates remain in a real polyline. The one exception
+        // is a fully-degenerate collapse: a spike [p, q, p] (start == end) reduces
+        // to the 2-point [p, p]. So the invariant is scoped to outputs of length
+        // >= 3 (verified: 0 such dups over 20k random inputs).
+        if (out.length >= 3) {
+          for (let i = 1; i < out.length; i++) {
+            if (Math.abs(out[i]!.x - out[i - 1]!.x) < EPS && Math.abs(out[i]!.y - out[i - 1]!.y) < EPS) return false
+          }
+        }
+        // idempotent: a second pass changes nothing
+        return JSON.stringify(simplifyPolyline(out)) === JSON.stringify(out)
+      }),
+      { numRuns: 500 },
+    )
+  })
 })
 
 describe('certificates', () => {

--- a/src/__tests__/sequence-layout.test.ts
+++ b/src/__tests__/sequence-layout.test.ts
@@ -227,6 +227,62 @@ describe('sequence layout – block spacing', () => {
   })
 })
 
+describe('sequence layout – spacing properties (over random sequences)', () => {
+  const ACTORS = ['A', 'B', 'C', 'D'] as const
+
+  // Generalizes "messages outside blocks are spaced at the base row height":
+  // for ANY block-free sequence, every consecutive message gap is exactly 40.
+  it('block-free sequences space every message at exactly the base row height', () => {
+    const arb = fc.record({
+      actorCount: fc.integer({ min: 2, max: 4 }),
+      msgs: fc.array(fc.record({ f: fc.nat(3), t: fc.nat(3), dash: fc.boolean() }), { minLength: 2, maxLength: 8 }),
+    })
+    fc.assert(
+      fc.property(arb, ({ actorCount, msgs }) => {
+        const actors = ACTORS.slice(0, actorCount)
+        const lines = ['sequenceDiagram', ...actors.map(a => `  participant ${a}`)]
+        for (const m of msgs) {
+          const from = actors[m.f % actorCount]!, to = actors[m.t % actorCount]!
+          if (from === to) continue
+          lines.push(`  ${from}${m.dash ? '-->>' : '->>'}${to}: x`)
+        }
+        const result = layout(lines.join('\n'))
+        for (let i = 1; i < result.messages.length; i++) {
+          if (result.messages[i]!.y - result.messages[i - 1]!.y !== 40) return false
+        }
+        return true
+      }),
+      { numRuns: 400 },
+    )
+  })
+
+  // Robustness over the richer generator (blocks, dividers, notes, self-calls):
+  // message rows stay finite and strictly ordered, never spaced tighter than the
+  // base row height — blocks/dividers/notes only ever ADD space.
+  it('messages stay finite and ordered with gaps never below the base height', () => {
+    const arb = fc.record({
+      actorCount: fc.integer({ min: 2, max: 4 }),
+      messageCount: fc.integer({ min: 1, max: 6 }),
+      noteMask: fc.array(fc.boolean(), { minLength: 6, maxLength: 6 }),
+      notePicks: fc.array(fc.nat(2), { minLength: 6, maxLength: 6 }),
+      selfMask: fc.array(fc.boolean(), { minLength: 6, maxLength: 6 }),
+    })
+    fc.assert(
+      fc.property(arb, input => {
+        const result = layout(generatedSequenceSource(input))
+        for (const m of result.messages) if (!Number.isFinite(m.y)) return false
+        for (let i = 1; i < result.messages.length; i++) {
+          // 1e-6 tolerance: gaps accumulate through block/divider offsets, so a
+          // genuine 40 can land at 39.9999… in floating point.
+          if (!(result.messages[i]!.y - result.messages[i - 1]!.y >= 40 - 1e-6)) return false
+        }
+        return true
+      }),
+      { numRuns: 400 },
+    )
+  })
+})
+
 describe('sequence layout – block positioning', () => {
   it('block top is above the first message with room for the header', () => {
     const result = layout(`sequenceDiagram


### PR DESCRIPTION
## What

Strengthen five hand-curated, example-based tests into property-based tests over generators, so they assert their invariant for *all* valid inputs rather than a handful of listed examples.

## Why

No issue — this is test hardening, not a bug fix. Several existing tests pin a *general* invariant (e.g. "duplicate edges never collapse", "a grouped service stays inside its frame") using a few hand-written examples. The repo already proves the value of property-based testing for layout (`layout-rubric.test.ts` runs outline/port oracles over a `randomFlowchart` generator); these five tests are the next-highest-leverage curated cases that a generator covers far more thoroughly.

This was split out of #65 (the issue-#62 duplicate-edge work) to keep that PR focused; only the duplicate-edge-specific ratchets stayed there.

## How

Each test gains a property backed by an offline probe over hundreds–thousands of cases. Where the invariant is absolute it's asserted directly; the sequence cases use the smallest robustly-true bound rather than re-deriving the layout's exact spacing rules.

- **`simplifyPolyline`** (`route-contracts.test.ts`) — random polylines (small integer coords so collinear/duplicate runs occur): idempotent, endpoint-preserving, non-growing, and no consecutive duplicates for outputs of length ≥ 3.
- **`measureMultilineText`** (`multiline-labels.test.ts`) — random multi-line labels: `height == lineCount × lineHeight`, `width == widest line`, all finite; and metamorphically, adding a line adds exactly one `lineHeight` and never shrinks the width.
- **Architecture containment** (`architecture-layout.test.ts`) — random multi-group `architecture-beta` diagrams: every service/junction declared `in` a group lies inside that group's frame.
- **ASCII line-style glyphs** (`ascii-edge-styles.test.ts`) — random LR edges × {solid, dotted, thick} × {unicode, ascii}: the chosen style renders its own glyph and never leaks another style's dashed/thick glyph.
- **Sequence spacing** (`sequence-layout.test.ts`) — block-free sequences space every message at exactly the base row height (40); richer sequences (blocks, dividers, notes, self-calls) stay finite and strictly ordered with gaps never below the base.

## Testing

- [x] New tests pass — all five files green (`bun test src/__tests__/{route-contracts,multiline-labels,architecture-layout,ascii-edge-styles,sequence-layout}.test.ts`).
- [x] **Flake-hunted** — ran the five files in a loop; the only flaky property (`simplifyPolyline`) was traced to a real spike-collapse case and fixed, then 0 flakes across 15 further loops.
- [x] Full suite passes — only the 3 pre-existing environmental failures (Playwright chromium binary absent; an `agent-doc-sync` test expecting `.claude`/`.agents` absent, which the agent harness creates locally), identical on `main`.
- [x] Each property is non-vacuous — verified the generators actually exercise the assertions (e.g. the sequence properties evaluate ~1,800 real message-pairs over 400 cases, not zero).

Writing these caught **three test-only bugs** the generators surfaced — exactly the point of the exercise:
1. a float-associativity mismatch in the multiline height assertion (`lines × fontSize × ratio` vs the code's `lines × (fontSize × ratio)`), fixed by asserting against the returned `lineHeight`;
2. a float-epsilon in the sequence gap bound (a genuine 40 landing at 39.9999…);
3. `simplifyPolyline`'s spike-collapse: `[p, q, p]` reduces to the degenerate 2-point `[p, p]`, so the no-duplicate invariant is scoped to outputs of length ≥ 3 (0 such dups over 20k random inputs).

## Risk

Test-only change — no production code is touched, so it cannot affect rendered output. The properties use random seeds like the repo's existing oracles; the one flaky property was identified and stabilized before this PR (no remaining nondeterminism observed over 15+ full loops).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HLUotMK7odkZNCpx7HkNcr

---
_Generated by [Claude Code](https://claude.ai/code/session_01HLUotMK7odkZNCpx7HkNcr)_