### PR TITLE
Prepare agentic-mermaid 0.1.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This changelog tracks user-facing changes for **Agentic Mermaid**, a fork of `lu
 
 ## Unreleased
 
+_No changes yet._
+
+## 0.1.1 — 2026-07-10
+
 ### Added
 - **Standards-based agent discovery and MCP Registry publishing.** Agent guidance now states when to use Agentic Mermaid and when to keep diagrams local. The website publishes `/index.md`, negotiates it from `/` with `Vary: Accept`, and advertises machine-readable resources with RFC 8288 links. The npm package ships official `server.json` metadata, exposes the registry launch path as `npx -y agentic-mermaid mcp`, and publishes each new release to the MCP Registry after npm succeeds.
 

--- a/llms.txt
+++ b/llms.txt
@@ -4,7 +4,7 @@
 > Mermaid diagrams with a typed IR. Deterministic ASCII / PNG / SVG. No
 > browser required. CLI + MCP + library.
 
-Version: 0.1.0
+Version: 0.1.1
 
 ## What it does
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "agentic-mermaid",
   "mcpName": "io.github.adewale/agentic-mermaid",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "license": "MIT",
   "description": "Agentic Mermaid: render, verify, and safely edit Mermaid diagrams as ASCII, PNG, SVG, or structured agent workflows — with composable styles (hand-drawn, excalidraw, watercolor, or your own as JSON).",
   "type": "module",

--- a/server.json
+++ b/server.json
@@ -7,13 +7,13 @@
     "url": "https://github.com/adewale/agentic-mermaid",
     "source": "github"
   },
-  "version": "0.1.0",
+  "version": "0.1.1",
   "websiteUrl": "https://agentic-mermaid.dev/",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "agentic-mermaid",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "runtimeHint": "npx",
       "runtimeArguments": [
         {

--- a/website/src/generated/deploy-version.ts
+++ b/website/src/generated/deploy-version.ts
@@ -3,4 +3,4 @@
 // main-worker compatibility_date). Used as the /mcp response-cache version
 // so any change to the hosted tool surface, transport, PNG path, SDK, or
 // worker runtime semantics invalidates cached tool results.
-export const DEPLOY_VERSION = 'v0.1.0-c7fa08e9ddd64e7d11ce4a74'
+export const DEPLOY_VERSION = 'v0.1.1-c499561ec7b23c56103ed470'


### PR DESCRIPTION
## What

Prepare `agentic-mermaid` 0.1.1 for npm and Official MCP Registry publication.

## Why

The already-published npm `0.1.0` is immutable and predates the new `mcpName`, `server.json`, and package-name MCP launch route. A new package version is required before the Registry can validate and publish `io.github.adewale/agentic-mermaid`.

## How

- Bump `package.json` to `0.1.1` and keep the top-level and npm-package versions in `server.json` identical.
- Update the shipped root `llms.txt` version and regenerate the website deploy hash.
- Roll the standards-based discovery entry from Unreleased into `0.1.1` dated 2026-07-10, then open a fresh Unreleased section.
- Leave release execution to the existing GitHub Release workflow, which publishes npm first and the MCP Registry in a separately retryable dependent job.

## Testing

- [x] `bun run website:check` (13 generated Worker inputs in sync)
- [x] Focused release, agent-readiness, `llms.txt`, and doc-sync suite (60 passed, 0 failed)
- [x] `bun x tsc --noEmit`
- [x] Official `mcp-publisher v1.7.9 validate` against the live Registry
- [x] Rebuilt distributables; `dist/am.js capabilities --json` reports `0.1.1` and `mcp --help` routes correctly
- [x] `npm pack --dry-run --json` reports `agentic-mermaid@0.1.1` and includes `dist/am.js`, `llms.txt`, `package.json`, and `server.json`
- [x] Installed-tarball consumer fuzz (5 passed), including the package-name MCP route and stdio JSON-RPC
- [x] Confirmed npm returns 404 for `agentic-mermaid@0.1.1`, so the version is unused
- [x] Required GitHub CI: test, e2e, and mutation-incremental all passed

## Risk

Low code risk: this PR changes release metadata and one generated cache-version hash, not runtime behavior. Publication is intentionally irreversible on both npm and the MCP Registry, so the workflow will run only after this PR is green and merged, and the GitHub Release is created on that exact merge commit. The MCP Registry remains in preview; post-release verification covers both npm and the Registry API.
