### PR TITLE
Address PR #110 review: restore website:check gate, harden deploy, DOM-free lint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,13 @@ jobs:
       - name: Install dependencies
         run: bun install
 
+      # Must run before the test step: the test preload rebuilds website/public
+      # and re-emits website/src/generated, overwriting the committed worker
+      # inputs (wasm/harness/fonts/deploy-version) this check pins against
+      # source — so drift has to be caught before the rebuild runs.
+      - name: Check the committed website worker inputs are current
+        run: bun run website:check
+
       - name: Run tests (coverage = under-tested finder, NOT an adequacy target)
         # The pass/fail of this suite is the gate. Coverage is printed only to
         # locate under-tested files — it is deliberately NOT a quality target:
@@ -62,12 +69,6 @@ jobs:
         # Compares a deterministic fingerprint of the renderer output behind
         # assets/hero.png (diagram SVG + ASCII) — no fonts/rasterization needed.
         run: bun run hero:check
-
-      - name: Check the Workers Static Assets website is current
-        # website/public is generated from website/source plus product truth
-        # (capabilities, examples, skills). The check also rejects stale/orphan
-        # generated files and placeholder public links.
-        run: bun run website:check
 
       - name: Golden snapshot drift is a hard gate (reviewed-token required)
         # The decision logic lives in scripts/ci/golden-drift.ts and is

--- a/.github/workflows/deploy-cloudflare.yml
+++ b/.github/workflows/deploy-cloudflare.yml
@@ -2,8 +2,11 @@ name: Deploy website to Cloudflare
 
 # The canonical live site is agentic-mermaid.dev — a Cloudflare Workers Static
 # Assets deployment (website/build.ts -> website/public) that also serves the
-# hosted MCP endpoint at /mcp. This workflow builds the bundle and deploys it
-# with wrangler on every push to main.
+# hosted MCP endpoint at /mcp. This workflow rebuilds the bundle and deploys it
+# with wrangler.
+#
+# Gated on a successful CI run for the same commit on main, so a red commit
+# never reaches the live site. Also runnable manually via workflow_dispatch.
 #
 # Requires two repository secrets: CLOUDFLARE_API_TOKEN (a token with the
 # Workers Scripts:Edit permission) and CLOUDFLARE_ACCOUNT_ID.
@@ -13,18 +16,9 @@ name: Deploy website to Cloudflare
 # announcing the endpoint — deploying does not set those up.
 
 on:
-  push:
-    branches: [main]
-    paths:
-      - 'website/**'
-      - 'editor/**'
-      - 'src/**'
-      - 'skills/**'
-      - 'docs/**'
-      - 'skill-evals/**'
-      - 'llms.txt'
-      - 'package.json'
-      - '.github/workflows/deploy-cloudflare.yml'
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
   workflow_dispatch:
 
 concurrency:
@@ -33,11 +27,21 @@ concurrency:
 
 jobs:
   deploy:
+    # Deploy on a manual dispatch, or when CI succeeded on main.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.workflow_run.conclusion == 'success' &&
+       github.event.workflow_run.head_branch == 'main')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          # For a workflow_run trigger, build the exact commit CI validated.
+          ref: ${{ github.event.workflow_run.head_sha || github.ref }}
       - name: Setup Bun
         uses: oven-sh/setup-bun@v1
+        with:
+          bun-version: 1.3.13
       - name: Install dependencies
         run: bun install
       - name: Build the site bundle

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -45,6 +45,11 @@ jobs:
 
       # --- Release gate: mirror ci.yml's deterministic `test` job so a tagged
       # release cannot publish a commit that would fail CI.
+      # Runs before the test step, whose preload overwrites the committed worker
+      # inputs this check pins.
+      - name: Check the committed website worker inputs are current
+        run: bun run website:check
+
       - name: Run tests
         run: bun test src/__tests__/
 
@@ -53,9 +58,6 @@ jobs:
 
       - name: Check README hero image is current with the renderer
         run: bun run hero:check
-
-      - name: Check the Workers Static Assets website is current
-        run: bun run website:check
 
       - name: Golden snapshot drift gate
         run: bun run scripts/ci/golden-drift.ts

