### PR TITLE
[codex] Fix hosted execute loader fallback

### DIFF
--- a/src/__tests__/hosted-execute-loader.test.ts
+++ b/src/__tests__/hosted-execute-loader.test.ts
@@ -84,8 +84,27 @@ describe('hosted execute loader glue', () => {
     expect(requests[1]!.modules['user.js']).not.toContain('return (')
   })
 
+  test('a bare parser startup failure also falls back to the statement-form isolate', async () => {
+    const { loader, requests } = makeLoader(req =>
+      req.id.includes('-e-')
+        ? new Error("Unexpected token 'const'")
+        : okResponse({ ok: true, value: 42, logs: [] }))
+    const execute = createLoaderExecute(loader, 'H')
+    const result = await execute('const x = 42; return x', 5000)
+    expect(result).toEqual({ ok: true, value: 42, logs: [] })
+    expect(requests.map(r => r.id.includes('-e-') ? 'e' : 's')).toEqual(['e', 's'])
+  })
+
   test('a double SyntaxError reports the statement attempt message, stripped of the startup preamble', async () => {
     const { loader } = makeLoader(() => new Error("Failed to start Worker:\nUncaught SyntaxError: Unexpected token ')'\n  at user.js:1"))
+    const execute = createLoaderExecute(loader, 'H')
+    const result = await execute('return ) === (', 5000)
+    expect(result.ok).toBe(false)
+    expect(result.error).toBe("Unexpected token ')'")
+  })
+
+  test('a double bare parser startup failure reports the statement attempt message', async () => {
+    const { loader } = makeLoader(() => new Error("Unexpected token ')'"))
     const execute = createLoaderExecute(loader, 'H')
     const result = await execute('return ) === (', 5000)
     expect(result.ok).toBe(false)

--- a/website/e2e-mcp.sh
+++ b/website/e2e-mcp.sh
@@ -101,7 +101,7 @@ check 'execute renders through the SDK after global hardening' 'C[New]' \
   "$(j '{"jsonrpc":"2.0","id":19,"method":"tools/call","params":{"name":"execute","arguments":{"code":"const r = mermaid.parseMermaid(\"flowchart TD\\n  A --> B\"); const m = mermaid.mutate(r.value, { kind: \"add_node\", id: \"C\", label: \"New\" }); return mermaid.serializeMermaid(m.value)"}}}')"
 
 check 'oversized bodies are 413' '413' \
-  "$(python3 -c "import json; print(json.dumps({'jsonrpc':'2.0','id':1,'method':'tools/call','params':{'name':'describe','arguments':{'source':'x'*200000}}}))" | curl -sS --max-time 10 -o /dev/null -w '%{http_code}' -X POST "$MCP" -H 'content-type: application/json' --data @-)"
+  "$(python3 -c 'import json; print(json.dumps({"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"describe","arguments":{"source":"x"*200000}}}))' | curl -sS --max-time 10 -o /dev/null -w '%{http_code}' -X POST "$MCP" -H 'content-type: application/json' --data @-)"
 
 # A disallowed cross-origin browser Origin is refused (MCP Origin validation).
 # A no-Origin client (every default curl above) is unaffected.
@@ -114,6 +114,6 @@ check 'an unsupported MCP-Protocol-Version is 400' '400' \
 
 # A batch beyond the fan-out cap is refused before any tool runs.
 check 'an over-cap batch is 400' '400' \
-  "$(python3 -c "import json; print(json.dumps([{'jsonrpc':'2.0','id':i,'method':'ping'} for i in range(25)]))" | curl -sS --max-time 10 -o /dev/null -w '%{http_code}' -X POST "$MCP" -H 'content-type: application/json' --data @-)"
+  "$(python3 -c 'import json; print(json.dumps([{"jsonrpc":"2.0","id":i,"method":"ping"} for i in range(25)]))' | curl -sS --max-time 10 -o /dev/null -w '%{http_code}' -X POST "$MCP" -H 'content-type: application/json' --data @-)"
 
 echo "e2e-mcp: $pass checks passed"

--- a/website/src/execute-loader.ts
+++ b/website/src/execute-loader.ts
@@ -79,6 +79,9 @@ export async function readCapped(body: ReadableStream<Uint8Array> | null, maxByt
 
 function isSyntaxStartupFailure(message: string): boolean {
   return /SyntaxError/i.test(message)
+    || /\bUnexpected token\b/i.test(message)
+    || /\bInvalid or unexpected token\b/i.test(message)
+    || /\bUnexpected end of input\b/i.test(message)
 }
 
 // Extra wall-clock margin over the isolate's cpuMs budget before the parent
@@ -160,7 +163,11 @@ function failure(message: string, timeoutMs: number): ExecuteResult {
     return { ok: false, error: `Script execution exceeded its ${timeoutMs}ms CPU budget`, logs: [] }
   }
   // Strip workerd's startup preamble so syntax errors read like the sandbox's.
-  const syntax = message.match(/SyntaxError:\s*(.*)/)
-  if (syntax) return { ok: false, error: syntax[1]!.split('\n')[0]!, logs: [] }
+  // Production Worker Loader sometimes omits the `SyntaxError:` prefix and
+  // throws the parser message directly, e.g. `Unexpected token 'const'`.
+  if (isSyntaxStartupFailure(message)) {
+    const syntax = message.match(/SyntaxError:\s*(.*)/)
+    return { ok: false, error: (syntax?.[1] ?? message).split('\n')[0]!, logs: [] }
+  }
   return { ok: false, error: `sandbox error: ${message}`, logs: [] }
 }

--- a/website/src/generated/deploy-version.ts
+++ b/website/src/generated/deploy-version.ts
@@ -3,4 +3,4 @@
 // main-worker compatibility_date). Used as the /mcp response-cache version
 // so any change to the hosted tool surface, transport, PNG path, SDK, or
 // worker runtime semantics invalidates cached tool results.
-export const DEPLOY_VERSION = 'v0.1.0-44dd74b8e9b2f36d0a253582'
+export const DEPLOY_VERSION = 'v0.1.0-1d2f7cb2d526d67827203d8d'


### PR DESCRIPTION
## Summary

Fixes the hosted MCP `execute` fallback path for production Worker Loader parser startup errors. Cloudflare can throw bare parser messages such as `Unexpected token 'const'` without a `SyntaxError:` prefix; the loader now treats those as syntax startup failures, retries statement-form execution, and reports final parser failures cleanly.

Also fixes the live MCP smoke-test Python quoting so `bash website/e2e-mcp.sh ...` works without disabling brace expansion, and regenerates the deploy-version hash for the rebased Worker source.

## Validation

- `bun run website:check`
- `bun test src/__tests__/deploy-hash.test.ts src/__tests__/website-build.test.ts src/__tests__/hosted-mcp.test.ts src/__tests__/hosted-mcp-http.test.ts src/__tests__/hosted-execute-loader.test.ts src/__tests__/hosted-execute-differential.test.ts`
- `WRANGLER_SEND_METRICS=false npx --yes wrangler@latest deploy --dry-run`
- Production deploy verified at `https://agentic-mermaid.dev/`
- `bash website/e2e-mcp.sh https://agentic-mermaid.dev/mcp` passed 26 checks
