### PR TITLE
Install sigstore inside npm for publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -40,12 +40,13 @@ jobs:
         # Node 22 bundles npm 10.9.x; trusted publishing needs npm >= 11.5.1.
         # Pin npm instead of using the moving `latest` tag: npm 12.0.0 shipped
         # without the `sigstore` module needed by libnpmpublish's provenance
-        # path on GitHub-hosted runners. Install `sigstore` alongside npm so
-        # package-level `publishConfig.provenance` can resolve it robustly.
+        # path on GitHub-hosted runners. Install `sigstore` into npm's own
+        # module tree so libnpmpublish can resolve it from inside npm.
         run: |
-          npm install -g npm@11.18.0 sigstore@latest
+          npm install -g npm@11.18.0
+          npm install --prefix "$(npm root -g)/npm" sigstore@latest --no-save
           npm --version
-          node -e "console.log(require.resolve('sigstore'))"
+          NPM_GLOBAL_ROOT="$(npm root -g)" node -e "const { createRequire } = require('module'); console.log(createRequire(process.env.NPM_GLOBAL_ROOT + '/npm/package.json').resolve('sigstore'))"
 
       - name: Install dependencies
         run: bun install


### PR DESCRIPTION
## What
- Installs sigstore into npm's own global module tree in publish.yml.
- Verifies resolution with a require rooted at npm/package.json.

## Why
The previous workflow installed sigstore as a global sibling, but Node resolution from npm's libnpmpublish does not search that sibling. The release run failed before publish during the resolution check.

## Testing
- git diff --check

## Risk
Workflow-only release fix; package code unchanged.