--- a/e2e/browser.test.ts
+++ b/e2e/browser.test.ts
@@ -60,22 +60,15 @@ async function waitForEditorRender(timeoutMs = 30_000): Promise<void> {
   )
 }
 
-/** Take a screenshot to a named file. */
-async function takeScreenshot(name: string): Promise<string> {
-  const path = join(SCREENSHOT_DIR, `${name}.png`)
-  await page.screenshot({ path })
-  return path
-}
-
 /**
  * Navigate to the local app without waiting for the page's load event.
  *
- * The generated showcase/editor pages run large module scripts and render many
- * SVGs before `load` can fire. On GitHub's slower Chromium runners that makes
+ * The generated editor page runs large module scripts and renders many SVGs
+ * before `load` can fire. On GitHub's slower Chromium runners that makes
  * Playwright's default `page.goto(..., waitUntil: "load")` flaky and leaves the
  * shared page in a pending-navigation state after one timeout. These tests wait
- * for app-specific readiness (`waitForRender`, `waitForEditorRender`, or a
- * selector) after navigation, so committing the response is the useful boundary.
+ * for app-specific readiness (`waitForEditorRender` or a selector) after
+ * navigation, so committing the response is the useful boundary.
  *
  * The page also embeds many SVGs whose Google Font imports can keep Chromium's
  * previous document in a loading state even after the app reports that rendering

--- a/eval/agent-usage/README.md
+++ b/eval/agent-usage/README.md
@@ -124,7 +124,7 @@ Prompt changes are gated three ways, cheapest-first:
    variant B: at variant A run `prepare --surface homepage` with a fixed case
    list, dispatch every `requests/*.md` to a fresh subagent, run `finalize`;
    repeat at variant B with the same cases, harness, and model. Follow the
-   `evals/shared-benchmark.json` run policy (≥3 runs per variant, 5
+   `skill-evals/shared-benchmark.json` run policy (≥3 runs per variant, 5
    recommended) because single runs are noise. Compare `ok` rate and the
    `taskOk`/`traceOk` split per case, plus response length as a proxy for
    discovery cost. Commit both transcript sets so the comparison replays

--- a/src/__tests__/comparison-differences-sync.test.ts
+++ b/src/__tests__/comparison-differences-sync.test.ts
@@ -7,8 +7,10 @@
 // removing a renderable family fails CI unless docs/comparison.md is updated.
 //
 // (The former scripts/site/differences.ts checks were retired with that Pages
-// generator; the Cloudflare /comparisons page renders every family from the
-// registry via website/build.ts, covered by website-build.test.ts.)
+// generator. The Cloudflare site's family coverage is pinned elsewhere: the
+// /comparisons page renders a curated per-family COMPARISON_CASES set, the
+// families-reference lead count is derived from the registry in website/build.ts,
+// and both are checked by website-build.test.ts + the citizenship matrix.)
 
 import { describe, test, expect } from 'bun:test'
 import { readFileSync } from 'node:fs'

--- a/src/__tests__/no-dom-in-product.test.ts
+++ b/src/__tests__/no-dom-in-product.test.ts
@@ -1,0 +1,57 @@
+// Enforces the "product source is DOM-free" invariant.
+//
+// The renderer is synchronous and browser-free by design. tsconfig ships the DOM
+// lib because the test program legitimately spans browser/worker-context files
+// (the editor-*-switch and website-browser-a11y tests, and website/src/worker.ts
+// pulled in transitively via website-build.test), so `bun x tsc --noEmit` no
+// longer flags accidental DOM globals in product code. This lint restores that
+// signal at the source level: no product file under src/ may reference a
+// DOM/browser global except the few that do deliberate, guarded environment
+// detection (allowlisted below).
+import { describe, expect, test } from 'bun:test'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { Glob } from 'bun'
+
+const SRC = join(import.meta.dir, '..')
+
+// Files permitted to name browser globals. Each does so via `typeof` guards or
+// an explicit local `declare`, for runtime environment detection — not real DOM
+// rendering. If you add a file here, it must keep that discipline.
+const ALLOWLIST = new Set<string>([
+  'browser.ts',       // the deliberate browser bundle entry (declare const window)
+  'elk-instance.ts',  // ELK worker shim: toggles a global `document` so elk-worker takes the worker path
+  'ascii/ansi.ts',    // declares `document` locally for a `typeof` color-support check
+])
+
+const GLOBALS = [
+  'document', 'window', 'getComputedStyle', 'customElements',
+  'HTMLElement', 'HTMLTextAreaElement', 'HTMLInputElement', 'HTMLDivElement',
+  'localStorage', 'sessionStorage', 'navigator', 'alert', 'requestAnimationFrame',
+]
+const pattern = new RegExp(`\\b(?:${GLOBALS.join('|')})\\b`)
+
+/** Blank out comments and string/template literals (newline-preserving) so only real code is scanned. */
+function stripNonCode(src: string): string {
+  const blank = (m: string) => m.replace(/[^\n]/g, ' ')
+  return src
+    .replace(/\/\*[\s\S]*?\*\//g, blank)     // block comments
+    .replace(/`(?:\\.|[^`\\])*`/g, blank)    // template literals (can span lines)
+    .replace(/\/\/[^\n]*/g, blank)           // line comments
+    .replace(/'(?:\\.|[^'\\])*'/g, ' ')      // single-quoted strings
+    .replace(/"(?:\\.|[^"\\])*"/g, ' ')      // double-quoted strings
+}
+
+describe('product source stays DOM-free', () => {
+  test('no product src/ file names a browser global outside the guarded allowlist', () => {
+    const offenders: string[] = []
+    for (const rel of new Glob('**/*.ts').scanSync(SRC)) {
+      if (rel.includes('__tests__/') || rel.endsWith('.d.ts') || ALLOWLIST.has(rel)) continue
+      const code = stripNonCode(readFileSync(join(SRC, rel), 'utf8'))
+      code.split('\n').forEach((line, i) => {
+        if (pattern.test(line)) offenders.push(`${rel}:${i + 1}  ${line.trim().slice(0, 90)}`)
+      })
+    }
+    expect(offenders).toEqual([])
+  })
+})

--- a/src/__tests__/website-public.preload.ts
+++ b/src/__tests__/website-public.preload.ts
@@ -5,13 +5,24 @@
 // so several tests (website-build, editor-*-switch, website-browser-a11y,
 // agent-doc-sync) would fail reading it. Build it once here, in a separate
 // process so the unit run's coverage instrumentation never touches the build.
-// Skipped when the bundle already exists (the common local case), so it only
-// costs a build on a clean tree or in CI.
-import { existsSync } from 'node:fs'
+//
+// Liveness is tracked by a sentinel written only AFTER a fully successful build.
+// index.html is emitted early in the build, so it is not a reliable marker — a
+// crashed or killed build would leave it behind and the next run would skip the
+// rebuild and test a half-built bundle. On failure the partial output is removed
+// so the next run rebuilds from scratch.
+import { existsSync, rmSync, writeFileSync } from 'node:fs'
 import { join } from 'node:path'
 
 const ROOT = join(import.meta.dir, '..', '..')
-if (!existsSync(join(ROOT, 'website', 'public', 'index.html'))) {
+const OUT = join(ROOT, 'website', 'public')
+const SENTINEL = join(OUT, '.preload-built')
+
+if (!existsSync(SENTINEL)) {
   const r = Bun.spawnSync(['bun', 'run', 'website/build.ts'], { cwd: ROOT, stdout: 'inherit', stderr: 'inherit' })
-  if (r.exitCode !== 0) throw new Error('website/public build (test preload) failed')
+  if (r.exitCode !== 0) {
+    rmSync(OUT, { recursive: true, force: true })
+    throw new Error('website/public build (test preload) failed')
+  }
+  writeFileSync(SENTINEL, '')
 }

--- a/website/build.ts
+++ b/website/build.ts
@@ -963,7 +963,11 @@ const FAMILY_REFERENCE: Array<[id: string, label: string, draws: string]> = [
   ['quadrant', 'Quadrant', 'Two-axis priority map with labeled regions and points.'],
   ['gantt', 'Gantt', 'Sections, dependencies, status tags, and a milestone.'],
 ]
-const familiesLead = 'Twelve families share one deterministic layout engine. Each parses from Mermaid text and renders to SVG, PNG, ASCII, Unicode, and layout JSON from the same positioned model.'
+// Number-word for the family count, derived from the registry so the published
+// prose can't drift from BUILTIN_FAMILY_METADATA (adding a family updates this).
+const FAMILY_COUNT_WORDS = ['zero', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight', 'nine', 'ten', 'eleven', 'twelve', 'thirteen', 'fourteen', 'fifteen', 'sixteen', 'seventeen', 'eighteen', 'nineteen', 'twenty']
+const familyCountWord = FAMILY_COUNT_WORDS[BUILTIN_FAMILY_METADATA.length] ?? String(BUILTIN_FAMILY_METADATA.length)
+const familiesLead = `${familyCountWord.charAt(0).toUpperCase()}${familyCountWord.slice(1)} families share one deterministic layout engine. Each parses from Mermaid text and renders to SVG, PNG, ASCII, Unicode, and layout JSON from the same positioned model.`
 function familiesReferenceHtml() {
   const rows = FAMILY_REFERENCE.map(([id, label, draws]) => `<tr id="${id}"><td><strong>${escapeHtml(label)}</strong></td><td>${escapeHtml(draws)}</td></tr>`).join('')
   return `<p>Every family carries a route certificate: a machine-checkable claim about how its edges were routed — orthogonal boxes for class and ER, lifelines for sequence, side-anchored links for architecture. That certificate is what lets <code>verify</code> answer in tiers instead of guessing.</p>


### PR DESCRIPTION
## What & why

Follow-up to the multi-agent review of #110 (already merged). Fixes all 8 confirmed findings — one real CI-guarantee regression plus deploy hardening and cleanup.

**CI / deploy (`70d1604`):**
- **Restore the `website:check` drift gate (finding #1, major).** The test preload rebuilds the bundle and re-emits `website/src/generated`, and `bun test` ran *before* `website:check` in `ci.yml`/`publish.yml` — so the check always compared freshly-regenerated worker inputs against source and could never catch stale committed inputs. Moved `website:check` before the test step in both workflows.
- **Gate the deploy on CI (#2).** `deploy-cloudflare.yml` auto-ran production (+ the public `/mcp`) on every push to `main` with no CI coupling; switched to `workflow_run` on a successful **CI** run for `main` (checks out the validated `head_sha`), keeping `workflow_dispatch`.
- **Pin the deploy's bun to 1.3.13 (#3)** — it's the only lane that emits the live harness/`deploy-version` artifact.
- **Robust preload (#5).** Replaced the early-emitted `index.html` "built" marker with a sentinel written only after a fully successful build; remove partial output on failure.

**Invariant + cleanup (`81b5d5d`):**
- **DOM-free-product lint (#4).** tsconfig ships the DOM lib (the test program transitively includes `website/src/worker.ts` via `website-build.test`), so tsc no longer flags accidental DOM use in the DOM-free renderer core. A scoped tsconfig split is infeasible; instead `no-dom-in-product.test.ts` fails if any product `src/` file names a browser global outside a small guarded allowlist. Proven red→green.
- **Registry-derived family count (#6).** `website/build.ts` now derives the published count word from `BUILTIN_FAMILY_METADATA.length` (was hardcoded "Twelve"); corrected an overstated coverage comment.
- **Removed dead `takeScreenshot()` (#7)** and **fixed one missed `evals/` → `skill-evals/` reference (#8).**

## Testing

- `bun test src/__tests__/` — **4510 pass / 0 fail** (incl. the new lint).
- `bun x tsc --noEmit` — **0 errors**.
- `bun run website:check` — in sync.
- `e2e/browser.test.ts` — **10 pass** in a real browser.
- DOM lint proven bug-discriminating (injecting `document.querySelector` into a product file fails it).

## Risk / notes

- **No committed goldens changed** (`src/__tests__/testdata/`, `__snapshots__/`).
- The `#2` `workflow_run` gate only takes effect once this lands on `main` (GitHub resolves the trigger from the default-branch workflow file), and it drops the old `paths` filter, so deploy runs after every successful CI on `main` (deploys are idempotent).

## Checklist

- [x] Tests pass locally (`bun test src/__tests__/`) and `bun x tsc --noEmit` is clean.
- [x] **Golden snapshots:** did **not** change committed goldens under `src/__tests__/testdata/`.
- [x] No diagram family added (N/A).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01L3Y4yTgpZYqdUXrYomch6w)_