### PR TITLE
Copy sigstore into npm module tree

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -40,11 +40,15 @@ jobs:
         # Node 22 bundles npm 10.9.x; trusted publishing needs npm >= 11.5.1.
         # Pin npm instead of using the moving `latest` tag: npm 12.0.0 shipped
         # without the `sigstore` module needed by libnpmpublish's provenance
-        # path on GitHub-hosted runners. Install `sigstore` into npm's own
-        # module tree so libnpmpublish can resolve it from inside npm.
+        # path on GitHub-hosted runners. Install `sigstore` in a temp prefix,
+        # then copy that node_modules tree into npm's own module tree so
+        # libnpmpublish can resolve it from inside npm without asking npm to
+        # install dependencies for npm itself.
         run: |
           npm install -g npm@11.18.0
-          npm install --prefix "$(npm root -g)/npm" sigstore@latest --no-save
+          tmp_sigstore="$(mktemp -d)"
+          npm install --prefix "$tmp_sigstore" sigstore@latest
+          cp -R "$tmp_sigstore/node_modules/." "$(npm root -g)/npm/node_modules/"
           npm --version
           NPM_GLOBAL_ROOT="$(npm root -g)" node -e "const { createRequire } = require('module'); console.log(createRequire(process.env.NPM_GLOBAL_ROOT + '/npm/package.json').resolve('sigstore'))"
 


### PR DESCRIPTION
## What
- Installs sigstore in a temporary prefix during publish workflow setup.
- Copies the resulting node_modules tree into npm's own node_modules so libnpmpublish can resolve sigstore without trying to install npm's own dependencies.

## Why
The previous prefix install ran inside npm's package directory and npm attempted to resolve npm's package dependencies, including unavailable @npmcli/docs, before publish.

## Testing
- git diff --check

## Risk
Workflow-only release fix; package code unchanged.