### PR TITLE
Guard against comparison.md ↔ differences.ts diagram-family drift

### DIFF
--- a/src/__tests__/comparison-differences-sync.test.ts
+++ b/src/__tests__/comparison-differences-sync.test.ts
@@ -1,0 +1,69 @@
+// Drift guard for the diagram-family coverage facts.
+//
+// docs/comparison.md and scripts/site/differences.ts both describe how many
+// diagram families this fork renders and which ones it adds on top of Beautiful
+// Mermaid. differences.ts names comparison.md as its "Content source of truth"
+// in a comment but does NOT read it at build time — it re-states the facts in
+// hand-authored HTML, so the two can silently drift (and the published
+// /differences page would then disagree with the doc).
+//
+// This test pins both surfaces to the runtime family registry
+// (BUILTIN_FAMILY_METADATA), the single source of truth. Adding or removing a
+// renderable family now fails CI unless docs/comparison.md AND
+// scripts/site/differences.ts are both updated to match.
+
+import { describe, test, expect } from 'bun:test'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { BUILTIN_FAMILY_METADATA } from '../agent/families.ts'
+
+const REPO = join(import.meta.dir, '..', '..')
+const read = (rel: string) => readFileSync(join(REPO, rel), 'utf8')
+const asSet = (xs: string[]) => [...xs].map(s => s.trim().toLowerCase()).sort()
+
+// Families upstream Beautiful Mermaid already renders. A stable external fact;
+// the fork-"added" families are everything in the registry beyond these.
+const UPSTREAM_BASE = ['flowchart', 'state', 'sequence', 'class', 'er', 'xychart']
+
+const registryIds = BUILTIN_FAMILY_METADATA.map(f => String(f.id))
+const forkAdded = registryIds.filter(id => !UPSTREAM_BASE.includes(id))
+const total = registryIds.length
+
+describe('comparison.md ↔ differences.ts ↔ family registry sync', () => {
+  test('UPSTREAM_BASE cleanly partitions the registry (guards this test premise)', () => {
+    for (const id of UPSTREAM_BASE) expect(registryIds).toContain(id)
+    expect(asSet([...UPSTREAM_BASE, ...forkAdded])).toEqual(asSet(registryIds))
+  })
+
+  test('docs/comparison.md count and fork-added list track the registry', () => {
+    const md = read('docs/comparison.md')
+    expect(md).toContain(`${total} diagram families`)
+    expect(md).toContain(`beyond the ${total} here`)
+    const cellList = md.match(/those \d+ \+ ([^)|]+)\)/)?.[1]
+    if (cellList === undefined) throw new Error('comparison.md "Diagram types" cell missing the "those N + ..." list')
+    expect(asSet(cellList.split(','))).toEqual(asSet(forkAdded))
+  })
+
+  test('scripts/site/differences.ts NEW_TYPES tracks the registry fork-added families', () => {
+    const ts = read('scripts/site/differences.ts')
+    const start = ts.indexOf('const NEW_TYPES')
+    if (start < 0) throw new Error('differences.ts NEW_TYPES array not found')
+    // NEW_TYPES closes with a "]" at column 0; the architecture entry's inline
+    // "[...]" is mid-line, so the first "\n]" is the array's real terminator.
+    const block = ts.slice(start, ts.indexOf('\n]', start))
+    const ids = [...block.matchAll(/\bid:\s*'([a-z][a-z-]*)'/g)]
+      .map(m => m[1])
+      .filter((id): id is string => id !== undefined)
+    expect(asSet(ids)).toEqual(asSet(forkAdded))
+  })
+
+  test('scripts/site/differences.ts states the total family count in prose', () => {
+    const ts = read('scripts/site/differences.ts').toLowerCase()
+    const WORDS: Record<number, string> = {
+      10: 'ten', 11: 'eleven', 12: 'twelve', 13: 'thirteen', 14: 'fourteen', 15: 'fifteen',
+    }
+    const word = WORDS[total]
+    if (!word) throw new Error(`add the number-word for ${total} to WORDS in this test`)
+    expect(ts).toContain(`outside the ${word} here`)
+  })
+})


### PR DESCRIPTION
## What

Adds `src/__tests__/comparison-differences-sync.test.ts`, a regression guard that pins the diagram-family coverage facts in **`docs/comparison.md`** and **`scripts/site/differences.ts`** to the runtime family registry (`BUILTIN_FAMILY_METADATA`).

## Why

`scripts/site/differences.ts` names `docs/comparison.md` as its *"Content source of truth"* in a comment, but it does **not** read it at build time — it re-states the family facts in hand-authored HTML. So the published `/differences` page and the doc can silently drift from each other and from the actual set of renderable families (e.g. a family is added and only one surface gets updated). Nothing caught that before this test.

*(Surfaced while reviewing PR #27: `differences.ts` cites `comparison.md` but never consumes it.)*

## How

Diffing the two files directly would be brittle (a Markdown table vs. an HTML generator), so the test makes the **registry the single source of truth** and asserts both surfaces agree with it:

- the family **count** is present in `comparison.md` (`"N diagram families"`, `"beyond the N here"`) and in `differences.ts` (`"outside the {word} here"`);
- the **fork-added family set** — registry minus the six upstream Beautiful Mermaid families — matches `comparison.md`'s `"those 6 + …"` cell **and** `differences.ts`'s `NEW_TYPES` array.

Adding or removing a renderable family now fails CI unless both docs are updated. It follows the existing `agent-doc-sync.test.ts` pattern (read repo files, assert against the code registry).

## Testing

- Full gate green locally: `bun test src/__tests__/` → **4085 pass, 7 skip, 0 fail**; `bun x tsc --noEmit` → clean.
- **Discriminating (red→green verified):** dropping `gantt` from `comparison.md`'s cell fails the comparison assertion; typoing the `gantt` id in `differences.ts`'s `NEW_TYPES` fails the differences assertion; both restore to green when reverted.
- Passes the repo's `test-quality-lint` and `agent-substrate-lint` guards.

## Scope & risk

- One new test file (+69 lines). No `src/` runtime, docs, or site-generator changes — it cannot affect behavior or output.
- **Honest framing:** this is a *regression guard*, not a fix for a live bug — there is **no current drift** (`comparison.md` and `differences.ts` already agree at 12 families). Its value is catching the next family change. The one prose-dependent assertion is the number-word check in `differences.ts`; a `WORDS` map makes it fail loudly if a new count needs a word added.