### PR TITLE
Harden layout & parser test contracts from an audit (#37, #36, #41, #25)

### DIFF
--- a/eval/sabotage/route-regressions.ts
+++ b/eval/sabotage/route-regressions.ts
@@ -59,6 +59,18 @@ const cases: SabotageCase[] = [
     command: ['bun', 'test', 'src/__tests__/subgraph-direction.test.ts', 'src/__tests__/subgraph-hierarchy-exhaustive.test.ts', '--timeout', '120000'],
     expectedFailure: /nested subgraph-id edges under direction overrides attach to the container|ROUTE_CONTAINER_MISANCHOR|edge should be present/,
   },
+  {
+    // Issue #25 acceptance criterion 3: "disabling the direct-lane proof
+    // reintroduces a failing test." Neuter tryStraighten (the repair the
+    // direct-lane proof authorizes) so it never straightens; the MFA forward
+    // lanes then keep their doglegs and the criterion-1 straightness test fails.
+    name: 'disabling the direct-lane straightening proof reintroduces MFA hitches',
+    file: 'src/route-contracts.ts',
+    oldText: '  if (!srcSpan || !tgtSpan) return { applied: false, blockers: [] }\n',
+    newText: '  if (true || !srcSpan || !tgtSpan) return { applied: false, blockers: [] }\n',
+    command: ['bun', 'test', 'src/__tests__/route-contracts.test.ts', '--timeout', '120000'],
+    expectedFailure: /MFA\/login regression.*straight horizontal lane|isStraightHorizontal/,
+  },
 ]
 
 function run(command: string[], cwd: string, options: { expectFailure?: boolean; timeout?: number } = {}) {

--- a/src/__tests__/diagram-family-citizenship.test.ts
+++ b/src/__tests__/diagram-family-citizenship.test.ts
@@ -4,6 +4,8 @@ import { join } from 'node:path'
 
 import { BUILTIN_FAMILY_METADATA, type BuiltinFamilyId } from '../agent/families.ts'
 import { MUTATION_OPS_BY_FAMILY } from '../cli/index.ts'
+import { parseMermaid, verifyMermaid, serializeMermaid, renderMermaidSVG, renderMermaidASCII } from '../agent/index.ts'
+import { FAMILY_COUNT_FIXTURES } from './helpers/family-count-fixtures.ts'
 
 const REPO = join(import.meta.dir, '..', '..')
 const MATRIX_PATH = join(REPO, 'docs/contributing/diagram-family-citizenship.matrix.json')
@@ -32,7 +34,11 @@ const EXPECTED_SURFACES = [
   'mutationLane',
 ] as const
 
-const TRACKED_EXCEPTION_SURFACES = new Set(['stableRegions', 'upstreamHarvest', 'divergenceLedger', 'mutationLane'])
+// Previously four surfaces could ship as tracked 'exception's. The backfill (#49)
+// drove the matrix to zero exceptions, so the contract now admits NONE: every
+// family must satisfy every surface. Any regression back to an 'exception' fails
+// both "every exception is tracked" and "core surfaces cannot be deferred". (#41)
+const TRACKED_EXCEPTION_SURFACES = new Set<SurfaceId>()
 
 type SurfaceId = typeof EXPECTED_SURFACES[number]
 
@@ -255,6 +261,47 @@ describe('diagram-family citizenship ratchet (issue #41)', () => {
         expect({ family, surface, status: row.cells[surface].status }).toEqual({ family, surface, status: 'satisfied' })
       }
     }
+  })
+
+  test('behavioral citizenship: every family parses, verifies, renders SVG+ASCII, round-trips, and is deterministic', () => {
+    // Most matrix cells are evidenced by file-existence only. This test makes the
+    // core surfaces (detectionParse, serializeRoundTrip, verifyRenderSeam,
+    // svgRender, asciiUnicodeRender, determinism) behavioral: it actually exercises
+    // the capability for every registered family, so a family that regressed while
+    // its evidence file still existed would now fail here. (#41)
+    const registryIds = new Set<string>(BUILTIN_FAMILY_METADATA.map(f => f.id))
+    const covered = new Set<string>()
+    for (const fx of FAMILY_COUNT_FIXTURES) {
+      const parsed = parseMermaid(fx.source)
+      expect({ family: fx.family, parseOk: parsed.ok }).toEqual({ family: fx.family, parseOk: true })
+      if (!parsed.ok) continue
+      covered.add(fx.family)
+
+      // detectionParse: detected as the right family.
+      expect({ family: fx.family, kind: parsed.value.kind }).toEqual({ family: fx.family, kind: fx.family })
+      // verifyRenderSeam: structural verify passes.
+      expect({ family: fx.family, verifyOk: verifyMermaid(fx.source).ok }).toEqual({ family: fx.family, verifyOk: true })
+      // serializeRoundTrip: serialize → reparse → serialize is stable.
+      const serialized = serializeMermaid(parsed.value)
+      const reparsed = parseMermaid(serialized)
+      expect({ family: fx.family, reparseOk: reparsed.ok }).toEqual({ family: fx.family, reparseOk: true })
+      if (reparsed.ok) {
+        expect({ family: fx.family, stable: serializeMermaid(reparsed.value) === serialized })
+          .toEqual({ family: fx.family, stable: true })
+      }
+      // svgRender: emits a real SVG document.
+      const svg = renderMermaidSVG(fx.source)
+      expect({ family: fx.family, svg: svg.includes('<svg') && svg.length > 100 })
+        .toEqual({ family: fx.family, svg: true })
+      // asciiUnicodeRender: emits non-empty text.
+      expect({ family: fx.family, ascii: renderMermaidASCII(fx.source).trim().length > 0 })
+        .toEqual({ family: fx.family, ascii: true })
+      // determinism: identical SVG across repeated renders.
+      expect({ family: fx.family, deterministic: renderMermaidSVG(fx.source) === svg })
+        .toEqual({ family: fx.family, deterministic: true })
+    }
+    // No registered family is silently skipped: each must have a behavioral fixture.
+    expect([...registryIds].filter(id => !covered.has(id)).sort()).toEqual([])
   })
 
   test('family-sensitive cells cite load-bearing family-specific evidence', () => {

--- a/src/__tests__/flowchart-parser-conformance.test.ts
+++ b/src/__tests__/flowchart-parser-conformance.test.ts
@@ -150,6 +150,39 @@ describe('flowchart parser conformance safety floor (issue #36)', () => {
     expect(verifyMermaid(source).warnings).toContainEqual(expect.objectContaining({ code: 'UNSUPPORTED_SYNTAX', syntax: 'flowchart_interaction_directive', line: 3 }))
   })
 
+  test('markdown-string labels are source-preserved and warned, never silently dropped', () => {
+    const source = 'flowchart LR\n  A["`**bold** text`"] --> B\n'
+    const diagram = parseAgent(source)
+    expect(diagram.body.kind).toBe('opaque')
+    expect(serializeMermaid(diagram)).toBe(source)
+    const verify = verifyMermaid(source)
+    expect(verify.ok).toBe(true)
+    expect(verify.warnings).toContainEqual(expect.objectContaining({ code: 'UNSUPPORTED_SYNTAX', syntax: 'flowchart_markdown_string', line: 2 }))
+  })
+
+  test('node metadata @{ shape } is preserved losslessly AND warned loudly (issue #36), no phantom nodes', () => {
+    const source = 'flowchart LR\n  A@{ shape: rounded, label: "Start" }\n  A --> B\n'
+    const graph = parseGraph(source)
+    expect([...graph.nodes.keys()].sort()).toEqual(['A', 'B'])
+    expect(graph.nodes.has('shape')).toBe(false)
+    expect(graph.nodes.has('label')).toBe(false)
+
+    const diagram = parseAgent(source)
+    expect(diagram.body.kind).toBe('opaque')
+    expect(serializeMermaid(diagram)).toBe(source)
+
+    const verify = verifyMermaid(source)
+    // Advisory (Tier-3): the warning is loud but never flips verify.ok and never drops source.
+    expect(verify.ok).toBe(true)
+    expect(verify.warnings).toContainEqual(expect.objectContaining({ code: 'UNSUPPORTED_SYNTAX', syntax: 'flowchart_node_metadata', line: 2 }))
+
+    // Edge metadata must NOT be reclassified as node metadata.
+    const edgeMeta = verifyMermaid('flowchart LR\n  A e1@==> B\n  e1@{ animate: true }\n').warnings
+      .map(w => w.code === 'UNSUPPORTED_SYNTAX' ? w.syntax : '').filter(Boolean)
+    expect(edgeMeta).toContain('flowchart_edge_metadata')
+    expect(edgeMeta).not.toContain('flowchart_node_metadata')
+  })
+
   test('class shorthand before compact arrows keeps the edge and escaped classDef commas', () => {
     const graph = parseGraph('flowchart LR\n  A:::animate-->B\n  classDef animate stroke-dasharray: 9\\,5,stroke:#333;')
     expect(graph.edges.map(e => `${e.source}->${e.target}`)).toEqual(['A->B'])

--- a/src/__tests__/helpers/edge-vocabulary.ts
+++ b/src/__tests__/helpers/edge-vocabulary.ts
@@ -1,0 +1,50 @@
+// Shared flowchart edge-syntax vocabulary for property generators (issue #37).
+//
+// Issue #37 asks the property-test generators to stop sampling only the plain
+// solid arrow `-->` and instead exercise the *wider* edge-syntax vocabulary the
+// parser supports, so the existing layout oracles (outline, port, hitch, rubric)
+// run across every line style, direction, and marker — not just one operator.
+//
+// Each form's parsed shape (style/markers) is asserted by a coverage test so the
+// generators provably sample real, distinct edges rather than forms the parser
+// silently collapses. Metadata here matches the parser's actual output.
+
+import type { EdgeMarker, EdgeStyle } from '../../types.ts'
+
+export interface EdgeForm {
+  /** Human-readable name, used in coverage-test failure messages. */
+  name: string
+  /** The Mermaid edge operator, e.g. `-.->`. */
+  op: string
+  style: EdgeStyle
+  startMarker?: EdgeMarker
+  endMarker?: EdgeMarker
+  /** Whether a `|label|` pipe label is valid after this operator. */
+  allowsPipeLabel: boolean
+}
+
+// Solid / dotted / thick line styles × uni- and bi-directional × arrow / circle /
+// cross markers, plus no-arrowhead links and the invisible link. All confirmed to
+// parse to the metadata below and to keep endpoints on the shape outline.
+export const EDGE_FORMS: readonly EdgeForm[] = [
+  { name: 'solid arrow', op: '-->', style: 'solid', endMarker: 'arrow', allowsPipeLabel: true },
+  { name: 'dotted arrow', op: '-.->', style: 'dotted', endMarker: 'arrow', allowsPipeLabel: true },
+  { name: 'thick arrow', op: '==>', style: 'thick', endMarker: 'arrow', allowsPipeLabel: true },
+  { name: 'solid bidirectional', op: '<-->', style: 'solid', startMarker: 'arrow', endMarker: 'arrow', allowsPipeLabel: true },
+  { name: 'dotted bidirectional', op: '<-.->', style: 'dotted', startMarker: 'arrow', endMarker: 'arrow', allowsPipeLabel: true },
+  { name: 'thick bidirectional', op: '<==>', style: 'thick', startMarker: 'arrow', endMarker: 'arrow', allowsPipeLabel: true },
+  { name: 'circle endpoint', op: '--o', style: 'solid', endMarker: 'circle', allowsPipeLabel: false },
+  { name: 'cross endpoint', op: '--x', style: 'solid', endMarker: 'cross', allowsPipeLabel: false },
+  { name: 'circle-to-circle', op: 'o--o', style: 'solid', startMarker: 'circle', endMarker: 'circle', allowsPipeLabel: false },
+  { name: 'cross-to-cross', op: 'x--x', style: 'solid', startMarker: 'cross', endMarker: 'cross', allowsPipeLabel: false },
+  { name: 'open solid link', op: '---', style: 'solid', allowsPipeLabel: false },
+  { name: 'open dotted link', op: '-.-', style: 'dotted', allowsPipeLabel: false },
+  { name: 'open thick link', op: '===', style: 'thick', allowsPipeLabel: false },
+  { name: 'invisible link', op: '~~~', style: 'invisible', allowsPipeLabel: false },
+]
+
+/** Render one edge line `A op B`, attaching a `|label|` only where the form allows it. */
+export function renderEdgeLine(a: string, b: string, form: EdgeForm, label = ''): string {
+  const pipe = label && form.allowsPipeLabel ? `|${label}|` : ''
+  return `${a} ${form.op}${pipe} ${b}`
+}

--- a/src/__tests__/heuristic-tracker.test.ts
+++ b/src/__tests__/heuristic-tracker.test.ts
@@ -14,6 +14,10 @@
 
 import { describe, test, expect } from 'bun:test'
 import { scoreAll, loadBaseline, compareToBaseline } from '../../eval/heuristic-tracker/run.ts'
+import { trackedExamples } from '../../eval/heuristic-tracker/catalog.ts'
+import { parseMermaid } from '../parser.ts'
+import { layoutGraphSync } from '../layout-engine.ts'
+import { auditRouteContracts } from '../route-contracts.ts'
 
 describe('heuristic-tracker ratchet', () => {
   const current = scoreAll()
@@ -32,5 +36,37 @@ describe('heuristic-tracker ratchet', () => {
     const baselineKeys = Object.keys(baseline).length
     expect(baselineKeys).toBeGreaterThan(0)
     expect(baselineKeys).toBe(Object.keys(current).length)
+  })
+
+  // Issue #25 acceptance criterion 7: "corpus diff shows no increase in unexplained
+  // bends, edge crossings, or label overlap." Unexplained bends and label overlap
+  // are STRUCTURAL route-contract findings that are deterministic across runtimes
+  // (verified stable), unlike raw edge-crossing COUNTS, which depend on non-portable
+  // ELK float geometry (see the file header) and stay a local soft metric, not a gate.
+  //
+  // This is a no-increase ratchet: the corpus may currently carry the known
+  // offenders below; any NEW unexplained-bend/label-overlap finding fails, and
+  // fixing a known one fails too (so the baseline only ever shrinks).
+  const KNOWN_ROUTE_CONTRACT_OFFENDERS = [
+    'contact-sheet/AJ: ROUTE_LABEL_ON_SHARED_TRUNK D->E',
+  ]
+
+  test('no NEW unexplained-bend or label-overlap findings across the tracked corpus (criterion 7)', () => {
+    const offenders: string[] = []
+    for (const ex of trackedExamples()) {
+      const key = `${ex.group}/${ex.name}`
+      try {
+        const graph = parseMermaid(ex.source)
+        const positioned = layoutGraphSync(graph)
+        for (const f of auditRouteContracts(positioned, graph)) {
+          if (f.code === 'ROUTE_UNEXPLAINED_BEND' || f.code === 'ROUTE_LABEL_ON_SHARED_TRUNK') {
+            offenders.push(`${key}: ${f.code} ${f.edge}`)
+          }
+        }
+      } catch (e) {
+        offenders.push(`${key}: layout error ${String(e).slice(0, 40)}`)
+      }
+    }
+    expect(offenders.sort()).toEqual([...KNOWN_ROUTE_CONTRACT_OFFENDERS].sort())
   })
 })

--- a/src/__tests__/layout-rubric.test.ts
+++ b/src/__tests__/layout-rubric.test.ts
@@ -15,6 +15,7 @@ import { layoutGraphSync } from '../layout-engine.ts'
 import { parseMermaid } from '../parser.ts'
 import { assessLayout, hardViolations, onShapeOutline } from '../layout-rubric.ts'
 import { shapePorts, diamondFacetPorts } from '../route-contracts.ts'
+import { EDGE_FORMS, renderEdgeLine } from './helpers/edge-vocabulary.ts'
 import { complicatedFixtures, simpleFixtures } from '../../eval/visual-rubric/fixtures.ts'
 import { scoreFixture } from '../../eval/visual-rubric/run.ts'
 
@@ -111,6 +112,12 @@ const SHAPE_WRAPPERS = [
   (l: string) => `[\\${l}\\]`,
 ] as const
 
+// The seeded counting ratchets at the bottom of this file pin
+// `fc.sample(randomFlowchart, { seed: 4242 })` against calibrated
+// crossing/separation baselines, so this generator's fast-check shape must stay
+// stable — plain solid `-->` only. Widening it (e.g. adding an edge `form`)
+// reshuffles the seeded draw and silently moves those baselines; the geometric
+// oracles use `randomFlowchartWideEdges` below instead.
 const randomFlowchart = fc
   .record({
     direction: fc.constantFrom('LR', 'TD', 'RL', 'BT'),
@@ -130,6 +137,37 @@ const randomFlowchart = fc
       .map(({ a, b, labeled }) => [names[a % nodeCount]!, names[b % nodeCount]!, labeled] as const)
       .filter(([a, b]) => a !== b)
       .map(([a, b, labeled]) => `  ${a} ${labeled ? '-- go ' : ''}--> ${b}`)
+    if (edges.length === 0) edges.push(`  ${names[0]} --> ${names[1]}`)
+    return `flowchart ${direction}\n${decl}\n${edges.join('\n')}`
+  })
+
+// Same scaffolding as `randomFlowchart`, but every edge samples the full
+// edge-syntax vocabulary (issue #37): all three line styles (solid/dotted/thick),
+// uni- and bi-directional, and every marker (arrow/circle/cross), plus open and
+// invisible links. The geometric oracles (endpoint-on-outline, ports, hitches,
+// rubric) consume this so they run across the whole vocabulary — markers trim
+// where an edge meets the shape outline, so this is real geometric coverage, not
+// just cosmetic styling. Kept separate from `randomFlowchart` so the seeded
+// counting ratchets stay pinned to their calibrated sample.
+const randomFlowchartWideEdges = fc
+  .record({
+    direction: fc.constantFrom('LR', 'TD', 'RL', 'BT'),
+    nodeCount: fc.integer({ min: 3, max: 6 }),
+    shapePicks: fc.array(fc.nat(SHAPE_WRAPPERS.length - 1), { minLength: 6, maxLength: 6 }),
+    edgePicks: fc.array(
+      fc.record({ a: fc.nat(5), b: fc.nat(5), labeled: fc.boolean(), form: fc.nat(EDGE_FORMS.length - 1) }),
+      { minLength: 2, maxLength: 8 },
+    ),
+  })
+  .map(({ direction, nodeCount, shapePicks, edgePicks }) => {
+    const names = Array.from({ length: nodeCount }, (_, i) => `N${i}`)
+    const decl = names
+      .map((n, i) => `  ${n}${SHAPE_WRAPPERS[shapePicks[i % shapePicks.length]!]!(`n${i}`)}`)
+      .join('\n')
+    const edges = edgePicks
+      .map(({ a, b, labeled, form }) => [names[a % nodeCount]!, names[b % nodeCount]!, labeled, form] as const)
+      .filter(([a, b]) => a !== b)
+      .map(([a, b, labeled, form]) => `  ${renderEdgeLine(a, b, EDGE_FORMS[form]!, labeled ? 'go' : '')}`)
     if (edges.length === 0) edges.push(`  ${names[0]} --> ${names[1]}`)
     return `flowchart ${direction}\n${decl}\n${edges.join('\n')}`
   })
@@ -156,10 +194,31 @@ function polylinesCross(p: RubricPt[], q: RubricPt[]): boolean {
   return false
 }
 
+describe('issue #37 — property generators sample the full edge-syntax vocabulary', () => {
+  it('every sampled edge form parses to its declared style and markers (not silently collapsed)', () => {
+    for (const form of EDGE_FORMS) {
+      const source = `flowchart LR\n  A[a]\n  B[b]\n  ${renderEdgeLine('A', 'B', form)}`
+      const positioned = layoutGraphSync(parseMermaid(source))
+      expect({ form: form.name, edges: positioned.edges.length }).toEqual({ form: form.name, edges: 1 })
+      const e = positioned.edges[0]!
+      expect({ form: form.name, style: e.style }).toEqual({ form: form.name, style: form.style })
+      expect({ form: form.name, startMarker: e.startMarker }).toEqual({ form: form.name, startMarker: form.startMarker })
+      expect({ form: form.name, endMarker: e.endMarker }).toEqual({ form: form.name, endMarker: form.endMarker })
+    }
+  })
+
+  it('the vocabulary spans all three line styles, both directions, and every marker', () => {
+    expect(new Set(EDGE_FORMS.map(f => f.style))).toEqual(new Set(['solid', 'dotted', 'thick', 'invisible']))
+    expect(EDGE_FORMS.some(f => f.startMarker === 'arrow' && f.endMarker === 'arrow')).toBe(true)
+    expect(new Set(EDGE_FORMS.flatMap(f => [f.startMarker, f.endMarker].filter(Boolean)))).toEqual(new Set(['arrow', 'circle', 'cross']))
+    expect(EDGE_FORMS.some(f => f.startMarker === undefined && f.endMarker === undefined)).toBe(true)
+  })
+})
+
 describe('property: ports and outlines (mathematical oracles over random diagrams)', () => {
   it('every edge endpoint lies on the rendered shape outline — all shapes, all directions', () => {
     fc.assert(
-      fc.property(randomFlowchart, source => {
+      fc.property(randomFlowchartWideEdges, source => {
         const graph = parseMermaid(source)
         const positioned = layoutGraphSync(graph)
         const nodeMap = new Map(positioned.nodes.map(n => [n.id, n]))
@@ -180,7 +239,7 @@ describe('property: ports and outlines (mathematical oracles over random diagram
 
   it('certificate port fields always agree with the geometric port oracle', () => {
     fc.assert(
-      fc.property(randomFlowchart, source => {
+      fc.property(randomFlowchartWideEdges, source => {
         const graph = parseMermaid(source)
         const positioned = layoutGraphSync(graph)
         const nodeMap = new Map(positioned.nodes.map(n => [n.id, n]))
@@ -215,7 +274,7 @@ describe('property: ports and outlines (mathematical oracles over random diagram
 
   it('no hitch survives: no edge bends while a clear lane exists for it', () => {
     fc.assert(
-      fc.property(randomFlowchart, source => {
+      fc.property(randomFlowchartWideEdges, source => {
         const graph = parseMermaid(source)
         const positioned = layoutGraphSync(graph)
         return assessLayout(graph, positioned).metrics.hitches === 0
@@ -226,7 +285,7 @@ describe('property: ports and outlines (mathematical oracles over random diagram
 
   it('every hard rubric metric is zero for arbitrary small diagrams', () => {
     fc.assert(
-      fc.property(randomFlowchart, source => {
+      fc.property(randomFlowchartWideEdges, source => {
         const graph = parseMermaid(source)
         const positioned = layoutGraphSync(graph)
         return hardViolations(assessLayout(graph, positioned)).length === 0

--- a/src/__tests__/route-contracts.test.ts
+++ b/src/__tests__/route-contracts.test.ts
@@ -7,6 +7,7 @@ import { onShapeOutline } from '../layout-rubric.ts'
 import { measureMultilineText } from '../text-metrics.ts'
 import { layoutMermaid, parseMermaid as agentParse, verifyMermaid } from '../agent/index.ts'
 import type { AnyPort, Point, PositionedEdge, PositionedGraph, PositionedGroup, PositionedNode } from '../types.ts'
+import { EDGE_FORMS, renderEdgeLine } from './helpers/edge-vocabulary.ts'
 
 /** The MFA/login regression from issue #25 — every dogleg here had a clear direct lane. */
 const MFA_SOURCE = `flowchart LR
@@ -1768,7 +1769,9 @@ describe('route contracts — properties', () => {
     .record({
       nodeCount: fc.integer({ min: 3, max: 7 }),
       edgePicks: fc.array(
-        fc.tuple(fc.nat(6), fc.nat(6), fc.constantFrom('', '', '', 'yes', 'No', 'on error')),
+        // The 4th element samples the wider edge-syntax vocabulary (issue #37):
+        // every line style, direction, and marker reaches the route contracts.
+        fc.tuple(fc.nat(6), fc.nat(6), fc.constantFrom('', '', '', 'yes', 'No', 'on error'), fc.nat(EDGE_FORMS.length - 1)),
         { minLength: 2, maxLength: 10 },
       ),
       direction: fc.constantFrom('LR', 'TD', 'RL', 'BT'),
@@ -1776,9 +1779,9 @@ describe('route contracts — properties', () => {
     .map(({ nodeCount, edgePicks, direction }) => {
       const names = Array.from({ length: nodeCount }, (_, i) => `N${i}`)
       const lines = edgePicks
-        .map(([a, b, label]) => [names[a % nodeCount]!, names[b % nodeCount]!, label] as const)
+        .map(([a, b, label, form]) => [names[a % nodeCount]!, names[b % nodeCount]!, label, form] as const)
         .filter(([a, b]) => a !== b)
-        .map(([a, b, label]) => label ? `  ${a} -- ${label} --> ${b}` : `  ${a} --> ${b}`)
+        .map(([a, b, label, form]) => `  ${renderEdgeLine(a, b, EDGE_FORMS[form]!, label)}`)
       if (lines.length === 0) lines.push(`  ${names[0]} --> ${names[1]}`)
       return `flowchart ${direction}\n${lines.join('\n')}`
     })

--- a/src/agent/flowchart-unsupported.ts
+++ b/src/agent/flowchart-unsupported.ts
@@ -26,6 +26,9 @@ export function flowchartUnsupportedSyntaxWarnings(source: string): LayoutWarnin
     if (isUnsupportedEdgeMetadataStatement(text)) {
       warnings.push({ code: 'UNSUPPORTED_SYNTAX', line, syntax: 'flowchart_edge_metadata', message: 'Flowchart edge metadata is preserved as source but ignored by the local renderer/layout.' })
     }
+    if (isNodeMetadataStatement(text)) {
+      warnings.push({ code: 'UNSUPPORTED_SYNTAX', line, syntax: 'flowchart_node_metadata', message: 'Flowchart node metadata (@{ shape: ... }) is preserved as source and its label is rendered, but the v11 shape vocabulary is not yet modeled by the local renderer/layout.' })
+    }
     if (isFlowchartInteractionDirective(text)) {
       warnings.push({ code: 'UNSUPPORTED_SYNTAX', line, syntax: 'flowchart_interaction_directive', message: 'Flowchart click/href directives are preserved as source but ignored by the local renderer for security and layout.' })
     }
@@ -64,7 +67,20 @@ function isUnsupportedEdgeMetadataStatement(statement: string): boolean {
   const metadata = match[1]!
   // Node metadata is source-preserved by the opaque fallback. Edge metadata
   // has animate/curve semantics only Mermaid itself understands today.
-  return !/(?:^|,)\s*(?:shape|label|icon|img)\s*:/i.test(metadata)
+  return !isNodeMetadata(metadata)
+}
+
+// `id@{ shape: ... }` node metadata (Mermaid v11.3+). Preserved losslessly by the
+// opaque fallback (issue #29), but still unmodeled — so it is surfaced loudly,
+// like every other unsupported flowchart construct (issue #36), rather than kept
+// silent. Advisory (Tier-3): it never flips verify.ok and never drops source.
+function isNodeMetadataStatement(statement: string): boolean {
+  const match = statement.trim().match(/^[\w-]+@\s*\{([\s\S]*)\}\s*$/)
+  return match ? isNodeMetadata(match[1]!) : false
+}
+
+function isNodeMetadata(metadata: string): boolean {
+  return /(?:^|,)\s*(?:shape|label|icon|img)\s*:/i.test(metadata)
 }
 
 function maskFlowchartLabels(statement: string): string {


### PR DESCRIPTION
## What

Four small, independent hardening changes surfaced by a layout/parser contract audit: widen the property-test generators to the full edge-syntax vocabulary (#37), make `@{shape}` node metadata warn loudly (#36), tighten the diagram-family citizenship ratchet (#41), and pin two route-regression proofs (#25). 7 of 8 files are tests/harness; the only production change is a single advisory warning.

## Why

Each finding is a place where the suite could stay green while a real capability silently regressed:

- **#37 — the property oracles only ever saw one operator.** The outline, port, hitch, and rubric oracles were generated from the plain solid arrow `-->` alone. Dotted/thick lines, bidirectional arrows, circle/cross markers, and invisible links never reached them, so a routing bug specific to those forms would pass unnoticed.
- **#36 — silent unsupported syntax.** `@{ shape: ... }` node metadata was preserved as source but emitted no `UNSUPPORTED_SYNTAX` warning, unlike every other unmodeled construct — a silent gap that misleads an agent into thinking the v11 shape was understood and laid out.
- **#41 — the citizenship ratchet had a soft allowlist.** Core citizenship surfaces could be deferred as "tracked exceptions," and nothing asserted that every family actually parses → verifies → renders → round-trips.
- **#25 — two route guarantees were unproven.** The direct-lane straightening proof (criterion 3) and the clean-corpus route findings (criterion 7) had no test that fails when the guarantee is removed.

Addresses #37, #36, #41, #25.

## How

One load-bearing test per finding (for #36, one warning plus its test), matching existing patterns and naming:

- **#37** — new shared `src/__tests__/helpers/edge-vocabulary.ts` enumerates 14 distinct edge forms with their parsed style/marker metadata. In `route-contracts.test.ts` the property generator now samples `EDGE_FORMS` instead of hardcoding `-->`. In `layout-rubric.test.ts` the wide vocabulary flows through the four geometric oracles (endpoint-on-outline, ports, hitches, rubric) via a dedicated `randomFlowchartWideEdges` — markers trim where an edge meets the outline, so this is real geometric coverage. The original `randomFlowchart` is left byte-identical so the seeded crossing/separation ratchets recently added on `main` (#62/#65) stay pinned to their calibrated sample. Coverage tests pin each form's parsed semantics.
- **#36** — `flowchart-unsupported.ts` now emits an advisory `flowchart_node_metadata` `UNSUPPORTED_SYNTAX` warning (a helper distinguishes node metadata from edge metadata). The warning is advisory only — it never flips `verify.ok` and never drops source. Also added the missing markdown-string-label warning test.
- **#41** — emptied the `TRACKED_EXCEPTION_SURFACES` allowlist so no core surface can be re-deferred, and added a behavioral test that parses, verifies, serializes/round-trips, renders SVG + ASCII, and checks determinism for every registered family using real fixtures.
- **#25** — added a sabotage case that disables the direct-lane straightening proof (criterion 3), and a portable no-increase corpus ratchet for unexplained-bend / label-overlap findings (criterion 7). Crossing counts are intentionally left ungated because they are not float-portable across platforms.

## Testing

- Rebased onto current `main`. Full suite green: `bun test src/__tests__/` → **4087 pass / 0 fail**; `bunx tsc --noEmit` clean; no golden snapshots moved by this PR.
- **Each change verified load-bearing (revert → red, restore → green):**
  - **#36** — remove the warning push in `flowchart-unsupported.ts` → the node-metadata conformance test fails; restores clean.
  - **#41** — flip one matrix cell to `exception` → 4 citizenship tests fail, including the now-tightened "core surfaces cannot be deferred as exceptions."
  - **#25** — `bun run sabotage:routes` → **5/5** cases fail-on-revert, including the new "disabling the direct-lane straightening proof reintroduces MFA hitches."
  - **#37** — the coverage tests assert each edge form parses to its declared style and markers, so they fail if the parser silently collapses a form.

## Integration with main (#65)

While this branch was open, `main` merged #65 (duplicate/parallel-edge lane routing) which added seeded `fc.sample(randomFlowchart, { seed: 4242 })` crossing/separation ratchets calibrated against the solid-`-->` generator. Naively widening that generator reshuffles the seeded draw and silently moves those baselines. The rebase resolves this by keeping `randomFlowchart` byte-identical for #65's ratchets and routing the wide vocabulary through a separate `randomFlowchartWideEdges` consumed only by the geometric oracles — so #65's baselines stay pinned and #37's coverage is fully delivered.

## Visual evidence

None — and deliberately so. There is no rendered-geometry change: 7 of 8 files are tests/harness, and the single production change only *adds* an advisory warning string. Layout determinism is unchanged and **no golden SVG/ASCII snapshots moved** by this PR, which is the honest evidence here rather than padding the PR with near-identical before/after renders.

## Risk

Low. Only `src/agent/flowchart-unsupported.ts` is production code, and its change is purely additive (a new advisory warning); a test asserts it never flips `verify.ok` or drops source. Everything else tightens or extends tests. The full suite passes with no snapshot movement.

Deliberately out of scope: an edge-ordering experiment for #38 was prototyped and discarded after it showed no measurable crossing benefit and regressed bend/straightness on ~7 diagrams.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015ePdiBNiMpPWC3hYLoQExS