### PR TITLE
docs: document the subgraph-membership divergence from Mermaid.js

### DIFF
--- a/docs/fork-differences.md
+++ b/docs/fork-differences.md
@@ -91,6 +91,46 @@ Users can discover fork features through:
 - Already upstreamed: fan-in grouping (upstream #68/#69) and labeled fan-out trunk sharing with box-start connector placement (#111/#112/#113, upstream PR #113) landed here first and now render identically in Beautiful Mermaid 1.1.3 — they are no longer fork-only.
 - ER cardinality parsing matches Mermaid's lexer exactly; malformed relationship lines error loudly instead of being silently dropped.
 
+## Parser and semantic divergences from Mermaid.js
+
+- **Subgraph membership is *first-defined-wins*.** A node belongs to the subgraph
+  where it is **first defined**, and a top-level reference counts as a definition —
+  so a node referenced at the top level and then listed inside a subgraph block
+  stays at the top level. Mermaid.js instead lets the subgraph *block* claim any
+  node it lists, regardless of a prior top-level reference. In the canonical Mermaid
+  docs example:
+
+  ```mermaid
+  flowchart TB
+      c1-->a2
+      subgraph one
+      a1-->a2
+      end
+      subgraph two
+      b1-->b2
+      end
+      subgraph three
+      c1-->c2
+      end
+  ```
+
+  Mermaid.js places `a2` inside `one` and `c1` inside `three`; this fork keeps `a2`
+  and `c1` at the top level (only `a1`/`c2` are inside those subgraphs). See it both
+  ways: [open in Mermaid Live](https://mermaid.live/edit#pako:eNp10DELwjAQBeC_Et7cDjpmcBBXJ50kyzW5NoU2V9KEIqX_XbSoRXB87z44eDOsOIZG3clkPcWkrkcTlFLK7sryQPs1jLlqIg1eSeC1oe2Zg_txaZK1qZ6u-u98ZN48tF-JAj3HnloHjdkgee7ZQBs4ril3yWBBAcpJLvdgoVPMXCBKbjx0Td3IBfLgKPGppSZS_yYDhZvIJ7Jrk8TzOsRrj-UBwvBYkQ)
+  · [open in the fork editor](https://adewale.github.io/beautiful-mermaid/editor#eyJzb3VyY2UiOiJmbG93Y2hhcnQgVEJcbiAgICBjMS0tPmEyXG4gICAgc3ViZ3JhcGggb25lXG4gICAgYTEtLT5hMlxuICAgIGVuZFxuICAgIHN1YmdyYXBoIHR3b1xuICAgIGIxLS0+YjJcbiAgICBlbmRcbiAgICBzdWJncmFwaCB0aHJlZVxuICAgIGMxLS0+YzJcbiAgICBlbmQifQ==).
+
+  This is a deliberate divergence, not a bug: it gives deterministic
+  *definition-scope* membership with no surprising re-parenting when a node is
+  mentioned again inside a container, consistent with the fork's goal of
+  predictable, source-preserving behavior rather than Mermaid pixel/layout parity
+  (see [#38](https://github.com/adewale/beautiful-mermaid/issues/38)). Mermaid's own
+  users report *its* behavior as a bug (`mermaid-js/mermaid#738`, `#2707`). The rule
+  is inherited from upstream Beautiful Mermaid (introduced in its v1.0.0 rewrite),
+  not fork-invented, and is guarded by `src/__tests__/parser.test.ts` — a node
+  genuinely defined inside one subgraph and later referenced inside another
+  likewise stays in its first subgraph (it is never re-parented by a mere
+  reference).
+
 ## What is intentionally not in this fork
 
 - No committed `dist/` artifacts.


### PR DESCRIPTION
## What

Add an entry to `docs/fork-differences.md` documenting that the fork uses
**first-defined-wins** subgraph membership, which diverges from Mermaid.js.

## Why

The fork keeps a forward-referenced node at the top level (a top-level reference
counts as a definition), whereas Mermaid.js lets the subgraph *block* claim any
node it lists. On the canonical Mermaid-docs example, Mermaid puts `a2` inside
`one`; the fork keeps `a2` at the top level. This divergence was **undocumented**
in `fork-differences.md` even though other Mermaid divergences are listed there — a
gap that surprised us while chasing a (non-)bug: it looked like a defect until the
tests (`parser.test.ts:630/646`) and history showed it is deliberate.

A background research pass established the provenance (evidence in the entry):
- The rule is **inherited from upstream Beautiful Mermaid**, introduced in its
  v1.0.0 rewrite — not fork-invented.
- Mermaid.js's own users report *its* behavior as a bug
  (`mermaid-js/mermaid#738` closed, `#2707` open), i.e. definition-scope membership
  is what many users actually want.
- It is consistent with the fork's stated philosophy (#38): deterministic,
  source-preserving behavior, explicitly **not** Mermaid pixel/layout parity.

## How

One new "Parser and semantic divergences from Mermaid.js" section with: the
canonical example (as a `mermaid` block), side-by-side **open in Mermaid Live** /
**open in the fork editor** links (so a reader can see both renderings), the
rationale, the upstream provenance, and the guarding tests.

## Testing

- [x] `website:check` — **81 files in sync** (the generated differences page only
  *links* to `fork-differences.md`, so no regeneration needed).
- [x] `agent-doc-sync.test.ts` family-coverage check still passes (content only
  added, no family labels removed).
- [x] Both editor links round-trip-verified: the fork link base64-decodes to
  `{"source": …}` and the Mermaid link inflates (pako) to the same source.

## Risk

None — documentation only, no code or behavior change; the divergence itself is
unchanged (this PR only describes it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018VMxvY7SNd5YByhFdVM3sc

---
_Generated by [Claude Code](https://claude.ai/code/session_018VMxvY7SNd5YByhFdVM3sc)_