### PR TITLE
Track hosted-MCP launch prerequisites in the backlog (DEC-2, DEC-3)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -24,6 +24,21 @@ dependents after. IDs are stable names, not an ordering.
   `agentic-mermaid/agent`, `am`, or `agentic-mermaid-mcp` in a real agent,
   TUI, CI gate, or editor integration outside this repo. Unblocked
   substantially by BUILD-7 (remote MCP reachability).
+- [ ] **DEC-2 — Add the WAF rate-limit rule on `POST /mcp` before announcing
+  the hosted endpoint** (`owner-decision`). The hosted MCP (`#94`,
+  `https://agentic-mermaid.dev/mcp`) is public, unauthenticated compute. Body /
+  input / output caps, the batch fan-out cap, edge caching, isolate CPU
+  budgets, and CORS Origin validation bound each request in code, but the abuse
+  backstop is a **dashboard** WAF rate-limit rule (e.g. 60 req/min per IP) that
+  cannot live in the repo. Don't announce the endpoint until it is live. See
+  the launch checklist in `website/README.md`.
+- [ ] **DEC-3 — Verify the `worker_loaders` (`LOADER`) binding resolves in
+  production** (`owner-decision`). Dynamic Workers needs the Workers Paid plan
+  with the Worker Loader feature enabled on the account; a deploy can succeed
+  with the binding declared but unprovisioned, and Code Mode `execute` is the
+  only tool that touches it (the pure tools pass even when `LOADER` is missing).
+  After the first deploy, run one `execute` call (e.g. `website/e2e-mcp.sh`
+  against the live URL) and confirm it returns a value, not a loader error.
 
 ## 1. Ready build backlog
 


### PR DESCRIPTION
## What

Adds the two owner/dashboard actions that gate the public launch of the hosted MCP endpoint (shipped in #94) to `TODO.md` §0 (release / owner decisions):

- **DEC-2** — add the WAF rate-limit rule on `POST /mcp` before announcing the endpoint (the abuse backstop that cannot live in the repo).
- **DEC-3** — verify the `worker_loaders` (`LOADER`) binding resolves in production after the first deploy (a deploy can succeed with it declared but unprovisioned; Code Mode `execute` is the only tool that touches it).

## Why

#94 landed the hosted MCP, but its two launch prerequisites are dashboard-side actions the repo can't enforce. They were documented in `website/README.md`'s launch checklist; this promotes them to the single active backlog (`TODO.md`) so they aren't lost. Per the repo policy that `TODO.md` is the only active backlog, they belong there rather than scattered across docs.

## How

Two `- [ ]` items in the existing `DEC-N` format, placed in §0 next to `DEC-1`, each cross-referencing the `website/README.md` launch checklist.

## Testing

- Docs-only change. `agent-doc-sync.test.ts` ("TODO.md is the only root markdown file with unchecked backlog boxes") passes — the new `- [ ]` items live in `TODO.md`, and no other root doc gains checkboxes.

## Risk

None — Markdown-only backlog note; no code or generated artifacts touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NQ8zfoEL3Xa9iJe59qh92C

---
_Generated by [Claude Code](https://claude.ai/code/session_01NQ8zfoEL3Xa9iJe59qh92C)_