### PR TITLE
npm shipping readiness: fix MCP execute→render_png crash, doc/example breakage, slim tarball

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Published as `agentic-mermaid`; the GitHub repository and Pages path currently r
 
 [Live Demo & Samples](https://adewale.github.io/beautiful-mermaid/) · [Live Editor](https://adewale.github.io/beautiful-mermaid/editor)
 
-Docs: [docs index](./docs/) · [agent guide](./Instructions_for_agents.md) · [agent API cookbook](./docs/agent-api-cookbook.md) · [skills](./skills/) · [fork differences](./docs/fork-differences.md) · [vs Mermaid & Beautiful Mermaid](./docs/comparison.md) · [changelog](./CHANGELOG.md)
+Docs: [docs index](./docs/) · [getting started](./docs/getting-started.md) · [agent guide](./Instructions_for_agents.md) · [agent API cookbook](./docs/agent-api-cookbook.md) · [skills](./skills/) · [fork differences](./docs/fork-differences.md) · [vs Mermaid & Beautiful Mermaid](./docs/comparison.md) · [changelog](./CHANGELOG.md)
 
 </div>
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,6 +6,7 @@ This directory holds the long-form documentation. The root README is intentional
 
 | Doc | Purpose |
 |---|---|
+| [`getting-started.md`](./getting-started.md) | Plain library use: render a Mermaid string to SVG/PNG/ASCII in 5 minutes. |
 | [`api.md`](./api.md) | Library, agent API, output functions, options, CLI/MCP pointers. |
 | [`diagram-families.md`](./diagram-families.md) | Supported Mermaid families, examples, and edit policy. |
 | [`theming.md`](./theming.md) | Two-color themes, built-in themes, custom themes, Shiki import. |

--- a/docs/ascii.md
+++ b/docs/ascii.md
@@ -59,10 +59,16 @@ const { ascii, regions, warnings, routeParity } = renderMermaidASCIIWithMeta(sou
 ```ts
 import { asciiToMermaid } from 'agentic-mermaid/agent'
 
-const source = asciiToMermaid(ascii)
+const result = asciiToMermaid(ascii)
+if (result.ok) {
+  const source = result.value // reconstructed Mermaid source
+}
 ```
 
-This is best-effort and lossy. It is useful for simple linear flowcharts, not for reconstructing arbitrary Mermaid source.
+`asciiToMermaid` returns a `Result<string, ParseError[]>`: `result.value` holds the
+Mermaid source on success, and `result.error` lists parse errors (e.g. `NO_BOXES`)
+otherwise. This is best-effort and lossy. It is useful for simple linear flowcharts,
+not for reconstructing arbitrary Mermaid source.
 
 ## Supported families
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,168 @@
+# Getting started (library)
+
+A 5-minute guide for using `agentic-mermaid` as a plain rendering library: turn a
+Mermaid string into **SVG**, **PNG**, or **ASCII/Unicode**. No agents, no server,
+no browser — every function below runs synchronously in Node, Bun, or the browser.
+
+> Editing diagrams with the typed parse → mutate → verify → serialize API is a
+> separate surface — see the [agent API cookbook](./agent-api-cookbook.md). You do
+> not need any of that just to render.
+
+## Install
+
+```bash
+npm install agentic-mermaid
+# or: bun add agentic-mermaid / pnpm add agentic-mermaid
+```
+
+## Render to SVG
+
+`renderMermaidSVG` takes Mermaid source and returns a self-contained SVG string.
+It supports all 12 diagram families (flowchart, sequence, class, ER, state, gantt,
+pie, …) — just pass the source.
+
+```ts
+import { renderMermaidSVG } from 'agentic-mermaid'
+
+const svg = renderMermaidSVG(`flowchart TD
+  Start --> Stop`)
+
+console.log(svg) // "<svg ...>...</svg>"
+```
+
+Write it to a file in Node/Bun:
+
+```ts
+import { writeFileSync } from 'node:fs'
+import { renderMermaidSVG } from 'agentic-mermaid'
+
+writeFileSync('diagram.svg', renderMermaidSVG('flowchart LR\n  A --> B --> C'))
+```
+
+## Render to PNG
+
+PNG rendering uses a bundled native rasterizer, so `renderMermaidPNG` lives on the
+`agentic-mermaid/agent` entry point. It returns a `Uint8Array` of PNG bytes.
+
+```ts
+import { writeFileSync } from 'node:fs'
+import { renderMermaidPNG } from 'agentic-mermaid/agent'
+
+const png = renderMermaidPNG(`flowchart TD
+  Start --> Stop`, {
+  fitTo: { width: 1200 }, // constrain output width (optional)
+  background: '#ffffff',  // PNG has no transparency by default
+})
+
+writeFileSync('diagram.png', png)
+```
+
+`PngOptions`: `scale` (default `2`, for retina), `background`, and
+`fitTo: { width?, height? }`.
+
+## Render to ASCII / Unicode
+
+Great for terminals, code reviews, and plain-text logs. Unicode box-drawing is the
+default; pass `{ useAscii: true }` for pure ASCII.
+
+```ts
+import { renderMermaidASCII } from 'agentic-mermaid'
+
+const unicode = renderMermaidASCII('flowchart LR\n  A --> B')
+const ascii = renderMermaidASCII('flowchart LR\n  A --> B', { useAscii: true })
+
+console.log(unicode)
+```
+
+See [`ascii.md`](./ascii.md) for supported families and cell-to-region metadata.
+
+## Theming
+
+Theme from two colors, or spread one of the 19 built-in themes. Colors are applied
+as CSS variables, so the SVG stays self-contained.
+
+```ts
+import { renderMermaidSVG, THEMES } from 'agentic-mermaid'
+
+// Two-color theme
+const dark = renderMermaidSVG('flowchart TD\n  A --> B', {
+  bg: '#1a1b26',
+  fg: '#a9b1d6',
+})
+
+// A built-in theme (zinc-light, tokyo-night, nord, dracula, catppuccin-mocha, …)
+const themed = renderMermaidSVG('flowchart TD\n  A --> B', {
+  ...THEMES['tokyo-night'],
+})
+
+// Transparent background, for embedding on any page
+const transparent = renderMermaidSVG('flowchart TD\n  A --> B', {
+  transparent: true,
+})
+```
+
+Common `RenderOptions`: `bg`, `fg`, `font`, `transparent`, and `security`. See
+[`theming.md`](./theming.md) for custom themes and Shiki/VS Code theme import.
+
+### Untrusted input
+
+If the Mermaid source is not yours, render with `security: 'strict'`. It disables
+the web-font `@import` and strips any external-fetch references from the output, so
+the SVG cannot phone home.
+
+```ts
+import { renderMermaidSVG } from 'agentic-mermaid'
+
+const safe = renderMermaidSVG(userProvidedSource, { security: 'strict' })
+```
+
+## In the browser and in frameworks
+
+`renderMermaidSVG` is synchronous and needs no DOM, so you can render during a
+component's render pass and drop the string straight into the markup. In React,
+memoize it to avoid re-rendering on every paint:
+
+```tsx
+import { useMemo } from 'react'
+import { renderMermaidSVG } from 'agentic-mermaid'
+
+function Diagram({ code }: { code: string }) {
+  const svg = useMemo(() => renderMermaidSVG(code), [code])
+  return <div dangerouslySetInnerHTML={{ __html: svg }} />
+}
+```
+
+See [`react.md`](./react.md) for the zero-flash, live-theme-switching setup.
+
+## Which import path?
+
+| You want | Import from |
+|---|---|
+| SVG | `agentic-mermaid` |
+| ASCII / Unicode | `agentic-mermaid` |
+| PNG (native rasterizer) | `agentic-mermaid/agent` |
+| Themes (`THEMES`, `fromShikiTheme`) | `agentic-mermaid` |
+| Everything in one path | `agentic-mermaid/agent` |
+| Typed editing (parse/mutate/verify) | `agentic-mermaid/agent` |
+
+`agentic-mermaid/agent` re-exports the renderers too, so if you would rather use a
+single import path for all formats, import everything from there.
+
+## Prefer the command line?
+
+The same renderers ship as the `am` CLI — no code required:
+
+```bash
+am render diagram.mmd --format svg
+am render diagram.mmd --format png --output diagram.png
+am render diagram.mmd --ascii
+```
+
+Run `am --help` for the full command set.
+
+## Next steps
+
+- [`diagram-families.md`](./diagram-families.md) — every supported family with examples.
+- [`theming.md`](./theming.md) — custom themes and Shiki import.
+- [`api.md`](./api.md) — the full option and function reference.
+- [`agent-api-cookbook.md`](./agent-api-cookbook.md) — typed editing (parse → mutate → verify → serialize).

--- a/examples/agent-improve-auth-flow.ts
+++ b/examples/agent-improve-auth-flow.ts
@@ -10,14 +10,38 @@
 //   bun run examples/agent-improve-auth-flow.ts --out-dir /tmp/auth-flow-improved
 
 import { Buffer } from 'node:buffer'
-import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs'
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join, resolve } from 'node:path'
+import { spawnSync } from 'node:child_process'
 import { handleRequest } from '../src/mcp/server.ts'
+
+const REPO = join(import.meta.dir, '..')
 
 function argValue(name: string): string | undefined {
   const idx = process.argv.indexOf(name)
   return idx >= 0 ? process.argv[idx + 1] : undefined
+}
+
+// Render the final source to PNG in a *fresh* process via `am render`. The
+// native PNG renderer (resvg) must not be loaded in this process: after MCP
+// Code Mode runs agent code in a `node:vm` sandbox, loading the native binding
+// here panics Bun (`panic: unreachable` on dlopen-after-vm). Shelling out to
+// the CLI keeps the dlopen in a clean process — same pattern as the MCP/CLI
+// parity example.
+function renderPngOutOfProcess(source: string, outPath: string): void {
+  const srcPath = `${outPath}.src.mmd`
+  writeFileSync(srcPath, source)
+  try {
+    const r = spawnSync(
+      'bun',
+      ['run', join(REPO, 'bin/am.ts'), 'render', srcPath, '--format', 'png', '--output', outPath],
+      { cwd: REPO, encoding: 'utf8' },
+    )
+    if (r.status !== 0) throw new Error(`am render --format png failed (${r.status})\nstderr: ${r.stderr}`)
+  } finally {
+    rmSync(srcPath, { force: true })
+  }
 }
 
 const outDir = resolve(argValue('--out-dir') ?? mkdtempSync(join(tmpdir(), 'am-agent-improve-')))
@@ -153,13 +177,14 @@ writeFileSync(files.source, result.source)
 writeFileSync(files.svg, result.svg)
 writeFileSync(files.ascii, result.ascii)
 // PNG is binary, so the host renders it from the verified final source. The
-// doc-sync smoke test can request a tiny placeholder to avoid loading native
-// PNG bindings in a nested Bun subprocess on constrained CI runners; the real
-// renderMermaidPNG path remains the default and is covered by agent PNG tests.
-const pngBytes = useTestPngPlaceholder
-  ? Buffer.from('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=', 'base64')
-  : (await import('../src/agent/index.ts')).renderMermaidPNG(result.source, { fitTo: { width: 1600 }, background: '#f8f7f4' })
-writeFileSync(files.png, pngBytes)
+// default path renders the real PNG out-of-process (see renderPngOutOfProcess);
+// `--test-png-placeholder` writes a tiny stand-in to skip native rendering on
+// environments without the resvg binding.
+if (useTestPngPlaceholder) {
+  writeFileSync(files.png, Buffer.from('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=', 'base64'))
+} else {
+  renderPngOutOfProcess(result.source, files.png)
+}
 writeFileSync(files.assessment, JSON.stringify({
   createOps: result.createOps,
   improveOps: result.improveOps,

--- a/package.json
+++ b/package.json
@@ -70,7 +70,6 @@
   "files": [
     "src/",
     "dist/",
-    "bin/",
     "assets/fonts/",
     "assets/hero.png",
     "docs/",
@@ -86,7 +85,11 @@
     "SECURITY.md",
     "llms.txt",
     "LICENSE",
-    "README.md"
+    "README.md",
+    "!dist/**/*.map",
+    "!src/**/__tests__/**",
+    "!src/**/*.test.ts",
+    "!docs/pr-assets/**"
   ],
   "scripts": {
     "test": "bun test --coverage src/__tests__/",

--- a/src/__tests__/agent-doc-sync.test.ts
+++ b/src/__tests__/agent-doc-sync.test.ts
@@ -733,5 +733,10 @@ describe('shipped distribution artifacts present', () => {
     for (const example of ['examples/agent-loop.ts', 'examples/mcp-vs-cli-complex-diagrams.ts', 'examples/agent-improve-auth-flow.ts']) expect(pkg.files).toContain(example)
     expect(existsSync(join(REPO, 'assets/fonts/DejaVuSans.ttf'))).toBe(true)
     expect(existsSync(join(REPO, 'assets/fonts/DejaVuSans-Bold.ttf'))).toBe(true)
+    // Tarball slimming: sourcemaps, shipped tests, and PR-evidence images are
+    // kept out of the npm tarball via files negation (keeps unpacked size ~10MB).
+    for (const exclude of ['!dist/**/*.map', '!src/**/__tests__/**', '!src/**/*.test.ts', '!docs/pr-assets/**']) expect(pkg.files).toContain(exclude)
+    // Redundant Bun source bins are not published; the bin map points at dist/*.js.
+    expect(pkg.files).not.toContain('bin/')
   })
 })

--- a/src/__tests__/agent-doc-sync.test.ts
+++ b/src/__tests__/agent-doc-sync.test.ts
@@ -1,7 +1,7 @@
 // Doc-sync + no-tautology guards.
 
 import { describe, test, expect } from 'bun:test'
-import { readFileSync, existsSync, readdirSync, mkdtempSync, rmSync } from 'node:fs'
+import { readFileSync, writeFileSync, existsSync, readdirSync, mkdtempSync, rmSync } from 'node:fs'
 import { spawnSync } from 'node:child_process'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
@@ -145,6 +145,36 @@ describe('agent-facing runnable docs', () => {
       expect(lintAgentTrace(r.trace as SdkCall[])).toEqual([])
     }
   })
+
+  // Public-API library docs are import-based (not MCP Code Mode), so they cannot
+  // run in the sandbox above. Execute the getting-started snippets as real Bun
+  // modules against the in-repo source so the plain-library quickstart cannot
+  // drift from the actual API (e.g. a Result returned where a string is shown).
+  test('getting-started.md library snippets execute', () => {
+    const blocks = tsCodeBlocks(join(REPO, 'docs/getting-started.md'))
+    expect(blocks.length).toBeGreaterThan(0)
+    // The doc's "untrusted input" snippet uses a reader-supplied placeholder.
+    const PREAMBLE = "const userProvidedSource = 'flowchart TD\\n  A --> B'\n"
+    const dir = mkdtempSync(join(tmpdir(), 'gs-snippets-'))
+    try {
+      let ran = 0
+      for (const [i, block] of blocks.entries()) {
+        // Point the published specifiers at the in-repo source; running from a
+        // temp cwd keeps any written artifacts (diagram.svg/png) out of the repo.
+        const wired = block
+          .replaceAll("'agentic-mermaid/agent'", JSON.stringify(join(REPO, 'src/agent/index.ts')))
+          .replaceAll("'agentic-mermaid'", JSON.stringify(join(REPO, 'src/index.ts')))
+        const file = join(dir, `block-${i}.ts`)
+        writeFileSync(file, PREAMBLE + wired)
+        const r = spawnSync('bun', ['run', file], { cwd: dir, encoding: 'utf8' })
+        expect({ block: i, status: r.status, stderr: r.stderr }).toEqual({ block: i, status: 0, stderr: '' })
+        ran++
+      }
+      expect(ran).toBeGreaterThan(0)
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  }, 60_000)
 })
 
 describe('vocabulary doc-sync', () => {
@@ -636,7 +666,9 @@ describe('shipped distribution artifacts present', () => {
   test('agent improvement example assesses, mutates, reassesses, and writes render files', async () => {
     const outDir = mkdtempSync(join(tmpdir(), 'am-example-test-'))
     try {
-      const r = await runBunExample(join(REPO, 'examples/agent-improve-auth-flow.ts'), ['--out-dir', outDir, '--test-png-placeholder'], 120_000)
+      // No --test-png-placeholder: exercise the real out-of-process PNG render.
+      // This is the documented `bun run examples/...` invocation end-to-end.
+      const r = await runBunExample(join(REPO, 'examples/agent-improve-auth-flow.ts'), ['--out-dir', outDir], 120_000)
       expect({ status: r.status, timedOut: r.timedOut, stderr: r.stderr }).toEqual({ status: 0, timedOut: false, stderr: '' })
       const payload = JSON.parse(r.stdout)
       expect(payload.ok).toBe(true)
@@ -651,6 +683,8 @@ describe('shipped distribution artifacts present', () => {
       expect(svg).toContain('Login Page')
       expect(ascii).toContain('Dashboard')
       expect(Array.from(png.subarray(0, 8))).toEqual([137, 80, 78, 71, 13, 10, 26, 10])
+      // A real rasterized diagram is many KB; a placeholder/regression would not be.
+      expect(png.length).toBeGreaterThan(1000)
       expect(assessment.improveOps).toBe(3)
     } finally {
       rmSync(outDir, { recursive: true, force: true })

--- a/src/__tests__/agent-doc-sync.test.ts
+++ b/src/__tests__/agent-doc-sync.test.ts
@@ -147,34 +147,53 @@ describe('agent-facing runnable docs', () => {
   })
 
   // Public-API library docs are import-based (not MCP Code Mode), so they cannot
-  // run in the sandbox above. Execute the getting-started snippets as real Bun
-  // modules against the in-repo source so the plain-library quickstart cannot
-  // drift from the actual API (e.g. a Result returned where a string is shown).
-  test('getting-started.md library snippets execute', () => {
-    const blocks = tsCodeBlocks(join(REPO, 'docs/getting-started.md'))
-    expect(blocks.length).toBeGreaterThan(0)
-    // The doc's "untrusted input" snippet uses a reader-supplied placeholder.
-    const PREAMBLE = "const userProvidedSource = 'flowchart TD\\n  A --> B'\n"
-    const dir = mkdtempSync(join(tmpdir(), 'gs-snippets-'))
+  // run in the sandbox above. Execute their standalone snippets as real Bun
+  // modules against the in-repo source. This catches snippets that FAIL TO RUN —
+  // renamed/missing exports, wrong call signatures, options that throw, runtime
+  // errors — i.e. API drift that breaks the documented code. It does NOT catch
+  // silent type/semantic mismatches that still execute (e.g. assigning a Result
+  // to a var the prose calls a string); those need human review. Skipped:
+  // continuation fragments (no import), module/handler fragments (top-level
+  // export/return), and React/JSX blocks.
+  test('public-API doc snippets execute', () => {
+    const AGENT = JSON.stringify(join(REPO, 'src/agent/index.ts'))
+    const CORE = JSON.stringify(join(REPO, 'src/index.ts'))
+    const docs = ['README.md', 'docs/getting-started.md', 'docs/api.md', 'docs/ascii.md', 'docs/config.md', 'docs/theming.md', 'docs/diagram-families.md']
+    // Reader-supplied placeholders the docs reference but expect you to provide.
+    const placeholders = (block: string): string => {
+      const declared = (id: string) => new RegExp(`(?:const|let|var)\\s+${id}\\b`).test(block) || new RegExp(`(?:const|let|var)\\s*\\{[^}]*\\b${id}\\b[^}]*\\}`).test(block)
+      const used = (id: string) => new RegExp(`\\b${id}\\b`).test(block) && !declared(id)
+      const defs: string[] = []
+      if (used('source')) defs.push("const source = 'flowchart TD\\n  API --> DB'")
+      if (used('diagram')) defs.push("const diagram = 'flowchart TD\\n  API --> DB'")
+      if (used('userProvidedSource')) defs.push("const userProvidedSource = 'flowchart TD\\n  A --> B'")
+      if (used('myTheme')) defs.push("const myTheme = { bg: '#ffffff', fg: '#111111' }")
+      if (used('ascii')) defs.push(`import { renderMermaidASCII as __ra } from ${AGENT}\nconst ascii = __ra('flowchart LR\\n  A --> B', { useAscii: true })`)
+      return defs.join('\n')
+    }
+    const dir = mkdtempSync(join(tmpdir(), 'doc-snippets-'))
     try {
       let ran = 0
-      for (const [i, block] of blocks.entries()) {
-        // Point the published specifiers at the in-repo source; running from a
-        // temp cwd keeps any written artifacts (diagram.svg/png) out of the repo.
-        const wired = block
-          .replaceAll("'agentic-mermaid/agent'", JSON.stringify(join(REPO, 'src/agent/index.ts')))
-          .replaceAll("'agentic-mermaid'", JSON.stringify(join(REPO, 'src/index.ts')))
-        const file = join(dir, `block-${i}.ts`)
-        writeFileSync(file, PREAMBLE + wired)
-        const r = spawnSync('bun', ['run', file], { cwd: dir, encoding: 'utf8' })
-        expect({ block: i, status: r.status, stderr: r.stderr }).toEqual({ block: i, status: 0, stderr: '' })
-        ran++
+      for (const doc of docs) {
+        for (const [i, block] of tsCodeBlocks(join(REPO, doc)).entries()) {
+          const runnable = /^\s*import\b/m.test(block) && !/^\s*(?:export|return)\b/m.test(block) && !/from ['"]react['"]/.test(block)
+          if (!runnable) continue
+          // Point published specifiers at in-repo source; a temp cwd keeps any
+          // written artifacts (diagram.svg/png) out of the repo.
+          const wired = block.replaceAll("'agentic-mermaid/agent'", AGENT).replaceAll("'agentic-mermaid'", CORE)
+          const file = join(dir, `${doc.replace(/[/.]/g, '_')}__${i}.ts`)
+          writeFileSync(file, placeholders(block) + '\n' + wired)
+          const r = spawnSync('bun', ['run', file], { cwd: dir, encoding: 'utf8' })
+          expect({ doc, block: i, status: r.status, stderr: r.stderr }).toEqual({ doc, block: i, status: 0, stderr: '' })
+          ran++
+        }
       }
-      expect(ran).toBeGreaterThan(0)
+      // Guard against the skip logic silently excluding everything (23 today).
+      expect(ran).toBeGreaterThanOrEqual(18)
     } finally {
       rmSync(dir, { recursive: true, force: true })
     }
-  }, 60_000)
+  }, 120_000)
 })
 
 describe('vocabulary doc-sync', () => {
@@ -650,6 +669,14 @@ describe('shipped distribution artifacts present', () => {
     expect(existsSync(join(REPO, 'docs/mcp-code-mode-rationale.md'))).toBe(true)
     expect(existsSync(join(REPO, 'docs/agent-workflow-examples.md'))).toBe(true)
   })
+
+  test('agent-loop example runs', async () => {
+    // Previously only existence-checked; execute it so parse/mutate/serialize
+    // drift can't ship green. It prints a human-readable trace, not JSON.
+    const r = await runBunExample(join(REPO, 'examples/agent-loop.ts'))
+    expect({ status: r.status, timedOut: r.timedOut, stderr: r.stderr }).toEqual({ status: 0, timedOut: false, stderr: '' })
+    expect(r.stdout).toContain('round-trips losslessly: true')
+  }, 90_000)
 
   test('MCP/CLI parity example runs', async () => {
     const r = await runBunExample(join(REPO, 'examples/mcp-vs-cli-complex-diagrams.ts'))

--- a/src/__tests__/agent-mcp-png.test.ts
+++ b/src/__tests__/agent-mcp-png.test.ts
@@ -1,9 +1,11 @@
 // Loop 9 M1 — MCP `render_png` tool. Decodes base64 and asserts PNG magic bytes.
 
 import { describe, test, expect } from 'bun:test'
+import { join } from 'node:path'
 import { handleRequest } from '../mcp/server.ts'
 
 const PNG_MAGIC = [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]
+const REPO = join(import.meta.dir, '..', '..')
 
 describe('MCP — render_png tool', () => {
   test('happy path returns base64 PNG', async () => {
@@ -76,4 +78,34 @@ describe('MCP — render_png tool', () => {
       expect(payload.ok).toBe(true)
     }
   })
+
+  // Regression: a real client session that runs Code Mode `execute` (a node:vm
+  // sandbox) and then `render_png` must not crash the server. On Bun, loading
+  // the native resvg addon for the first time after a vm context has run panics
+  // the process; runStdio warms the renderer at startup to prevent it. This runs
+  // the actual shipped stdio bin out-of-process so a crash would surface as a
+  // non-zero exit / missing response rather than killing the test runner.
+  test('stdio server survives execute then render_png in one session', async () => {
+    const proc = Bun.spawn(['bun', 'run', join(REPO, 'bin/agentic-mermaid-mcp.ts')], {
+      cwd: REPO, stdin: 'pipe', stdout: 'pipe', stderr: 'pipe',
+    })
+    const requests = [
+      { jsonrpc: '2.0', id: 1, method: 'initialize', params: {} },
+      { jsonrpc: '2.0', id: 2, method: 'tools/call', params: { name: 'execute', arguments: { code: 'return 1' } } },
+      { jsonrpc: '2.0', id: 3, method: 'tools/call', params: { name: 'render_png', arguments: { source: 'flowchart TD\n  A --> B', output: 'base64' } } },
+    ]
+    proc.stdin.write(requests.map(r => JSON.stringify(r)).join('\n') + '\n')
+    await proc.stdin.end()
+    const stdout = await new Response(proc.stdout).text()
+    const exit = await proc.exited
+    // Without the warm-up the process dies with SIGILL (exit 132) after the vm
+    // run, so the render_png response never arrives.
+    expect(exit).toBe(0)
+    const responses = stdout.split('\n').filter(Boolean).map(line => JSON.parse(line) as { id: number; result?: { content: Array<{ text: string }> } })
+    const pngResponse = responses.find(r => r.id === 3)
+    expect(pngResponse).toBeDefined()
+    const payload = JSON.parse(pngResponse!.result!.content[0]!.text) as { ok: boolean; png_base64?: string }
+    expect(payload.ok).toBe(true)
+    expect(Buffer.from(payload.png_base64!, 'base64').length).toBeGreaterThan(100)
+  }, 30_000)
 })

--- a/src/__tests__/agent-mcp.test.ts
+++ b/src/__tests__/agent-mcp.test.ts
@@ -5,6 +5,7 @@ import { executeInSandbox } from '../mcp/sandbox.ts'
 import { handleRequest } from '../mcp/server.ts'
 import { runCli } from '../cli/index.ts'
 import { BUILTIN_FAMILY_METADATA } from '../agent/families.ts'
+import pkg from '../../package.json'
 
 describe('sandbox — happy', () => {
   test('flowchart workflow', async () => {
@@ -372,6 +373,8 @@ describe('MCP — JSON-RPC happy + sad', () => {
   test('initialize', async () => {
     const r = await handleRequest({ jsonrpc: '2.0', id: 1, method: 'initialize' })
     expect((r!.result as any).serverInfo.name).toBe('agentic-mermaid-mcp')
+    // The MCP handshake version is derived from package.json; keep them aligned.
+    expect((r!.result as any).serverInfo.version).toBe(pkg.version)
     const instructions = (r!.result as any).instructions as string
     for (const family of BUILTIN_FAMILY_METADATA) expect(instructions).toContain(family.narrower)
     expect(instructions).not.toContain('Journey, xychart, architecture')

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -199,7 +199,24 @@ function getDefaultArtifactStore(): ArtifactStore {
 function reply(id: number | string | null, result: unknown): JsonRpcResponse { return { jsonrpc: '2.0', id, result } }
 function error(id: number | string | null, code: number, message: string): JsonRpcResponse { return { jsonrpc: '2.0', id, error: { code, message } } }
 
+// Force the native resvg (`@resvg/resvg-js`) addon to load NOW, before the
+// server starts handling requests. On Bun, the addon's first `dlopen` — which
+// is deferred until the first `new Resvg()` — panics the runtime
+// (`panic: unreachable`) if it happens *after* a `node:vm` context has run.
+// Code Mode `execute` runs agent code in exactly such a sandbox, so a normal
+// `execute` then `render_png` session would otherwise crash the whole process.
+// Warming here lands the dlopen up front. Guarded so a host without the binding
+// still boots (render_png then reports the failure per-call instead of at start).
+function warmUpPngRenderer(): void {
+  try {
+    renderMermaidPNG('flowchart LR\n  A --> B')
+  } catch {
+    // Binding unavailable in this environment; render_png will surface the error.
+  }
+}
+
 export async function runStdio(options: { artifactDir?: string; maxArtifactBytes?: number; artifactTtlMs?: number } = {}): Promise<void> {
+  warmUpPngRenderer()
   const artifactStore = createArtifactStore({ dir: options.artifactDir, maxBytes: options.maxArtifactBytes, ttlMs: options.artifactTtlMs })
   process.stdin.setEncoding('utf8')
   let buf = ''
@@ -225,6 +242,7 @@ export async function runStdio(options: { artifactDir?: string; maxArtifactBytes
 }
 
 export async function startHttpServer(options: HttpMcpOptions = {}): Promise<HttpMcpServer> {
+  warmUpPngRenderer()
   const host = options.host ?? '127.0.0.1'
   const port = options.port ?? 3000
   if (!isLoopbackHost(host) && !options.authToken) throw new Error('HTTP MCP remote bind requires --auth-token')

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -11,6 +11,7 @@ import { SDK_DECLARATION } from './sdk-decl.ts'
 import { createArtifactStore, type ArtifactRecord, type ArtifactStore } from './artifacts.ts'
 import { renderMermaidPNG } from '../agent/png.ts'
 import { BUILTIN_FAMILY_METADATA } from '../agent/families.ts'
+import pkg from '../../package.json'
 
 export interface JsonRpcRequest { jsonrpc: '2.0'; id?: number | string | null; method: string; params?: unknown }
 export interface JsonRpcResponse { jsonrpc: '2.0'; id: number | string | null; result?: unknown; error?: { code: number; message: string; data?: unknown } }
@@ -40,7 +41,9 @@ export interface HttpMcpServer {
 }
 
 const SERVER_NAME = 'agentic-mermaid-mcp'
-const SERVER_VERSION = '0.4.0'
+// Derived from package.json so the MCP handshake version always matches the
+// published npm package and cannot drift.
+const SERVER_VERSION = pkg.version
 const PROTOCOL_VERSION = '2024-11-05'
 const MAX_RPC_BODY_BYTES = 1024 * 1024
 const MAX_SANDBOX_TIMEOUT_MS = 30_000


### PR DESCRIPTION
## What

Make `agentic-mermaid` ready to publish: fix a server-crash blocker and the doc/example breakage found while verifying the docs, add a plain-library quickstart, and slim the npm tarball ~2.5×.

## Why

While verifying that every doc and example actually runs (prep for the first `agentic-mermaid` publish), I found real breakage plus one shipping blocker:

- **MCP server crash (blocker).** The shipped stdio `agentic-mermaid-mcp` server crashes Bun (`panic: unreachable`, exit 132) on a normal Code Mode session: `execute` (a `node:vm` sandbox) followed by `render_png`. Root cause: the native `@resvg/resvg-js` addon's first `dlopen` (deferred to the first `new Resvg()`) panics when it happens *after* a vm context has run.
- **`docs/ascii.md` bug.** `asciiToMermaid` returns `Result<string, ParseError[]>`, but the example assigned it straight to a string — a reader gets `{ ok, value }`, not Mermaid source.
- **`examples/agent-improve-auth-flow.ts`** crashed on its documented `bun run` command for the same vm+resvg reason.
- **Coverage gaps:** no public-API doc code blocks were executed in CI (exactly why the ascii bug survived); `agent-loop.ts` was never run; the tarball shipped ~12.5 MB of sourcemaps/tests/PR images; MCP `SERVER_VERSION` was a stale hardcoded `0.4.0`.

No issue number — found during publish-readiness verification.

### Reproduction (MCP blocker)

```bash
# In the repo, drive the real stdio server: initialize → execute → render_png
printf '%s\n%s\n%s\n' \
  '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}' \
  '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"execute","arguments":{"code":"return 1"}}}' \
  '{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"render_png","arguments":{"source":"flowchart TD\n  A --> B","output":"base64"}}}' \
  | bun run bin/agentic-mermaid-mcp.ts
# Before this PR: process dies with `panic: unreachable` (exit 132); id:3 never answered.
# After: all three respond; render_png returns a valid PNG.
```

## How

- **MCP crash:** warm up the resvg renderer once at server startup (`runStdio` + `startHttpServer`), before requests are handled, so the `dlopen` lands before any sandbox. Guarded in try/catch so hosts without the binding still boot; `handleRenderPng` stays synchronous. (Lazy-loading was ruled out empirically — the addon is already lazy; the fix is the opposite, eager warm-up.)
- **Example:** render the PNG out-of-process via `am render` (mirrors the existing MCP/CLI parity example) so the native load happens in a clean process.
- **ascii.md:** show the `Result` being checked (`if (result.ok) { const source = result.value }`).
- **New doc:** `docs/getting-started.md` — plain-library quickstart (SVG/PNG/ASCII, theming, strict mode, import-path table), linked from README + docs index.
- **Tarball:** exclude sourcemaps/tests/PR images via `files` negation (maps still emitted for local builds); drop redundant `bin/` Bun source from `files`.
- **Version:** derive `SERVER_VERSION` from `package.json` (tsup inlines it).

## Testing

- Full suite **4140 pass, 0 fail**; `bun x tsc --noEmit` clean.
- **Red→green verified:**
  - MCP regression (`agent-mcp-png`): drives the real stdio bin through `initialize → execute → render_png`; without the warm-up the process exits 132 and never answers `render_png`.
  - Doc-snippet executor (`agent-doc-sync`): a renamed export injected into `api.md` makes it fail; reverting passes.
  - Example PNG test: now runs the real out-of-process PNG path (dropped `--test-png-placeholder`) and asserts a >1 KB PNG; the original command crashed (exit 132).
- **Manual:** packed the tarball and installed it into a clean Node project — library SVG/PNG render, font resolution from `node_modules`, and both bins work; unpacked size **24.9 MB → 10.3 MB** (672 → 296 files). Built the MCP bin and confirmed the Node handshake reports `0.1.0`.

- [x] New/modified tests pass
- [x] Tests fail when fix is reverted (regression guard)
- [x] Full test suite passes (no regressions)
- [x] Manual testing completed (tarball install + MCP handshake)

## Risk

- **Touch points:** `src/mcp/server.ts` (startup warm-up + version), `package.json` `files`, one example, three test files, docs. No renderer/layout/geometry code changed → **no golden/snapshot drift** (nothing under `src/__tests__/testdata/` touched).
- **Warm-up** adds one tiny PNG render at MCP startup (a few ms) and is the documented Bun-bug mitigation; guarded so a missing native binding doesn't block boot.
- **`files` negation** verified empirically via `npm pack` + clean install (all runtime files retained: `dist/*.js`, `src/index.ts` / `src/agent/index.ts`, fonts).
- **HTTP MCP transport** shares the same unsafe vm+resvg ordering but happened to dodge the crash; the same startup warm-up covers it.

### Honest limitations (trust)

- The new doc-snippet executor catches snippets that **fail to run** (renamed exports, bad signatures, runtime throws) — it does **not** catch silent type/semantic mismatches that still execute (like the original `asciiToMermaid`-as-string), which needed human review. This is documented in the test.
- The two `console.log` lines the readiness script flags are **doc examples** in `getting-started.md` showing output, not debug code.
- Intentionally **not** changed: `test-quality-lint` (documented narrow-by-design; the suite relies on `test.todo`).
- Out of scope: the `DEC-1` "one real external consumer" release gate remains the maintainer's call.

## Repo checklist

- [x] Tests pass locally (`bun test src/__tests__/`) and `bun x tsc --noEmit` is clean.
- [x] **Golden snapshots:** did **not** change committed goldens under `src/__tests__/testdata/`.
- [x] No diagram family added (registry wiring N/A).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017o5NMNKRtc56DEzoTCqnJj)_