### PR TITLE
Implement fluid editor interactions and accessibility fallbacks

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -174,3 +174,12 @@ The prompt card is the agent handoff primitive. It must keep copy controls visib
 - **Don't** use gradient text, decorative grid backgrounds, broad soft card shadows, or side-stripe borders.
 - **Don't** repeat tiny uppercase/mono section labels as page scaffolding when headings or grouping can do the work.
 - **Don't** hide core editor controls on mobile; adapt them so Source, Preview, Diagram, Unicode, ASCII, zoom, pan, copy, export, settings, examples, and theme remain reachable.
+
+## Motion Rules
+
+- Start any animation from the current presentation value; a fresh gesture cancels and takes control immediately.
+- Momentum belongs only to a gesture that supplied velocity. Click-triggered controls, menus, dialogs, tabs, and copy feedback never bounce or overshoot.
+- Rendering is a response path, never a choreography path: improve render latency and suppress spinner flashes rather than crossfading a preview swap.
+- Reduced motion preserves short opacity and colour feedback only. It never restores translation, scale, springs, or decorative movement.
+- Do not add translucent chrome. Existing frosted overlays must provide opaque reduced-transparency and increased-contrast fallbacks.
+- Keep rubber-band splitters, floating translucent preview toolbars, haptic copy ticks, global page transitions, and broad mechanical px-to-rem conversion out of this product surface unless separately justified and reviewed.

--- a/e2e/browser.test.ts
+++ b/e2e/browser.test.ts
@@ -288,6 +288,106 @@ describe('browser: live editor integration', () => {
     }
   }, 60_000)
 
+  it('retargets preview zoom and pauses a focused toast without blocking its eventual dismissal', async () => {
+    await gotoApp(`${BASE}/editor`)
+    await page.waitForSelector('#code-editor', { timeout: 30_000 })
+    await waitForEditorRender(60_000)
+
+    await page.click('#zoom-label')
+    await page.waitForFunction(() => document.getElementById('zoom-label')?.textContent === '100%', undefined, { timeout: 10_000 })
+    await page.click('#zoom-in-btn')
+    await page.click('#zoom-in-btn')
+    await page.click('#zoom-in-btn')
+    await page.waitForFunction(() => document.getElementById('zoom-label')?.textContent === '195%', undefined, { timeout: 10_000 })
+
+    await page.click('#pan-btn')
+    await page.evaluate(() => {
+      const body = document.getElementById('preview-body')!
+      const pointer = (type: string, pointerId: number, clientX: number, clientY: number) => body.dispatchEvent(new PointerEvent(type, {
+        bubbles: true, cancelable: true, pointerId, pointerType: 'touch', clientX, clientY,
+      }))
+      pointer('pointerdown', 1, 120, 160)
+      pointer('pointerdown', 2, 220, 160)
+      pointer('pointermove', 2, 300, 160)
+      pointer('pointerup', 2, 300, 160)
+      pointer('pointerup', 1, 120, 160)
+    })
+    await page.waitForFunction(() => Number.parseInt(document.getElementById('zoom-label')?.textContent || '0', 10) > 195, undefined, { timeout: 10_000 })
+
+    // The generated editor runs from a local HTTP origin, so clipboard access
+    // intentionally fails and exercises the same user-visible toast path.
+    await page.click('#copy-text-output-btn')
+    await page.locator('#toast.show').waitFor({ state: 'visible', timeout: 10_000 })
+    await page.locator('#toast').focus()
+    // Programmatic activation preserves focus on the status node, exercising
+    // replacement while a reader is still holding the pause.
+    await page.evaluate(() => (document.getElementById('copy-text-output-btn') as HTMLButtonElement).click())
+    await new Promise((resolve) => setTimeout(resolve, 150))
+    await new Promise((resolve) => setTimeout(resolve, 2600))
+    expect(await page.locator('#toast').evaluate((el) => el.classList.contains('show'))).toBe(true)
+    await page.locator('#zoom-label').focus()
+    await page.waitForFunction(() => !document.getElementById('toast')?.classList.contains('show'), undefined, { timeout: 4_000 })
+
+    await page.click('#export-chevron-btn')
+    await page.keyboard.press('Escape')
+    expect(await page.locator('#export-dropdown').evaluate((el) => ({ inert: (el as HTMLElement).inert, closing: el.classList.contains('closing') }))).toEqual({ inert: true, closing: true })
+    await page.waitForFunction(() => !document.getElementById('export-dropdown')?.classList.contains('closing'), undefined, { timeout: 1_000 })
+  }, 60_000)
+
+  it('lets an ordinary pointer grab preview momentum and suppresses coast under reduced motion', async () => {
+    async function preparePannablePreview() {
+      await gotoApp(`${BASE}/editor`)
+      await page.waitForSelector('#code-editor', { timeout: 30_000 })
+      await waitForEditorRender(60_000)
+      await page.click('#zoom-label')
+      await page.waitForFunction(() => document.getElementById('zoom-label')?.textContent === '100%', undefined, { timeout: 10_000 })
+      for (let i = 0; i < 6; i++) await page.click('#zoom-in-btn')
+      await page.waitForFunction(() => Number.parseInt(document.getElementById('zoom-label')?.textContent || '0', 10) >= 380, undefined, { timeout: 10_000 })
+      await page.click('#pan-btn')
+    }
+    async function flingLeft() {
+      const box = await page.locator('#preview-body').boundingBox()
+      expect(box).not.toBeNull()
+      const x = box!.x + box!.width * 0.6
+      const y = box!.y + box!.height * 0.5
+      await page.mouse.move(x, y)
+      await page.mouse.down()
+      await new Promise((resolve) => setTimeout(resolve, 24))
+      await page.mouse.move(x - 140, y)
+      await page.mouse.up()
+    }
+
+    await preparePannablePreview()
+    await flingLeft()
+    await new Promise((resolve) => setTimeout(resolve, 40))
+    const beforeGrab = await page.locator('#preview-body').evaluate((el) => (el as HTMLElement).scrollLeft)
+    await new Promise((resolve) => setTimeout(resolve, 120))
+    expect(await page.locator('#preview-body').evaluate((el) => (el as HTMLElement).scrollLeft)).toBeGreaterThan(beforeGrab)
+    // Start a fresh coast and grab it promptly, before it can reach its scroll bound.
+    await preparePannablePreview()
+    await flingLeft()
+    await new Promise((resolve) => setTimeout(resolve, 16))
+    await page.click('#pan-btn')
+    const box = await page.locator('#preview-body').boundingBox()
+    await page.mouse.move(box!.x + box!.width * 0.6, box!.y + box!.height * 0.5)
+    await page.mouse.down()
+    await page.mouse.up()
+    const afterGrab = await page.locator('#preview-body').evaluate((el) => (el as HTMLElement).scrollLeft)
+    await new Promise((resolve) => setTimeout(resolve, 120))
+    expect(await page.locator('#preview-body').evaluate((el) => (el as HTMLElement).scrollLeft)).toBe(afterGrab)
+
+    try {
+      await preparePannablePreview()
+      await page.emulateMedia({ reducedMotion: 'reduce' })
+      await flingLeft()
+      const afterRelease = await page.locator('#preview-body').evaluate((el) => (el as HTMLElement).scrollLeft)
+      await new Promise((resolve) => setTimeout(resolve, 160))
+      expect(await page.locator('#preview-body').evaluate((el) => (el as HTMLElement).scrollLeft)).toBe(afterRelease)
+    } finally {
+      await page.emulateMedia({ reducedMotion: 'no-preference' })
+    }
+  }, 60_000)
+
   it('empty-state CTA opens a persistent examples sidebar', async () => {
     await gotoApp(`${BASE}/editor`)
     await page.waitForSelector('#code-editor', { timeout: 30_000 })

--- a/e2e/browser.test.ts
+++ b/e2e/browser.test.ts
@@ -345,7 +345,7 @@ describe('browser: live editor integration', () => {
       await page.waitForFunction(() => Number.parseInt(document.getElementById('zoom-label')?.textContent || '0', 10) >= 380, undefined, { timeout: 10_000 })
       await page.click('#pan-btn')
     }
-    async function flingLeft() {
+    async function flingLeft(stationaryBeforeReleaseMs = 0) {
       const box = await page.locator('#preview-body').boundingBox()
       expect(box).not.toBeNull()
       const x = box!.x + box!.width * 0.6
@@ -354,6 +354,7 @@ describe('browser: live editor integration', () => {
       await page.mouse.down()
       await new Promise((resolve) => setTimeout(resolve, 24))
       await page.mouse.move(x - 140, y)
+      if (stationaryBeforeReleaseMs) await new Promise((resolve) => setTimeout(resolve, stationaryBeforeReleaseMs))
       await page.mouse.up()
     }
 
@@ -363,6 +364,13 @@ describe('browser: live editor integration', () => {
     const beforeGrab = await page.locator('#preview-body').evaluate((el) => (el as HTMLElement).scrollLeft)
     await new Promise((resolve) => setTimeout(resolve, 120))
     expect(await page.locator('#preview-body').evaluate((el) => (el as HTMLElement).scrollLeft)).toBeGreaterThan(beforeGrab)
+    // A release after a deliberate stationary hold must not reuse old drag velocity.
+    await preparePannablePreview()
+    await flingLeft(150)
+    const afterStationaryRelease = await page.locator('#preview-body').evaluate((el) => (el as HTMLElement).scrollLeft)
+    await new Promise((resolve) => setTimeout(resolve, 160))
+    expect(await page.locator('#preview-body').evaluate((el) => (el as HTMLElement).scrollLeft)).toBe(afterStationaryRelease)
+
     // Start a fresh coast and grab it promptly, before it can reach its scroll bound.
     await preparePannablePreview()
     await flingLeft()

--- a/e2e/browser.test.ts
+++ b/e2e/browser.test.ts
@@ -396,6 +396,22 @@ describe('browser: live editor integration', () => {
     }
   }, 60_000)
 
+  it('commits button zoom immediately under reduced motion', async () => {
+    await gotoApp(`${BASE}/editor`)
+    await page.waitForSelector('#code-editor', { timeout: 30_000 })
+    await waitForEditorRender(60_000)
+    try {
+      await page.emulateMedia({ reducedMotion: 'reduce' })
+      await page.click('#zoom-label')
+      await page.waitForFunction(() => document.getElementById('zoom-label')?.textContent === '100%', undefined, { timeout: 10_000 })
+      await page.click('#zoom-in-btn')
+      expect(await page.locator('#zoom-label').textContent()).toBe('125%')
+      expect(await page.locator('#preview-inner svg').evaluate((el) => ({ transform: (el as HTMLElement).style.transform, width: (el as HTMLElement).style.width }))).toEqual({ transform: '', width: expect.stringMatching(/px$/) })
+    } finally {
+      await page.emulateMedia({ reducedMotion: 'no-preference' })
+    }
+  }, 60_000)
+
   it('empty-state CTA opens a persistent examples sidebar', async () => {
     await gotoApp(`${BASE}/editor`)
     await page.waitForSelector('#code-editor', { timeout: 30_000 })

--- a/editor/css/affordances.css
+++ b/editor/css/affordances.css
@@ -45,18 +45,24 @@
 }
 :where(.export-dropdown, .theme-dropdown-menu, .font-popup, .color-popup) { z-index: var(--z-popover-nested); }
 
-/* Popovers enter from their trigger: one short ease-out fade/scale, with the
-   transform origin at the anchoring corner so the menu grows out of its button.
-   Exits stay instant — dismissal should never lag. The global reduced-motion
-   override in variables.css flattens these to 0.01ms. */
+/* Popovers close semantically on the event frame; this short noninteractive
+   visual tail preserves the origin path without trapping focus or clicks. */
 @keyframes popover-in {
   from { opacity: 0; transform: translateY(-2px) scale(0.98); }
+}
+@keyframes popover-out {
+  to { opacity: 0; transform: translateY(-2px) scale(0.98); }
 }
 :where(.export-dropdown, .theme-dropdown-menu, .font-popup, .color-popup).open {
   animation: popover-in var(--dur-control) var(--ease-out);
 }
-.export-dropdown.open, .theme-dropdown-menu.open { transform-origin: top right; }
-.font-popup.open, .color-popup.open { transform-origin: top left; }
+:where(.export-dropdown, .theme-dropdown-menu, .font-popup, .color-popup).closing {
+  display: flex;
+  pointer-events: none;
+  animation: popover-out 0.09s cubic-bezier(0.4, 0, 1, 1) both;
+}
+.export-dropdown.open, .theme-dropdown-menu.open, .export-dropdown.closing, .theme-dropdown-menu.closing { transform-origin: top right; }
+.font-popup.open, .color-popup.open, .font-popup.closing, .color-popup.closing { transform-origin: top left; }
 /* The scrim fades in; the centered panel fades and scales up behind it. */
 @keyframes dialog-in {
   from { opacity: 0; }
@@ -64,8 +70,16 @@
 @keyframes dialog-panel-in {
   from { opacity: 0; transform: scale(0.98) translateY(4px); }
 }
+@keyframes dialog-out {
+  to { opacity: 0; }
+}
+@keyframes dialog-panel-out {
+  to { opacity: 0; transform: scale(0.98) translateY(4px); }
+}
 .shortcuts-dialog.open { animation: dialog-in var(--dur-ui) var(--ease-out); }
 .shortcuts-dialog.open .shortcuts-dialog-panel { animation: dialog-panel-in var(--dur-ui) var(--ease-out); }
+.shortcuts-dialog.closing { animation: dialog-out 0.09s cubic-bezier(0.4, 0, 1, 1) both; }
+.shortcuts-dialog.closing .shortcuts-dialog-panel { animation: dialog-panel-out 0.09s cubic-bezier(0.4, 0, 1, 1) both; }
 :where(.preview-label, .panel-title, .verify-label, .text-output-label, .example-category-title, .font-section-label, .color-palette-title, .placeholder-kicker) {
   color: var(--fg3);
   font-family: var(--font-mono);

--- a/editor/css/misc.css
+++ b/editor/css/misc.css
@@ -37,8 +37,10 @@
 }
 .toast.show {
   opacity: 1;
+  pointer-events: auto;
   transform: translateX(-50%) translateY(-4px);
 }
+.toast.replacing { opacity: 0; pointer-events: none; }
 
 /* Keyboard shortcuts cheat sheet dialog */
 /* Gmail-style cheat sheet: a full-screen scrim dims the editor behind a
@@ -55,9 +57,11 @@
   -webkit-backdrop-filter: blur(2px);
   backdrop-filter: blur(2px);
 }
-.shortcuts-dialog.open {
+.shortcuts-dialog.open,
+.shortcuts-dialog.closing {
   display: flex;
 }
+.shortcuts-dialog.closing { pointer-events: none; }
 .shortcuts-dialog-panel {
   width: min(400px, calc(100vw - 32px));
   max-height: min(80vh, 520px);
@@ -135,6 +139,31 @@
   margin-top: 8px;
   font-size: var(--t-label);
   color: var(--fg4);
+}
+
+/* Accessibility preferences replace frosted overlays with fully solid surfaces. */
+@media (prefers-reduced-transparency: reduce), (prefers-contrast: more) {
+  .shortcuts-dialog {
+    background: var(--bg2);
+    -webkit-backdrop-filter: none;
+    backdrop-filter: none;
+  }
+  .shortcuts-dialog-panel {
+    background: var(--popover-bg);
+    border-color: var(--line-strong);
+    -webkit-backdrop-filter: none;
+    backdrop-filter: none;
+  }
+}
+
+/* Reduced motion still preserves the helpful status fade, never its rise. */
+@media (prefers-reduced-motion: reduce) {
+  .toast {
+    transform: translateX(-50%);
+    transition-property: opacity;
+    transition-duration: 0.15s !important;
+  }
+  .toast.show { transform: translateX(-50%); }
 }
 
 /* Scrollbar */

--- a/editor/css/panels.css
+++ b/editor/css/panels.css
@@ -285,6 +285,14 @@
   body[data-mobile-panel="preview"] .panel-right {
     display: flex;
   }
+  @media (prefers-reduced-motion: no-preference) {
+    @keyframes mobile-panel-in { from { opacity: 0; } to { opacity: 1; } }
+    body[data-mobile-panel="code"] .panel-left,
+    body[data-mobile-panel="config"] .panel-left,
+    body[data-mobile-panel="preview"] .panel-right {
+      animation: mobile-panel-in var(--dur-control) var(--ease-out);
+    }
+  }
   .examples-sidebar {
     width: var(--examples-width, calc(100vw - 20px));
   }

--- a/editor/js/buttons.js
+++ b/editor/js/buttons.js
@@ -147,6 +147,7 @@ function trapShortcutsFocus(e) {
 var shortcutsPopup = (shortcutsDialog && typeof createPopupController === 'function')
   ? createPopupController({
       popup: shortcutsDialog,
+      visualClose: true,
       visibility: { manageTabStops: true },
       afterOpen: function() {
         document.addEventListener('keydown', trapShortcutsFocus, true);

--- a/editor/js/buttons.js
+++ b/editor/js/buttons.js
@@ -119,6 +119,68 @@ document.addEventListener('click', function(e) {
 var shortcutsDialog = document.getElementById('shortcuts-dialog');
 var shortcutsDialogClose = document.getElementById('shortcuts-dialog-close');
 var shortcutsReturnFocus = null;
+var shortcutsInertSiblings = [];
+var shortcutsHomeParent = shortcutsDialog && shortcutsDialog.parentNode;
+var shortcutsHomeNextSibling = shortcutsDialog && shortcutsDialog.nextSibling;
+var shortcutsExitTail = null;
+var shortcutsExitTimer = null;
+
+function portalShortcutsDialog() {
+  if (shortcutsDialog && shortcutsDialog.parentNode !== document.body) document.body.appendChild(shortcutsDialog);
+}
+
+function restoreShortcutsDialog() {
+  if (!shortcutsDialog || !shortcutsHomeParent || shortcutsDialog.parentNode === shortcutsHomeParent) return;
+  shortcutsHomeParent.insertBefore(shortcutsDialog, shortcutsHomeNextSibling);
+}
+
+function clearShortcutsExitTail() {
+  if (shortcutsExitTimer) clearTimeout(shortcutsExitTimer);
+  shortcutsExitTimer = null;
+  if (shortcutsExitTail && shortcutsExitTail.parentNode) shortcutsExitTail.parentNode.removeChild(shortcutsExitTail);
+  shortcutsExitTail = null;
+}
+
+function createShortcutsExitTail() {
+  if (!shortcutsDialog || (typeof EditorMotion !== 'undefined' && EditorMotion.reduced())) return;
+  clearShortcutsExitTail();
+  var tail = shortcutsDialog.cloneNode(true);
+  tail.removeAttribute('id');
+  tail.removeAttribute('aria-modal');
+  tail.removeAttribute('aria-labelledby');
+  tail.setAttribute('aria-hidden', 'true');
+  tail.inert = true;
+  tail.querySelectorAll('[id]').forEach(function(node) { node.removeAttribute('id'); });
+  tail.style.pointerEvents = 'none';
+  document.body.appendChild(tail);
+  shortcutsExitTail = tail;
+  shortcutsExitTimer = setTimeout(clearShortcutsExitTail, 90);
+}
+
+function shortcutsReturnTarget(target) {
+  var fallback = null;
+  for (var node = target; node && node !== document.body; node = node.parentElement) {
+    if (!node.id) continue;
+    var trigger = document.querySelector('[aria-controls="' + node.id + '"]');
+    if (trigger && !trigger.closest('[inert]')) fallback = trigger;
+  }
+  return fallback || target;
+}
+
+function setShortcutsBackgroundInert(open) {
+  if (!shortcutsDialog) return;
+  if (open) {
+    shortcutsInertSiblings = [];
+    Array.prototype.forEach.call(document.body.children, function(child) {
+      if (child === shortcutsDialog) return;
+      shortcutsInertSiblings.push({ element: child, inert: child.inert });
+      child.inert = true;
+    });
+    return;
+  }
+  shortcutsInertSiblings.forEach(function(entry) { entry.element.inert = entry.inert; });
+  shortcutsInertSiblings = [];
+}
 
 function shortcutsFocusable() {
   if (!shortcutsDialog) return [];
@@ -150,10 +212,17 @@ var shortcutsPopup = (shortcutsDialog && typeof createPopupController === 'funct
       visualClose: true,
       visibility: { manageTabStops: true },
       afterOpen: function() {
+        clearShortcutsExitTail();
+        portalShortcutsDialog();
+        setShortcutsBackgroundInert(true);
         document.addEventListener('keydown', trapShortcutsFocus, true);
         if (shortcutsDialogClose) shortcutsDialogClose.focus();
       },
       afterClose: function() {
+        createShortcutsExitTail();
+        clearPopupClosing(shortcutsDialog);
+        restoreShortcutsDialog();
+        setShortcutsBackgroundInert(false);
         document.removeEventListener('keydown', trapShortcutsFocus, true);
         if (shortcutsReturnFocus && typeof shortcutsReturnFocus.focus === 'function') shortcutsReturnFocus.focus();
         shortcutsReturnFocus = null;
@@ -178,6 +247,6 @@ document.addEventListener('keydown', function(e) {
   // as the cheat-sheet shortcut when focus is outside editable controls.
   if (tag === 'TEXTAREA' || tag === 'INPUT' || tag === 'SELECT' || (target && target.isContentEditable)) return;
   e.preventDefault();
-  shortcutsReturnFocus = document.activeElement;
+  shortcutsReturnFocus = shortcutsReturnTarget(document.activeElement);
   shortcutsPopup.open({ source: 'keyboard' });
 });

--- a/editor/js/color-picker.js
+++ b/editor/js/color-picker.js
@@ -21,6 +21,7 @@ var colorPopupController = createPopupController({
   popup: colorPopup,
   trigger: function() { return activeColorAnchor; },
   closePeersOnOpen: false,
+  visualClose: true,
   triggerEvents: false,
   visibility: { focusSelector: '#color-hex-input' },
   beforeOpen: function() {

--- a/editor/js/export.js
+++ b/editor/js/export.js
@@ -25,6 +25,7 @@ var exportPopup = createPopupController({
   popup: exportDropdown,
   trigger: exportChevronBtn,
   visibility: { toggleTriggerClass: false },
+  visualClose: true,
   beforeOpen: updateExportAvailability,
   afterOpen: function(meta) {
     if (meta && meta.focusFirst) {

--- a/editor/js/font-picker.js
+++ b/editor/js/font-picker.js
@@ -85,6 +85,7 @@ var fontPopupController = createPopupController({
   popup: fontPopup,
   trigger: fontSelectBtn,
   closePeersOnOpen: false,
+  visualClose: true,
   visibility: { focusSelector: '#font-search' },
   beforeOpen: function() {
     // The colour picker is the one peer sharing the nested tier (both skip the

--- a/editor/js/helpers.js
+++ b/editor/js/helpers.js
@@ -23,10 +23,29 @@ function setDescendantTabStops(container, enabled) {
   });
 }
 
+function clearPopupClosing(popup) {
+  if (!popup) return;
+  if (popup._closingTimer) clearTimeout(popup._closingTimer);
+  popup._closingTimer = null;
+  popup.classList.remove('closing');
+}
+
+function startPopupClosing(popup, opts) {
+  if (!popup || !opts.visualClose || (typeof EditorMotion !== 'undefined' && EditorMotion.reduced())) return;
+  clearPopupClosing(popup);
+  popup.classList.add('closing');
+  popup._closingTimer = setTimeout(function() {
+    popup.classList.remove('closing');
+    popup._closingTimer = null;
+  }, opts.closeDuration || 90);
+}
+
 function setPopupVisibility(popup, trigger, open, opts) {
   if (!popup) return;
   opts = opts || {};
   var className = opts.className || 'open';
+  if (open) clearPopupClosing(popup);
+  else startPopupClosing(popup, opts);
   popup.classList.toggle(className, open);
   popup.setAttribute('aria-hidden', open ? 'false' : 'true');
   if (opts.inert !== false) popup.inert = !open;
@@ -68,7 +87,7 @@ function createPopupController(opts) {
       });
     }
     if (open && typeof opts.beforeOpen === 'function') opts.beforeOpen(meta, currentTrigger);
-    setPopupVisibility(popup, currentTrigger, open, Object.assign({ className: className }, opts.visibility || {}));
+    setPopupVisibility(popup, currentTrigger, open, Object.assign({ className: className, visualClose: opts.visualClose, closeDuration: opts.closeDuration }, opts.visibility || {}));
     if (open && typeof opts.afterOpen === 'function') opts.afterOpen(meta, currentTrigger);
     if (!open && typeof opts.afterClose === 'function') opts.afterClose(meta, currentTrigger);
     if (!open && meta.restoreFocus && opts.restoreFocus !== false && currentTrigger && typeof currentTrigger.focus === 'function') {

--- a/editor/js/init.js
+++ b/editor/js/init.js
@@ -45,6 +45,7 @@ var themeMenuPopup = createListboxPopupController({
   trigger: themeDropdownBtn,
   itemSelector: '.theme-dropdown-item',
   activeSelector: '.theme-dropdown-item.active',
+  visualClose: true,
   contains: function(target) { return !!target.closest("#theme-dropdown-wrap"); },
   onSelect: function(item) { setTheme(item.dataset.theme || ""); },
 });
@@ -111,6 +112,7 @@ var styleMenuPopup = createListboxPopupController({
   trigger: styleDropdownBtn,
   itemSelector: '.theme-dropdown-item',
   activeSelector: '.theme-dropdown-item.active',
+  visualClose: true,
   contains: function(target) { return !!target.closest("#style-dropdown-wrap"); },
   onSelect: function(item) { setStyle(item.dataset.style || "crisp"); },
 });

--- a/editor/js/motion.js
+++ b/editor/js/motion.js
@@ -1,0 +1,129 @@
+/* Shared, dependency-free motion primitives for the editor. The API is kept
+ * DOM-free so timers and geometry can be tested with fake rAF/performance. */
+var EditorMotion = (function() {
+  function clamp(value, min, max) {
+    return Math.min(max, Math.max(min, value));
+  }
+
+  function adaptiveRenderDelay(lastSuccessfulMs) {
+    if (!Number.isFinite(lastSuccessfulMs)) return 300;
+    return clamp(lastSuccessfulMs * 1.5, 60, 300);
+  }
+
+  function reduced() {
+    return !!(window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches);
+  }
+
+  function springTo(options) {
+    var from = options.from;
+    var to = options.to;
+    var velocity = options.velocity || 0;
+    var response = Math.max(0.05, options.response || 0.3);
+    var onFrame = options.onFrame || function() {};
+    var onDone = options.onDone;
+    var omega = (2 * Math.PI) / response;
+    var A = from - to;
+    var B = velocity + omega * A;
+    var start = performance.now();
+    var frameId = 0;
+    var active = true;
+    var state = { value: from, velocity: velocity };
+
+    function frame(now) {
+      if (!active) return;
+      var t = Math.max(0, (now - start) / 1000);
+      var decay = Math.exp(-omega * t);
+      state.value = to + (A + B * t) * decay;
+      state.velocity = (B - omega * (A + B * t)) * decay;
+      if (Math.abs(state.value - to) < 0.001 * Math.max(1, Math.abs(A)) && Math.abs(state.velocity) < 0.01) {
+        state.value = to;
+        state.velocity = 0;
+        onFrame(state.value, state.velocity);
+        active = false;
+        if (onDone) onDone(state.value, state.velocity);
+        return;
+      }
+      onFrame(state.value, state.velocity);
+      frameId = requestAnimationFrame(frame);
+    }
+
+    frameId = requestAnimationFrame(frame);
+    return {
+      cancel: function() {
+        if (!active) return;
+        active = false;
+        cancelAnimationFrame(frameId);
+      },
+      getState: function() { return { value: state.value, velocity: state.velocity }; },
+    };
+  }
+
+  function decay2d(options) {
+    var vx = options.vx || 0;
+    var vy = options.vy || 0;
+    var rate = options.rate || 0.998;
+    var onFrame = options.onFrame || function() {};
+    var onDone = options.onDone;
+    var last = performance.now();
+    var frameId = 0;
+    var active = true;
+
+    function frame(now) {
+      if (!active) return;
+      var dt = Math.min(0.05, Math.max(0, (now - last) / 1000));
+      last = now;
+      var factor = Math.pow(rate, dt * 1000);
+      vx *= factor;
+      vy *= factor;
+      if (Math.hypot(vx, vy) < 4) {
+        active = false;
+        if (onDone) onDone();
+        return;
+      }
+      if (onFrame(vx * dt, vy * dt, vx, vy) === false) {
+        active = false;
+        if (onDone) onDone();
+        return;
+      }
+      frameId = requestAnimationFrame(frame);
+    }
+
+    frameId = requestAnimationFrame(frame);
+    return {
+      cancel: function() {
+        if (!active) return;
+        active = false;
+        cancelAnimationFrame(frameId);
+      },
+      getVelocity: function() { return { vx: vx, vy: vy }; },
+    };
+  }
+
+  function makeVelocityTracker() {
+    var samples = [];
+    return {
+      reset: function() { samples.length = 0; },
+      push: function(time, x, y) {
+        samples.push({ time: time, x: x, y: y });
+        while (samples.length > 2 && time - samples[0].time > 100) samples.shift();
+      },
+      get: function() {
+        if (samples.length < 2) return { vx: 0, vy: 0 };
+        var first = samples[0];
+        var last = samples[samples.length - 1];
+        var elapsed = (last.time - first.time) / 1000;
+        if (elapsed <= 0) return { vx: 0, vy: 0 };
+        return { vx: (last.x - first.x) / elapsed, vy: (last.y - first.y) / elapsed };
+      },
+    };
+  }
+
+  return {
+    adaptiveRenderDelay: adaptiveRenderDelay,
+    clamp: clamp,
+    decay2d: decay2d,
+    makeVelocityTracker: makeVelocityTracker,
+    reduced: reduced,
+    springTo: springTo,
+  };
+})();

--- a/editor/js/pan.js
+++ b/editor/js/pan.js
@@ -2,11 +2,103 @@ var panBtn = document.getElementById('pan-btn');
 var panActive = false;
 var panStart = null;
 var panPointerId = null;
+var panTracker = EditorMotion.makeVelocityTracker();
+var panDecay = null;
+var activePanPointers = Object.create(null);
+var pinchState = null;
 
 function syncPanButton() {
   panBtn.classList.toggle('active', panActive);
   panBtn.setAttribute('aria-pressed', panActive ? 'true' : 'false');
   previewBody.classList.toggle('pan-mode', panActive);
+}
+
+function cancelPanMomentum() {
+  if (!panDecay) return;
+  panDecay.cancel();
+  panDecay = null;
+}
+
+function cancelPreviewMotion() {
+  cancelPanMomentum();
+  if (typeof cancelZoomMotion === 'function') cancelZoomMotion();
+}
+
+function pointerValues() {
+  return Object.keys(activePanPointers).map(function(id) { return activePanPointers[id]; });
+}
+
+function setPointer(event) {
+  activePanPointers[event.pointerId] = { id: event.pointerId, x: event.clientX, y: event.clientY, type: event.pointerType };
+}
+
+function shouldPan(event) {
+  return panActive || event.metaKey || event.ctrlKey;
+}
+
+function beginSinglePan(pointer) {
+  panPointerId = pointer.id;
+  panStart = { x: pointer.x, y: pointer.y, sl: previewBody.scrollLeft, st: previewBody.scrollTop };
+  pinchState = null;
+  panTracker.reset();
+  panTracker.push(performance.now(), pointer.x, pointer.y);
+  previewBody.classList.add('panning');
+}
+
+function beginPinch() {
+  var points = pointerValues();
+  if (points.length !== 2) return;
+  var dx = points[1].x - points[0].x;
+  var dy = points[1].y - points[0].y;
+  var distance = Math.max(1, Math.hypot(dx, dy));
+  pinchState = {
+    ids: [points[0].id, points[1].id],
+    distance: distance,
+    midpoint: { x: (points[0].x + points[1].x) / 2, y: (points[0].y + points[1].y) / 2 },
+    zoom: getPresentationZoom(),
+    sl: previewBody.scrollLeft,
+    st: previewBody.scrollTop,
+  };
+  panStart = null;
+  panPointerId = null;
+  previewBody.classList.add('panning');
+}
+
+function updatePinch() {
+  if (!pinchState) return;
+  var first = activePanPointers[pinchState.ids[0]];
+  var second = activePanPointers[pinchState.ids[1]];
+  if (!first || !second) return;
+  var dx = second.x - first.x;
+  var dy = second.y - first.y;
+  var distance = Math.max(1, Math.hypot(dx, dy));
+  var midpoint = { x: (first.x + second.x) / 2, y: (first.y + second.y) / 2 };
+  var nextZoom = constrainZoom(pinchState.zoom * distance / pinchState.distance);
+  setPresentationZoom(nextZoom, midpoint);
+  previewBody.scrollLeft = pinchState.sl - (midpoint.x - pinchState.midpoint.x);
+  previewBody.scrollTop = pinchState.st - (midpoint.y - pinchState.midpoint.y);
+}
+
+function beginMomentum() {
+  var velocity = panTracker.get();
+  if (Math.hypot(velocity.vx, velocity.vy) < 50) return;
+  cancelPanMomentum();
+  panDecay = EditorMotion.decay2d({
+    vx: velocity.vx,
+    vy: velocity.vy,
+    rate: 0.998,
+    onFrame: function(dx, dy) {
+      var beforeLeft = previewBody.scrollLeft;
+      var beforeTop = previewBody.scrollTop;
+      // Dragging right reveals content to the left; preserve that sign for coast.
+      previewBody.scrollLeft -= dx;
+      previewBody.scrollTop -= dy;
+      var movedX = previewBody.scrollLeft !== beforeLeft;
+      var movedY = previewBody.scrollTop !== beforeTop;
+      return movedX || movedY;
+    },
+    onDone: function() { panDecay = null; },
+  });
 }
 
 panBtn.addEventListener('click', function() {
@@ -15,62 +107,76 @@ panBtn.addEventListener('click', function() {
 });
 syncPanButton();
 
-// Pointer events (not mouse events) so pan works with touch and pen too;
-// pan-mode sets touch-action: none in CSS so touch drags reach us instead of
-// triggering native scrolling.
-previewBody.addEventListener('pointerdown', function(e) {
-  var shouldPan = panActive || e.metaKey || e.ctrlKey;
-  if (!shouldPan) return;
-  if (e.pointerType === 'mouse' && e.button !== 0) return;
-  e.preventDefault();
-  panPointerId = e.pointerId;
-  panStart = { x: e.clientX, y: e.clientY, sl: previewBody.scrollLeft, st: previewBody.scrollTop };
-  previewBody.classList.add('panning');
+previewBody.addEventListener('pointerdown', function(event) {
+  // A coast is always grabbable, even when the next pointerdown is not itself
+  // eligible to begin pan mode (for example after releasing Cmd/Ctrl).
+  cancelPanMomentum();
+  if (!shouldPan(event)) return;
+  if (event.pointerType === 'mouse' && event.button !== 0) return;
+  event.preventDefault();
+  cancelPreviewMotion();
+  setPointer(event);
   if (previewBody.setPointerCapture) {
-    try { previewBody.setPointerCapture(e.pointerId); } catch(err) {}
+    try { previewBody.setPointerCapture(event.pointerId); } catch (err) {}
   }
+  var points = pointerValues();
+  if (points.length === 1) beginSinglePan(points[0]);
+  else if (points.length === 2) beginPinch();
 });
 
-previewBody.addEventListener('pointermove', function(e) {
-  if (!panStart || e.pointerId !== panPointerId) return;
-  var dx = e.clientX - panStart.x;
-  var dy = e.clientY - panStart.y;
+previewBody.addEventListener('pointermove', function(event) {
+  if (!activePanPointers[event.pointerId]) return;
+  setPointer(event);
+  if (pinchState) {
+    updatePinch();
+    return;
+  }
+  if (!panStart || event.pointerId !== panPointerId) return;
+  var dx = event.clientX - panStart.x;
+  var dy = event.clientY - panStart.y;
   previewBody.scrollLeft = panStart.sl - dx;
-  previewBody.scrollTop  = panStart.st  - dy;
+  previewBody.scrollTop = panStart.st - dy;
+  panTracker.push(performance.now(), event.clientX, event.clientY);
 });
 
-function endPan(e) {
-  if (!panStart || e.pointerId !== panPointerId) return;
+function endPan(event, cancelled) {
+  if (!activePanPointers[event.pointerId]) return;
+  var wasPinching = !!pinchState;
+  delete activePanPointers[event.pointerId];
+  var remaining = pointerValues();
+
+  if (wasPinching) {
+    if (remaining.length === 1) beginSinglePan(remaining[0]);
+    else {
+      pinchState = null;
+      panStart = null;
+      panPointerId = null;
+      previewBody.classList.remove('panning');
+      commitPresentationZoom(getPresentationZoom());
+    }
+    return;
+  }
+
+  if (event.pointerId !== panPointerId) return;
   panStart = null;
   panPointerId = null;
   previewBody.classList.remove('panning');
+  if (!cancelled && !EditorMotion.reduced()) beginMomentum();
 }
-previewBody.addEventListener('pointerup', endPan);
-previewBody.addEventListener('pointercancel', endPan);
+previewBody.addEventListener('pointerup', function(event) { endPan(event, false); });
+previewBody.addEventListener('pointercancel', function(event) { endPan(event, true); });
 
-window.addEventListener('keydown', function(e) {
-  if (e.metaKey || e.ctrlKey) previewBody.classList.add('cmd-pan');
+window.addEventListener('keydown', function(event) {
+  if (event.metaKey || event.ctrlKey) previewBody.classList.add('cmd-pan');
 });
-window.addEventListener('keyup', function(e) {
-  if (!e.metaKey && !e.ctrlKey) previewBody.classList.remove('cmd-pan');
+window.addEventListener('keyup', function(event) {
+  if (!event.metaKey && !event.ctrlKey) previewBody.classList.remove('cmd-pan');
 });
 
-previewBody.addEventListener('wheel', function(e) {
-  if (!e.ctrlKey && !e.metaKey) return;
-  e.preventDefault();
-  var factor = Math.pow(0.999, e.deltaY);
-  var svgEl = previewInner.querySelector('svg');
-  if (!svgEl) {
-    applyZoom(state.zoom * factor);
-    return;
-  }
-  // Anchor the zoom at the cursor: remember which diagram point sits under it,
-  // apply the (clamped) zoom, then scroll so that point lands back under it.
-  var before = svgEl.getBoundingClientRect();
-  var px = (e.clientX - before.left) / (before.width || 1);
-  var py = (e.clientY - before.top) / (before.height || 1);
-  applyZoom(state.zoom * factor);
-  var after = svgEl.getBoundingClientRect();
-  previewBody.scrollLeft += (after.left + px * after.width) - e.clientX;
-  previewBody.scrollTop  += (after.top + py * after.height) - e.clientY;
+previewBody.addEventListener('wheel', function(event) {
+  cancelPanMomentum();
+  if (!event.ctrlKey && !event.metaKey) return;
+  event.preventDefault();
+  var factor = Math.pow(0.999, event.deltaY);
+  queueWheelZoom(getPresentationZoom() * factor, { x: event.clientX, y: event.clientY });
 }, { passive: false });

--- a/editor/js/pan.js
+++ b/editor/js/pan.js
@@ -161,7 +161,12 @@ function endPan(event, cancelled) {
   panStart = null;
   panPointerId = null;
   previewBody.classList.remove('panning');
-  if (!cancelled && !EditorMotion.reduced()) beginMomentum();
+  if (!cancelled && !EditorMotion.reduced()) {
+    // Release is a velocity sample too: a stationary hold before pointerup
+    // must clear an earlier drag's momentum rather than restarting it.
+    panTracker.push(performance.now(), event.clientX, event.clientY);
+    beginMomentum();
+  }
 }
 previewBody.addEventListener('pointerup', function(event) { endPan(event, false); });
 previewBody.addEventListener('pointercancel', function(event) { endPan(event, true); });

--- a/editor/js/rendering.js
+++ b/editor/js/rendering.js
@@ -1,5 +1,7 @@
 var renderTimer = null;
+var renderSpinnerTimer = null;
 var renderRequestVersion = 0;
+var lastSuccessfulRenderMs = null;
 var autoFitPending = true;
 
 function currentEditorSource() {
@@ -10,13 +12,21 @@ function isCurrentRender(version, source) {
   return version === renderRequestVersion && currentEditorSource() === source;
 }
 
+function clearRenderSpinner() {
+  if (renderSpinnerTimer) clearTimeout(renderSpinnerTimer);
+  renderSpinnerTimer = null;
+  spinner.classList.remove("visible");
+}
+
 function scheduleRender(delay) {
   var version = ++renderRequestVersion;
   if (renderTimer) clearTimeout(renderTimer);
+  clearRenderSpinner();
+  var nextDelay = delay == null ? EditorMotion.adaptiveRenderDelay(lastSuccessfulRenderMs) : delay;
   renderTimer = setTimeout(function() {
     renderTimer = null;
     doRender(version);
-  }, delay ?? 300);
+  }, nextDelay);
 }
 
 function hexToRgb(hex) {
@@ -412,6 +422,8 @@ function ensureTextOutputs(source) {
 
 async function doRender(version) {
   if (typeof version !== "number") version = ++renderRequestVersion;
+  if (typeof cancelPreviewMotion === 'function') cancelPreviewMotion();
+  clearRenderSpinner();
   var source = currentEditorSource();
   if (!source) {
     if (!isCurrentRender(version, source)) return;
@@ -427,13 +439,17 @@ async function doRender(version) {
     return;
   }
 
-  spinner.classList.add("visible");
   var t0 = performance.now();
+  renderSpinnerTimer = setTimeout(function() {
+    if (version === renderRequestVersion) spinner.classList.add("visible");
+  }, 250);
 
   try {
     var svg = await renderMermaid(source, buildOptions());
     if (!isCurrentRender(version, source)) return;
-    var ms = (performance.now() - t0).toFixed(0);
+    var renderMs = performance.now() - t0;
+    var ms = renderMs.toFixed(0);
+    lastSuccessfulRenderMs = renderMs;
     previewInner.innerHTML = svg;
     var svgEl = previewInner.querySelector("svg");
     ensurePreviewSvgAccessibility(svgEl, source);
@@ -466,6 +482,6 @@ async function doRender(version) {
     setTextOutputs("Fix the render error to see Unicode output.", "Fix the render error to see ASCII output.");
     if (typeof updateExportAvailability === "function") updateExportAvailability();
   } finally {
-    if (version === renderRequestVersion) spinner.classList.remove("visible");
+    if (version === renderRequestVersion) clearRenderSpinner();
   }
 }

--- a/editor/js/toast.js
+++ b/editor/js/toast.js
@@ -1,7 +1,74 @@
-var toastTimer;
-function showToast(msg) {
-  toast.textContent = msg;
-  toast.classList.add('show');
-  clearTimeout(toastTimer);
-  toastTimer = setTimeout(function() { toast.classList.remove('show'); }, 2500);
+var toastTimer = null;
+var toastReplacementTimer = null;
+var toastRemaining = 0;
+var toastStartedAt = 0;
+var toastPaused = false;
+var TOAST_DURATION = 2500;
+
+function clearToastTimer() {
+  if (toastTimer) clearTimeout(toastTimer);
+  toastTimer = null;
 }
+
+function hideToast() {
+  clearToastTimer();
+  toast.classList.remove('show');
+  toast.classList.remove('replacing');
+  toast.tabIndex = -1;
+  toastPaused = false;
+  toastRemaining = 0;
+}
+
+function scheduleToastDismissal() {
+  clearToastTimer();
+  if (toastPaused || toastRemaining <= 0) return;
+  toastStartedAt = performance.now();
+  toastTimer = setTimeout(hideToast, toastRemaining);
+}
+
+function pauseToast() {
+  if (!toast.classList.contains('show') || toastPaused) return;
+  toastRemaining = Math.max(0, toastRemaining - (performance.now() - toastStartedAt));
+  toastPaused = true;
+  clearToastTimer();
+}
+
+function resumeToast() {
+  if (!toast.classList.contains('show') || !toastPaused) return;
+  toastPaused = false;
+  scheduleToastDismissal();
+}
+
+function presentToast(message) {
+  // Replacing text must preserve a reader's active hover/focus pause; the
+  // replacement itself does not emit a new pointerenter/focusin event.
+  var remainsPaused = toast.matches(':hover, :focus-within');
+  toast.textContent = message;
+  toast.classList.remove('replacing');
+  toast.classList.add('show');
+  toast.tabIndex = 0;
+  toastRemaining = TOAST_DURATION;
+  toastPaused = remainsPaused;
+  if (!toastPaused) scheduleToastDismissal();
+}
+
+function showToast(message) {
+  if (toastReplacementTimer) clearTimeout(toastReplacementTimer);
+  if (toast.classList.contains('show')) {
+    clearToastTimer();
+    toast.classList.add('replacing');
+    toastReplacementTimer = setTimeout(function() {
+      toastReplacementTimer = null;
+      presentToast(message);
+    }, 80);
+    return;
+  }
+  presentToast(message);
+}
+
+toast.addEventListener('pointerenter', pauseToast);
+toast.addEventListener('pointerleave', resumeToast);
+toast.addEventListener('focusin', pauseToast);
+toast.addEventListener('focusout', function(event) {
+  if (!toast.contains(event.relatedTarget)) resumeToast();
+});

--- a/editor/js/zoom.js
+++ b/editor/js/zoom.js
@@ -1,34 +1,141 @@
 function getSvgNaturalSize(svgEl) {
   var vb = svgEl.viewBox && svgEl.viewBox.baseVal;
   if (vb && vb.width > 0 && vb.height > 0) return { w: vb.width, h: vb.height };
-  var w = parseFloat(svgEl.getAttribute('width'))  || svgEl.getBoundingClientRect().width  || 400;
+  var w = parseFloat(svgEl.getAttribute('width')) || svgEl.getBoundingClientRect().width || 400;
   var h = parseFloat(svgEl.getAttribute('height')) || svgEl.getBoundingClientRect().height || 300;
   return { w: w, h: h };
 }
 
-function applyZoom(z) {
-  state.zoom = Math.max(0.1, Math.min(8, z));
+var presentationZoom = state.zoom;
+var zoomTarget = state.zoom;
+var zoomSpring = null;
+var zoomCommitTimer = null;
+
+function constrainZoom(value) {
+  return Math.max(0.1, Math.min(8, value));
+}
+
+function zoomAnchor(anchor) {
+  if (anchor && Number.isFinite(anchor.x) && Number.isFinite(anchor.y)) return anchor;
+  var rect = previewBody.getBoundingClientRect();
+  return { x: rect.left + rect.width / 2, y: rect.top + rect.height / 2 };
+}
+
+function preserveZoomAnchor(svgEl, anchor, mutate) {
+  var point = zoomAnchor(anchor);
+  var before = svgEl.getBoundingClientRect();
+  var x = (point.x - before.left) / (before.width || 1);
+  var y = (point.y - before.top) / (before.height || 1);
+  mutate();
+  var after = svgEl.getBoundingClientRect();
+  previewBody.scrollLeft += (after.left + x * after.width) - point.x;
+  previewBody.scrollTop += (after.top + y * after.height) - point.y;
+}
+
+function getPresentationZoom() {
+  return presentationZoom;
+}
+
+function setPresentationZoom(value, anchor) {
+  presentationZoom = constrainZoom(value);
   var svgEl = previewInner.querySelector('svg');
-  if (svgEl) {
-    var nat = getSvgNaturalSize(svgEl);
-    svgEl.style.width  = (nat.w * state.zoom) + 'px';
-    svgEl.style.height = (nat.h * state.zoom) + 'px';
-    svgEl.style.transform = '';
+  if (!svgEl) {
+    zoomLabel.textContent = Math.round(presentationZoom * 100) + '%';
+    return presentationZoom;
   }
-  zoomLabel.textContent = Math.round(state.zoom * 100) + '%';
+  preserveZoomAnchor(svgEl, anchor, function() {
+    svgEl.style.transformOrigin = 'top left';
+    svgEl.style.transform = 'scale(' + (presentationZoom / state.zoom) + ')';
+  });
+  zoomLabel.textContent = Math.round(presentationZoom * 100) + '%';
+  return presentationZoom;
+}
+
+function clearZoomTimers() {
+  if (zoomCommitTimer) clearTimeout(zoomCommitTimer);
+  zoomCommitTimer = null;
+}
+
+function commitPresentationZoom(value, anchor) {
+  clearZoomTimers();
+  var target = constrainZoom(value == null ? presentationZoom : value);
+  var svgEl = previewInner.querySelector('svg');
+  state.zoom = target;
+  presentationZoom = target;
+  zoomTarget = target;
+  if (svgEl) {
+    preserveZoomAnchor(svgEl, anchor, function() {
+      var nat = getSvgNaturalSize(svgEl);
+      svgEl.style.width = (nat.w * target) + 'px';
+      svgEl.style.height = (nat.h * target) + 'px';
+      svgEl.style.transform = '';
+      svgEl.style.transformOrigin = '';
+    });
+  }
+  zoomLabel.textContent = Math.round(target * 100) + '%';
+  return target;
+}
+
+function cancelZoomMotion(commit) {
+  if (zoomSpring) {
+    zoomSpring.cancel();
+    zoomSpring = null;
+  }
+  clearZoomTimers();
+  if (commit !== false && Math.abs(presentationZoom - state.zoom) > 0.0001) commitPresentationZoom(presentationZoom);
+}
+
+function applyZoom(value, anchor) {
+  cancelZoomMotion(false);
+  return commitPresentationZoom(value, anchor);
+}
+
+function animateZoomTo(value, anchor) {
+  var target = constrainZoom(value);
+  zoomTarget = target;
+  if (EditorMotion.reduced()) return applyZoom(target, anchor);
+  var velocity = zoomSpring ? zoomSpring.getState().velocity : 0;
+  if (zoomSpring) zoomSpring.cancel();
+  clearZoomTimers();
+  var start = presentationZoom;
+  zoomSpring = EditorMotion.springTo({
+    from: start,
+    to: target,
+    velocity: velocity,
+    response: 0.3,
+    onFrame: function(next) { setPresentationZoom(next, anchor); },
+    onDone: function() {
+      zoomSpring = null;
+      commitPresentationZoom(target, anchor);
+    },
+  });
+}
+
+function queueWheelZoom(value, anchor) {
+  zoomTarget = constrainZoom(value);
+  if (zoomSpring) {
+    zoomSpring.cancel();
+    zoomSpring = null;
+  }
+  setPresentationZoom(zoomTarget, anchor);
+  clearZoomTimers();
+  zoomCommitTimer = setTimeout(function() {
+    zoomCommitTimer = null;
+    commitPresentationZoom(presentationZoom, anchor);
+  }, 120);
 }
 
 document.getElementById('zoom-in-btn').addEventListener('click', function() {
-  applyZoom(state.zoom * 1.25);
+  animateZoomTo(zoomTarget * 1.25);
 });
 document.getElementById('zoom-out-btn').addEventListener('click', function() {
-  applyZoom(state.zoom / 1.25);
+  animateZoomTo(zoomTarget / 1.25);
 });
-// The percentage readout doubles as the reset control.
 zoomLabel.addEventListener('click', function() {
-  applyZoom(1);
+  animateZoomTo(1);
 });
-function fitToView() {
+
+function fitToView(animate) {
   var svgEl = previewInner.querySelector('svg');
   if (!svgEl || !previewBody) { applyZoom(1); return; }
   var nat = getSvgNaturalSize(svgEl);
@@ -38,8 +145,9 @@ function fitToView() {
   var availW = previewBody.clientWidth - padX - 8;
   var availH = previewBody.clientHeight - padY - 8;
   if (availW <= 0 || availH <= 0 || nat.w <= 0 || nat.h <= 0) { applyZoom(1); return; }
-  // Shrink to fit; never enlarge a small diagram past its natural size.
-  applyZoom(Math.min(availW / nat.w, availH / nat.h, 1));
+  var target = Math.min(availW / nat.w, availH / nat.h, 1);
+  if (animate) animateZoomTo(target);
+  else applyZoom(target);
 }
 
-document.getElementById('zoom-fit-btn').addEventListener('click', fitToView);
+document.getElementById('zoom-fit-btn').addEventListener('click', function() { fitToView(true); });

--- a/research/apple-design-before-after-mock.html
+++ b/research/apple-design-before-after-mock.html
@@ -1,0 +1,813 @@
+<!doctype html><html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Agentic Mermaid — fluid-interface upgrades, before/after</title>
+<style>
+  /* ============ tokens: the site's own Kiln system, both schemes ============ */
+  :root {
+    --bg: #F8F4F0; --fg: #26201B; --accent: #1B6E52;
+    --plate: #FFFFFF;
+    --ink-soft: color-mix(in srgb, var(--fg) 80%, var(--bg));
+    --ink-faint: color-mix(in srgb, var(--fg) 64%, var(--bg));
+    --surface: color-mix(in srgb, var(--fg) 4%, var(--bg));
+    --chip: color-mix(in srgb, var(--fg) 9%, var(--bg));
+    --line: color-mix(in srgb, var(--fg) 13%, var(--bg));
+    --line-strong: color-mix(in srgb, var(--fg) 24%, var(--bg));
+    --accent-tint: color-mix(in srgb, var(--accent) 12%, var(--bg));
+    --scrim: rgba(24, 22, 18, 0.55);
+    --shadow-pop: 0 0 0 1px rgba(0,0,0,0.05), 0 4px 10px rgba(0,0,0,0.10), 0 18px 44px rgba(0,0,0,0.18);
+    --grain-o: 0.13;
+    --serif: Charter, 'Bitstream Charter', 'Iowan Old Style', 'Palatino Linotype', Palatino, Georgia, serif;
+    --sans: 'Avenir Next', Avenir, 'Segoe UI', system-ui, sans-serif;
+    --mono: 'SFMono-Regular', 'SF Mono', Menlo, Consolas, ui-monospace, monospace;
+    --ease-out: cubic-bezier(0.22, 1, 0.36, 1);
+  }
+  @media (prefers-color-scheme: dark) {
+    :root {
+      --bg: #17130D; --fg: #EBE7E0; --accent: #6FC2A2;
+      --plate: #141D19;
+      --scrim: rgba(0, 0, 0, 0.6);
+      --shadow-pop: 0 0 0 1px rgba(255,255,255,0.08), 0 18px 44px rgba(0,0,0,0.5);
+      --grain-o: 0.06;
+    }
+  }
+  :root[data-theme="dark"] {
+    --bg: #17130D; --fg: #EBE7E0; --accent: #6FC2A2;
+    --plate: #141D19;
+    --scrim: rgba(0, 0, 0, 0.6);
+    --shadow-pop: 0 0 0 1px rgba(255,255,255,0.08), 0 18px 44px rgba(0,0,0,0.5);
+    --grain-o: 0.06;
+  }
+  :root[data-theme="light"] {
+    --bg: #F8F4F0; --fg: #26201B; --accent: #1B6E52;
+    --plate: #FFFFFF;
+    --scrim: rgba(24, 22, 18, 0.55);
+    --shadow-pop: 0 0 0 1px rgba(0,0,0,0.05), 0 4px 10px rgba(0,0,0,0.10), 0 18px 44px rgba(0,0,0,0.18);
+    --grain-o: 0.13;
+  }
+
+  * { box-sizing: border-box; }
+  html { -webkit-font-smoothing: antialiased; text-rendering: optimizeLegibility; }
+  body {
+    margin: 0; background: var(--bg); color: var(--fg);
+    font-family: var(--sans); font-size: 1.0625rem; line-height: 1.6;
+  }
+  /* the site's grain, so the mock reads as the same material */
+  body::before {
+    content: ""; position: fixed; inset: 0; pointer-events: none; z-index: 0; opacity: var(--grain-o);
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='140' height='140'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='2' stitchTiles='stitch'/%3E%3CfeColorMatrix type='saturate' values='0'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E");
+  }
+  main { position: relative; z-index: 1; max-width: 920px; margin: 0 auto; padding: 48px 24px 96px; }
+
+  .kicker { margin: 0 0 10px; color: var(--ink-soft); font-family: var(--mono); font-size: 0.8125rem; font-weight: 650; }
+  h1 {
+    margin: 0 0 14px; font-family: var(--serif); font-weight: 600;
+    font-size: clamp(1.9rem, 4.5vw, 2.6rem); line-height: 1.08; letter-spacing: -0.018em; text-wrap: balance;
+  }
+  .lead { max-width: 46rem; margin: 0 0 8px; color: var(--ink-soft); font-size: 1.15rem; line-height: 1.5; text-wrap: pretty; }
+  .lead strong { color: var(--fg); }
+  .note { max-width: 46rem; margin: 0; color: var(--ink-faint); font-size: 0.875rem; }
+  .note code { font-family: var(--mono); font-size: 0.9em; background: var(--surface); padding: 1px 6px; border-radius: 6px; }
+
+  section.demo { margin-top: 56px; padding-top: 24px; border-top: 1px solid var(--line); }
+  section.demo h2 { margin: 0 0 6px; font-family: var(--serif); font-weight: 600; font-size: 1.45rem; line-height: 1.2; letter-spacing: -0.012em; text-wrap: balance; }
+  section.demo > p { max-width: 46rem; margin: 0 0 18px; color: var(--ink-soft); font-size: 0.9375rem; line-height: 1.55; text-wrap: pretty; }
+
+  .pair { display: grid; grid-template-columns: 1fr 1fr; gap: 14px; }
+  @media (max-width: 700px) { .pair { grid-template-columns: 1fr; } }
+  .card {
+    min-width: 0; display: flex; flex-direction: column;
+    border: 1px solid var(--line); border-radius: 12px; background: var(--surface);
+    overflow: hidden; box-shadow: 0 1px 0 color-mix(in srgb, var(--fg) 5%, transparent);
+  }
+  .card-head { display: flex; align-items: center; justify-content: space-between; gap: 10px; padding: 9px 12px; border-bottom: 1px solid var(--line); }
+  .tag { font-family: var(--mono); font-size: 0.75rem; font-weight: 650; padding: 2px 10px; border-radius: 999px; border: 1px solid var(--line-strong); color: var(--ink-soft); }
+  .card.after .tag { color: var(--accent); border-color: color-mix(in srgb, var(--accent) 45%, var(--line)); background: var(--accent-tint); }
+  .card-head small { color: var(--ink-faint); font-size: 0.75rem; font-family: var(--mono); }
+  .stage { position: relative; background: var(--plate); min-height: 170px; display: grid; place-items: center; overflow: hidden; }
+  .card-foot { display: flex; align-items: center; gap: 10px; padding: 9px 12px; border-top: 1px solid var(--line); min-height: 46px; }
+  .readout { margin-left: auto; color: var(--ink-faint); font-family: var(--mono); font-size: 0.78rem; font-variant-numeric: tabular-nums; white-space: nowrap; }
+
+  button.ctl {
+    font: 650 0.8125rem var(--sans); color: var(--ink-soft);
+    background: var(--surface); border: 1px solid var(--line-strong); border-radius: 8px;
+    min-height: 34px; padding: 0 12px; cursor: pointer;
+    transition: background 0.16s var(--ease-out), color 0.16s var(--ease-out), transform 0.1s var(--ease-out);
+  }
+  button.ctl:hover { background: var(--chip); color: var(--fg); }
+  button.ctl:active { transform: scale(0.96); }
+  button.ctl:focus-visible, .thumb:focus-visible, .seg button:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+  button.ctl.primary { background: var(--accent); border-color: var(--accent); color: var(--bg); }
+  button.ctl.primary:hover { background: color-mix(in srgb, var(--accent) 70%, var(--fg)); }
+
+  /* R1 — latency */
+  .minisrc { width: 100%; padding: 10px 14px; border-bottom: 1px dashed var(--line); font-family: var(--mono); font-size: 0.78rem; color: var(--ink-soft); white-space: pre; overflow-x: auto; }
+  .minisrc .caret { display: inline-block; width: 7px; height: 13px; background: var(--accent); vertical-align: -2px; opacity: 0; }
+  .minisrc .caret.on { opacity: 1; }
+  .r1-stage { display: flex; flex-direction: column; align-items: stretch; justify-content: flex-start; }
+  .r1-svgwrap { flex: 1; display: grid; place-items: center; padding: 12px; }
+  .spinner {
+    position: absolute; top: 10px; right: 10px; width: 16px; height: 16px; border-radius: 50%;
+    border: 2px solid var(--chip); border-top-color: var(--accent); opacity: 0;
+  }
+  .spinner.on { opacity: 1; animation: spin 0.6s linear infinite; }
+  @keyframes spin { to { transform: rotate(360deg); } }
+
+  .dia-node { fill: var(--surface); stroke: var(--line-strong); }
+  .dia-node.acc { stroke: var(--accent); }
+  .dia-edge { stroke: var(--ink-faint); fill: none; }
+  .dia-label { font: 600 10px var(--sans); fill: var(--fg); }
+
+  /* R3 — momentum pan */
+  .panbox { position: absolute; inset: 0; cursor: grab; touch-action: none; }
+  .panbox:focus-visible { outline: 2px solid var(--accent); outline-offset: -2px; }
+  .panbox.grabbing { cursor: grabbing; }
+  .pancontent { position: absolute; top: 0; left: 0; will-change: transform; }
+  .hint {
+    position: absolute; left: 10px; bottom: 8px; pointer-events: none;
+    font-family: var(--mono); font-size: 0.72rem; color: var(--ink-faint);
+    background: color-mix(in srgb, var(--plate) 82%, transparent); padding: 2px 8px; border-radius: 999px;
+  }
+
+  /* R2 — zoom */
+  .zoomwrap { position: absolute; inset: 0; display: grid; place-items: center; overflow: hidden; }
+  .zoomsubject { display: grid; justify-items: center; will-change: transform; }
+
+  /* R7 — lightbox */
+  .thumbrow { display: flex; gap: 10px; padding: 16px; }
+  .thumb { padding: 0; border: 1px solid var(--line); border-radius: 8px; background: var(--surface); cursor: zoom-in; display: block; }
+  .thumb svg { display: block; border-radius: 7px; }
+  .overlay { position: absolute; inset: 0; display: none; place-items: center; background: var(--scrim); z-index: 3; }
+  .overlay.open { display: grid; }
+  .overlay-panel {
+    width: 78%; max-width: 320px; border-radius: 12px; background: var(--bg);
+    border: 1px solid var(--line-strong); box-shadow: var(--shadow-pop); padding: 12px;
+    will-change: transform, opacity;
+  }
+  .overlay-panel h3 { margin: 0 0 8px; font: 600 0.9rem var(--sans); }
+  .overlay-panel .frame { display: grid; place-items: center; background: var(--plate); border: 1px solid var(--line); border-radius: 8px; padding: 10px; }
+  .overlay-panel footer { display: flex; justify-content: flex-end; margin-top: 10px; }
+
+  /* R6 — popover */
+  .popanchor { position: relative; }
+  .popmenu {
+    position: absolute; top: calc(100% + 6px); right: 0; z-index: 2; min-width: 150px;
+    background: var(--bg); border: 1px solid var(--line-strong); border-radius: 10px;
+    box-shadow: var(--shadow-pop); padding: 5px; display: none;
+    transform-origin: top right; will-change: transform, opacity;
+  }
+  .popmenu.open { display: block; }
+  .popmenu button { display: block; width: 100%; text-align: left; border: 0; background: transparent; cursor: pointer; padding: 7px 10px; border-radius: 6px; font: 500 0.8125rem var(--sans); color: var(--ink-soft); }
+  .popmenu button:hover { background: var(--chip); color: var(--fg); }
+  .popmenu button:focus-visible { outline: 2px solid var(--accent); outline-offset: -2px; }
+
+  /* R8 — mobile panel switch */
+  .phone { width: min(230px, 80%); border: 1px solid var(--line-strong); border-radius: 14px; overflow: hidden; background: var(--bg); }
+  .seg { display: flex; gap: 3px; padding: 5px; border-bottom: 1px solid var(--line); background: var(--surface); }
+  .seg button {
+    flex: 1; font: 650 0.72rem var(--sans); color: var(--ink-soft); background: transparent;
+    border: 0; border-radius: 6px; min-height: 28px; cursor: pointer;
+  }
+  .seg button[aria-pressed="true"] { background: var(--bg); color: var(--fg); box-shadow: 0 0 0 1px var(--line); }
+  .phone-body { position: relative; height: 120px; background: var(--plate); }
+  .phone-view { position: absolute; inset: 0; display: grid; place-items: center; }
+  .phone-view.src { padding: 10px 12px; place-items: start; font-family: var(--mono); font-size: 0.68rem; line-height: 1.7; color: var(--ink-soft); white-space: pre; }
+  .phone-view[hidden] { display: none; }
+  @keyframes fadein { from { opacity: 0; } }
+  .fade-on-show .phone-view:not([hidden]) { animation: fadein 0.12s var(--ease-out); }
+
+  /* R12 — toast */
+  .toast {
+    position: absolute; left: 50%; bottom: 12px; transform: translateX(-50%) translateY(6px);
+    background: var(--bg); border: 1px solid var(--line-strong); border-radius: 8px;
+    box-shadow: var(--shadow-pop); padding: 8px 12px 10px; min-width: 190px;
+    font: 500 0.8125rem var(--sans); opacity: 0; pointer-events: none;
+    visibility: hidden;
+    transition: opacity 0.2s, transform 0.2s, visibility 0s 0.2s;
+  }
+  .toast.show { opacity: 1; transform: translateX(-50%) translateY(0); pointer-events: auto; visibility: visible; transition: opacity 0.2s, transform 0.2s, visibility 0s; }
+  .toast .bar { height: 2px; margin-top: 7px; border-radius: 1px; background: var(--chip); overflow: hidden; }
+  .toast .bar i { display: block; height: 100%; width: 100%; background: var(--accent); transform-origin: left; }
+
+  /* remainder table */
+  .rest { margin-top: 56px; padding-top: 24px; border-top: 1px solid var(--line); }
+  .rest h2 { margin: 0 0 12px; font-family: var(--serif); font-weight: 600; font-size: 1.45rem; letter-spacing: -0.012em; }
+  .rest ul { list-style: none; margin: 0; padding: 0; display: grid; gap: 0; }
+  .rest li { display: flex; gap: 14px; align-items: baseline; padding: 11px 0; border-bottom: 1px solid var(--line); font-size: 0.9375rem; color: var(--ink-soft); }
+  .rest li b { color: var(--fg); }
+  .rest .rid { flex: none; width: 88px; font-family: var(--mono); font-size: 0.78rem; font-weight: 650; color: var(--accent); }
+  footer.colophon { margin-top: 48px; color: var(--ink-faint); font-size: 0.8125rem; max-width: 46rem; }
+
+  @media (prefers-reduced-motion: reduce) {
+    .spinner.on { animation: none; }
+    .fade-on-show .phone-view:not([hidden]) { animation: none; }
+    .toast { transition: opacity 0.15s, visibility 0s 0.15s; transform: translateX(-50%); }
+    .toast.show { transform: translateX(-50%); transition: opacity 0.15s, visibility 0s; }
+  }
+</style>
+
+<main>
+  <p class="kicker">agentic-mermaid · apple-design skill · mock, not screenshots</p>
+  <h1>Fluid-interface upgrades: what changes, side by side</h1>
+  <p class="lead">Nearly every recommendation in this PR is about <strong>motion and latency</strong>, which a static screenshot can't show. Each pair below is a <strong>working simulation</strong> — the “Proposed” cards run the actual physics from the plan (critically-damped springs, exponential momentum decay, grab-to-interrupt). Visual design of the site is intentionally unchanged.</p>
+  <p class="note">Ranks refer to <code>research/apple-design-fluid-interactions.md</code>. This page honors <code>prefers-reduced-motion</code>: with it enabled, “Proposed” demos fall back to fades and instant states — exactly the behavior the plan specifies (R11).</p>
+
+  <!-- ============================ R1 ============================ -->
+  <section class="demo" id="r1">
+    <h2><span style="font-family:var(--mono);font-size:0.8em;color:var(--accent)">Rank 1 · R1</span> — Type-to-render latency</h2>
+    <p>Today every keystroke waits a fixed 300&nbsp;ms debounce and flashes a spinner even when the render takes 25&nbsp;ms. Proposed: the debounce adapts to the last measured render time, and the spinner only appears for genuinely slow renders. Press the button in each card and watch the diagram respond.</p>
+    <div class="pair">
+      <div class="card before" data-r1 data-delay="300" data-spinner="1">
+        <div class="card-head"><span class="tag">Current</span><small>300 ms fixed debounce</small></div>
+        <div class="stage r1-stage">
+          <div class="minisrc">flowchart TD
+  A[Parse] --&gt; B[Verify]<span class="r1-newline"></span><span class="caret"></span></div>
+          <div class="r1-svgwrap"></div>
+          <div class="spinner"></div>
+        </div>
+        <div class="card-foot"><button class="ctl primary r1-go" type="button">Edit source</button><span class="readout">—</span></div>
+      </div>
+      <div class="card after" data-r1 data-delay="80" data-spinner="0">
+        <div class="card-head"><span class="tag">Proposed</span><small>adaptive ≈ 80 ms, no spinner flash</small></div>
+        <div class="stage r1-stage">
+          <div class="minisrc">flowchart TD
+  A[Parse] --&gt; B[Verify]<span class="r1-newline"></span><span class="caret"></span></div>
+          <div class="r1-svgwrap"></div>
+          <div class="spinner"></div>
+        </div>
+        <div class="card-foot"><button class="ctl primary r1-go" type="button">Edit source</button><span class="readout">—</span></div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ============================ R3 ============================ -->
+  <section class="demo" id="r3">
+    <h2><span style="font-family:var(--mono);font-size:0.8em;color:var(--accent)">Rank 4 · R3</span> — Momentum panning with grab-to-interrupt</h2>
+    <p>Today a drag-pan tracks the pointer 1:1 but stops dead the instant you let go. Proposed: the canvas inherits your release velocity and coasts with scroll-like deceleration — and touching it mid-coast grabs it exactly where it is. <strong>Flick each canvas.</strong></p>
+    <div class="pair">
+      <div class="card before" data-r3 data-momentum="0">
+        <div class="card-head"><span class="tag">Current</span><small>stops dead on release</small></div>
+        <div class="stage"><div class="panbox"><div class="pancontent"></div></div><span class="hint">drag / flick</span></div>
+        <div class="card-foot"><span class="readout">release velocity discarded</span></div>
+      </div>
+      <div class="card after" data-r3 data-momentum="1">
+        <div class="card-head"><span class="tag">Proposed</span><small>decay 0.998 · grab to stop</small></div>
+        <div class="stage"><div class="panbox"><div class="pancontent"></div></div><span class="hint">flick, then grab mid-coast</span></div>
+        <div class="card-foot"><span class="readout">—</span></div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ============================ R2 ============================ -->
+  <section class="demo" id="r2">
+    <h2><span style="font-family:var(--mono);font-size:0.8em;color:var(--accent)">Rank 5 · R2</span> — Smooth, interruptible zoom</h2>
+    <p>Today each zoom step lands as an instant ×1.25 jump (and relayouts the whole SVG). Proposed: one retargetable spring drives the scale — mash <b>+</b> three times fast and it glides to the final target with no jumps, starting every retarget from the live on-screen value.</p>
+    <div class="pair">
+      <div class="card before" data-r2 data-spring="0">
+        <div class="card-head"><span class="tag">Current</span><small>discrete ×1.25 steps</small></div>
+        <div class="stage"><div class="zoomwrap"><div class="zoomsubject"></div></div></div>
+        <div class="card-foot">
+          <button class="ctl z-out" type="button" aria-label="Zoom out">−</button>
+          <button class="ctl z-in" type="button" aria-label="Zoom in">+</button>
+          <button class="ctl z-reset" type="button">100%</button>
+          <span class="readout">100%</span>
+        </div>
+      </div>
+      <div class="card after" data-r2 data-spring="1">
+        <div class="card-head"><span class="tag">Proposed</span><small>critically-damped spring, response 0.3&nbsp;s</small></div>
+        <div class="stage"><div class="zoomwrap"><div class="zoomsubject"></div></div></div>
+        <div class="card-foot">
+          <button class="ctl z-out" type="button" aria-label="Zoom out">−</button>
+          <button class="ctl z-in" type="button" aria-label="Zoom in">+</button>
+          <button class="ctl z-reset" type="button">100%</button>
+          <span class="readout">100%</span>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ============================ R7 ============================ -->
+  <section class="demo" id="r7">
+    <h2><span style="font-family:var(--mono);font-size:0.8em;color:var(--accent)">Rank 7 · R7</span> — Comparison lightbox grows from its source</h2>
+    <p>On the public site's comparisons page, clicking a render pair opens the inspection dialog with no motion at all — it simply appears. Proposed: the dialog scales up from the panel you clicked and returns into it on close, so the spatial relationship is never lost. <strong>Click a thumbnail in each card.</strong></p>
+    <div class="pair">
+      <div class="card before" data-r7 data-anim="0">
+        <div class="card-head"><span class="tag">Current</span><small>appears / vanishes instantly</small></div>
+        <div class="stage">
+          <div class="thumbrow"></div>
+          <div class="overlay"><div class="overlay-panel" role="dialog" aria-modal="true" aria-label="Inspect render"><h3>Inspect render</h3><div class="frame"></div><footer><button class="ctl ov-close" type="button">Close</button></footer></div></div>
+        </div>
+        <div class="card-foot"><span class="readout">no origin, no path</span></div>
+      </div>
+      <div class="card after" data-r7 data-anim="1">
+        <div class="card-head"><span class="tag">Proposed</span><small>origin-aware · 200 ms in, 120 ms out</small></div>
+        <div class="stage">
+          <div class="thumbrow"></div>
+          <div class="overlay"><div class="overlay-panel" role="dialog" aria-modal="true" aria-label="Inspect render"><h3>Inspect render</h3><div class="frame"></div><footer><button class="ctl ov-close" type="button">Close</button></footer></div></div>
+        </div>
+        <div class="card-foot"><span class="readout">—</span></div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ============================ R12 ============================ -->
+  <section class="demo" id="r12">
+    <h2><span style="font-family:var(--mono);font-size:0.8em;color:var(--accent)">Rank 8 · R12</span> — Toasts stop racing the reader</h2>
+    <p>Editor toasts dismiss on a fixed 2.5&nbsp;s timer even while you're reading them. Proposed: hovering (or focusing) the toast pauses the timer; it resumes when you leave. <strong>Trigger the toast, then hold your pointer over it.</strong></p>
+    <div class="pair">
+      <div class="card before" data-r12 data-pause="0">
+        <div class="card-head"><span class="tag">Current</span><small>timer ignores the reader</small></div>
+        <div class="stage" style="min-height:130px">
+          <button class="ctl toast-go" type="button">Copy share link</button>
+          <div class="toast" role="status"><span class="msg"></span><span class="bar"><i></i></span></div>
+        </div>
+        <div class="card-foot"><span class="readout">dismisses under your cursor</span></div>
+      </div>
+      <div class="card after" data-r12 data-pause="1">
+        <div class="card-head"><span class="tag">Proposed</span><small>hover / focus pauses the timer</small></div>
+        <div class="stage" style="min-height:130px">
+          <button class="ctl toast-go" type="button">Copy share link</button>
+          <div class="toast" role="status"><span class="msg"></span><span class="bar"><i></i></span></div>
+        </div>
+        <div class="card-foot"><span class="readout">—</span></div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ============================ R6 ============================ -->
+  <section class="demo" id="r6">
+    <h2><span style="font-family:var(--mono);font-size:0.8em;color:var(--accent)">Rank 10 · R6</span> — Popovers exit the way they entered</h2>
+    <p>Editor menus animate in from their trigger but currently vanish instantly on close — an asymmetry the eye registers as unfinished. Proposed: a 90&nbsp;ms reverse along the same path, faster than the 160&nbsp;ms entrance so dismissal still feels immediate. <strong>Open and close each menu.</strong></p>
+    <div class="pair">
+      <div class="card before" data-r6 data-exit="0">
+        <div class="card-head"><span class="tag">Current</span><small>enter 160 ms · exit instant</small></div>
+        <div class="stage">
+          <div class="popanchor">
+            <button class="ctl pop-btn" type="button" aria-haspopup="true" aria-expanded="false">Export ▾</button>
+            <div class="popmenu" role="menu"><button type="button" role="menuitem">SVG</button><button type="button" role="menuitem">PNG</button><button type="button" role="menuitem">Copy source</button></div>
+          </div>
+        </div>
+        <div class="card-foot"><span class="readout">asymmetric</span></div>
+      </div>
+      <div class="card after" data-r6 data-exit="1">
+        <div class="card-head"><span class="tag">Proposed</span><small>enter 160 ms · exit 90 ms, same path</small></div>
+        <div class="stage">
+          <div class="popanchor">
+            <button class="ctl pop-btn" type="button" aria-haspopup="true" aria-expanded="false">Export ▾</button>
+            <div class="popmenu" role="menu"><button type="button" role="menuitem">SVG</button><button type="button" role="menuitem">PNG</button><button type="button" role="menuitem">Copy source</button></div>
+          </div>
+        </div>
+        <div class="card-foot"><span class="readout">symmetric</span></div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ============================ R8 ============================ -->
+  <section class="demo" id="r8">
+    <h2><span style="font-family:var(--mono);font-size:0.8em;color:var(--accent)">Rank 11 · R8</span> — Mobile panel switch: hard cut → soft cut</h2>
+    <p>On phones, switching Source/Preview flips the entire viewport with <code>display:none</code> — a jarring hard cut. Proposed: the incoming panel fades in over 120&nbsp;ms. <strong>Toggle the segmented control.</strong></p>
+    <div class="pair">
+      <div class="card before" data-r8 data-fade="0">
+        <div class="card-head"><span class="tag">Current</span><small>hard cut</small></div>
+        <div class="stage">
+          <div class="phone">
+            <div class="seg"><button type="button" data-v="src" aria-pressed="true">Source</button><button type="button" data-v="pre" aria-pressed="false">Preview</button></div>
+            <div class="phone-body">
+              <div class="phone-view src">flowchart TD
+  A[Parse] --&gt; B[Verify]
+  B --&gt; C[Serialize]</div>
+              <div class="phone-view pre" hidden></div>
+            </div>
+          </div>
+        </div>
+        <div class="card-foot"><span class="readout">display:none flip</span></div>
+      </div>
+      <div class="card after" data-r8 data-fade="1">
+        <div class="card-head"><span class="tag">Proposed</span><small>120 ms fade-in</small></div>
+        <div class="stage">
+          <div class="phone">
+            <div class="seg"><button type="button" data-v="src" aria-pressed="true">Source</button><button type="button" data-v="pre" aria-pressed="false">Preview</button></div>
+            <div class="phone-body">
+              <div class="phone-view src">flowchart TD
+  A[Parse] --&gt; B[Verify]
+  B --&gt; C[Serialize]</div>
+              <div class="phone-view pre" hidden></div>
+            </div>
+          </div>
+        </div>
+        <div class="card-foot"><span class="readout">soft cut</span></div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ============================ the rest ============================ -->
+  <section class="rest">
+    <h2>In the plan, not demoable on this page</h2>
+    <ul>
+      <li><span class="rid">Rank 2 · R11</span><span><b>Curated reduced-motion.</b> Both stylesheets currently zero <i>all</i> animation to 0.01 ms under <code>prefers-reduced-motion</code>, which also kills comprehension-aiding fades and theme-change easing. The plan restores short, transform-free fades — this very page behaves that way.</span></li>
+      <li><span class="rid">Rank 3 · F1</span><span><b>Motion utility.</b> The ~60-line vanilla spring/decay/velocity helper. The Proposed cards above literally run it — it is the prototype.</span></li>
+      <li><span class="rid">Rank 6 · R10</span><span><b>Transparency &amp; contrast fallbacks.</b> <code>prefers-reduced-transparency</code> and <code>prefers-contrast</code> are unhandled today on the frosted shortcuts dialog and lightbox backdrop; the plan adds solid equivalents. No visual change unless the OS signal is set.</span></li>
+      <li><span class="rid">Rank 9 · R5</span><span><b>Two-finger pinch zoom.</b> Touch users currently have no pinch at all in the preview. Needs a touch device to demonstrate; behavior = the R2 spring driven by two pointers.</span></li>
+      <li><span class="rid">Rank 12 · R15</span><span><b>Design-page specimens.</b> The shipped spring values and rulings get added to <code>/about/design</code> and <code>DESIGN.md</code> so future contributors inherit them.</span></li>
+    </ul>
+  </section>
+
+  <footer class="colophon">
+    Built with the site's own tokens (Kiln Stone / Charcoal grounds, Pine accent, Charter/Avenir/SF&nbsp;Mono stacks) so the pairs read as the real product. The static design of the site is deliberately untouched by this plan — every change above is behavioral. Full details, file:line references, and acceptance criteria: <span style="font-family:var(--mono)">research/apple-design-fluid-interactions.md</span>.
+  </footer>
+</main>
+
+<script>
+(function () {
+  'use strict';
+  var RM = matchMedia('(prefers-reduced-motion: reduce)');
+  function reduced() { return RM.matches; }
+
+  /* ==== F1: the actual motion utility from the plan (prototype) ==== */
+  function springTo(from, to, v0, response, onFrame, onDone) {
+    var omega = (2 * Math.PI) / response;
+    var A = from - to, B = v0 + omega * A;
+    var start = performance.now(), raf = 0;
+    function frame(now) {
+      var t = (now - start) / 1000, e = Math.exp(-omega * t);
+      var x = to + (A + B * t) * e;
+      var v = (B - omega * (A + B * t)) * e;
+      if (Math.abs(x - to) < 0.0015 * Math.max(1, Math.abs(A)) && Math.abs(v) < 0.02) {
+        onFrame(to, 0); if (onDone) onDone(); return;
+      }
+      onFrame(x, v);
+      raf = requestAnimationFrame(frame);
+    }
+    raf = requestAnimationFrame(frame);
+    return function cancel() { cancelAnimationFrame(raf); };
+  }
+  function decay2d(vx, vy, rate, onFrame, onDone) {
+    var last = performance.now(), raf = 0;
+    function frame(now) {
+      var dt = Math.min(0.05, (now - last) / 1000); last = now;
+      var k = Math.pow(rate, dt * 1000);
+      vx *= k; vy *= k;
+      if (Math.hypot(vx, vy) < 4) { if (onDone) onDone(); return; }
+      onFrame(vx * dt, vy * dt);
+      raf = requestAnimationFrame(frame);
+    }
+    raf = requestAnimationFrame(frame);
+    return function cancel() { cancelAnimationFrame(raf); };
+  }
+  function makeVelocityTracker() {
+    var samples = [];
+    return {
+      push: function (t, x, y) {
+        samples.push({ t: t, x: x, y: y });
+        while (samples.length > 2 && t - samples[0].t > 100) samples.shift();
+      },
+      get: function () {
+        if (samples.length < 2) return { vx: 0, vy: 0 };
+        var a = samples[0], b = samples[samples.length - 1];
+        var dt = (b.t - a.t) / 1000;
+        if (dt <= 0) return { vx: 0, vy: 0 };
+        return { vx: (b.x - a.x) / dt, vy: (b.y - a.y) / dt };
+      },
+      reset: function () { samples.length = 0; }
+    };
+  }
+
+  /* ==== tiny SVG diagram builders (generated, not hand-authored) ==== */
+  var SVGNS = 'http://www.w3.org/2000/svg';
+  function el(name, attrs, parent) {
+    var e = document.createElementNS(SVGNS, name);
+    for (var k in attrs) e.setAttribute(k, attrs[k]);
+    if (parent) parent.appendChild(e);
+    return e;
+  }
+  function miniDiagram(nodes) {
+    // nodes: array of {x,y,label,acc}
+    var svg = el('svg', { viewBox: '0 0 220 96', width: '220', height: '96', role: 'img', 'aria-label': 'Mini flowchart' });
+    for (var i = 1; i < nodes.length; i++) {
+      var a = nodes[i - 1], b = nodes[i];
+      el('path', { d: 'M' + (a.x + 26) + ' ' + a.y + ' L' + (b.x - 26) + ' ' + b.y, class: 'dia-edge', 'stroke-width': '1.3' }, svg);
+    }
+    nodes.forEach(function (n) {
+      el('rect', { x: n.x - 26, y: n.y - 14, width: 52, height: 28, rx: 6, class: 'dia-node' + (n.acc ? ' acc' : ''), 'stroke-width': '1.2' }, svg);
+      var t = el('text', { x: n.x, y: n.y + 3.5, 'text-anchor': 'middle', class: 'dia-label' }, svg);
+      t.textContent = n.label;
+    });
+    return svg;
+  }
+
+  /* ============================ R1 ============================ */
+  document.querySelectorAll('[data-r1]').forEach(function (card) {
+    var wrap = card.querySelector('.r1-svgwrap');
+    var spinner = card.querySelector('.spinner');
+    var readout = card.querySelector('.readout');
+    var btn = card.querySelector('.r1-go');
+    var newline = card.querySelector('.r1-newline');
+    var caret = card.querySelector('.caret');
+    var delay = parseInt(card.dataset.delay, 10);
+    var showSpinner = card.dataset.spinner === '1';
+    var extended = false, busy = false;
+
+    function draw() {
+      wrap.innerHTML = '';
+      var nodes = [{ x: 34, y: 48, label: 'Parse' }, { x: 110, y: 48, label: 'Verify' }];
+      if (extended) nodes.push({ x: 186, y: 48, label: 'Render', acc: true });
+      wrap.appendChild(miniDiagram(nodes));
+    }
+    draw();
+
+    btn.addEventListener('click', function () {
+      if (busy) return;
+      busy = true;
+      extended = !extended;
+      newline.textContent = extended ? '\n  B --> C[Render]' : '';
+      caret.classList.add('on');
+      if (showSpinner) spinner.classList.add('on');
+      readout.textContent = 'debouncing…';
+      var t0 = performance.now();
+      setTimeout(function () {                       // the debounce
+        setTimeout(function () {                     // the (fast) render itself
+          draw();
+          spinner.classList.remove('on');
+          caret.classList.remove('on');
+          readout.textContent = 'updated in ' + Math.round(performance.now() - t0) + ' ms';
+          busy = false;
+        }, 25);
+      }, delay);
+    });
+  });
+
+  /* ============================ R3 ============================ */
+  document.querySelectorAll('[data-r3]').forEach(function (card) {
+    var box = card.querySelector('.panbox');
+    var content = card.querySelector('.pancontent');
+    var readout = card.querySelector('.readout');
+    var momentum = card.dataset.momentum === '1';
+
+    // generate a wide node-field to pan around
+    var W = 1200, H = 520;
+    var svg = el('svg', { viewBox: '0 0 ' + W + ' ' + H, width: W, height: H, 'aria-hidden': 'true' });
+    var col = 0;
+    for (var gx = 50; gx < W; gx += 92) {
+      col++;
+      var row = 0;
+      for (var gy = 40; gy < H; gy += 72) {
+        row++;
+        var jitter = ((gx * 7 + gy * 13) % 3) - 1;
+        if (gx + 92 < W) el('path', { d: 'M' + (gx + 22) + ' ' + gy + ' L' + (gx + 72) + ' ' + (gy + jitter * 12), class: 'dia-edge', 'stroke-width': '1.2', opacity: '0.8' }, svg);
+        el('rect', { x: gx - 20, y: gy - 11, width: 40, height: 22, rx: 5, class: 'dia-node' + ((col + row) % 5 === 0 ? ' acc' : ''), 'stroke-width': '1.3' }, svg);
+      }
+    }
+    content.appendChild(svg);
+
+    var x = -220, y = -60, dragging = false, startX = 0, startY = 0, ox = 0, oy = 0;
+    var tracker = makeVelocityTracker(), cancelCoast = null;
+    function bounds() {
+      var r = box.getBoundingClientRect();
+      return { minX: Math.min(0, r.width - W), minY: Math.min(0, r.height - H) };
+    }
+    function apply() {
+      var b = bounds();
+      x = Math.max(b.minX, Math.min(0, x));
+      y = Math.max(b.minY, Math.min(0, y));
+      content.style.transform = 'translate(' + x + 'px,' + y + 'px)';
+    }
+    apply();
+
+    box.addEventListener('pointerdown', function (e) {
+      if (cancelCoast) { cancelCoast(); cancelCoast = null; readout.textContent = 'grabbed mid-coast'; }
+      dragging = true;
+      box.classList.add('grabbing');
+      box.setPointerCapture(e.pointerId);
+      startX = e.clientX; startY = e.clientY; ox = x; oy = y;
+      tracker.reset();
+      tracker.push(performance.now(), e.clientX, e.clientY);
+      e.preventDefault();
+    });
+    box.addEventListener('pointermove', function (e) {
+      if (!dragging) return;
+      x = ox + (e.clientX - startX);
+      y = oy + (e.clientY - startY);
+      tracker.push(performance.now(), e.clientX, e.clientY);
+      apply();
+    });
+    function up(e) {
+      if (!dragging) return;
+      dragging = false;
+      box.classList.remove('grabbing');
+      if (!momentum || reduced()) return;
+      tracker.push(performance.now(), e.clientX, e.clientY); // a hold before release reads as ~0 velocity
+      var v = tracker.get();
+      if (Math.hypot(v.vx, v.vy) < 50) return;
+      readout.textContent = 'coasting — ' + Math.round(Math.hypot(v.vx, v.vy)) + ' px/s handed off';
+      cancelCoast = decay2d(v.vx, v.vy, 0.998, function (dx, dy) {
+        x += dx; y += dy; apply();
+      }, function () { cancelCoast = null; readout.textContent = 'settled'; });
+    }
+    box.addEventListener('pointerup', up);
+    box.addEventListener('pointercancel', up);
+    box.tabIndex = 0;
+    box.setAttribute('aria-label', 'Pannable diagram canvas. Use arrow keys to pan.');
+    box.addEventListener('keydown', function (e) {
+      var step = e.shiftKey ? 120 : 40, dx = 0, dy = 0;
+      if (e.key === 'ArrowLeft') dx = step; else if (e.key === 'ArrowRight') dx = -step;
+      else if (e.key === 'ArrowUp') dy = step; else if (e.key === 'ArrowDown') dy = -step;
+      else return;
+      e.preventDefault();
+      if (cancelCoast) { cancelCoast(); cancelCoast = null; }
+      x += dx; y += dy; apply();
+    });
+  });
+
+  /* ============================ R2 ============================ */
+  document.querySelectorAll('[data-r2]').forEach(function (card) {
+    var subject = card.querySelector('.zoomsubject');
+    var readout = card.querySelector('.readout');
+    var useSpring = card.dataset.spring === '1';
+    subject.appendChild(miniDiagram([
+      { x: 34, y: 30, label: 'Source' }, { x: 110, y: 30, label: 'Layout' }, { x: 186, y: 30, label: 'SVG', acc: true },
+      ]));
+    // second row for a bit of visual mass
+    var svg2 = miniDiagram([{ x: 72, y: 20, label: 'Verify' }, { x: 148, y: 20, label: 'Export' }]);
+    svg2.setAttribute('viewBox', '0 0 220 40');
+    svg2.setAttribute('height', '40');
+    subject.appendChild(svg2);
+
+    var scale = 1, target = 1, vel = 0, cancel = null;
+    function render(s) { subject.style.transform = 'scale(' + s + ')'; readout.textContent = Math.round(s * 100) + '%'; }
+    function go(next) {
+      target = Math.max(0.4, Math.min(3, next));
+      if (!useSpring || reduced()) { if (cancel) cancel(); scale = target; vel = 0; render(scale); return; }
+      if (cancel) cancel();                      // retarget from the live value + velocity
+      cancel = springTo(scale, target, vel, 0.3, function (x, v) { scale = x; vel = v; render(x); },
+        function () { cancel = null; });
+    }
+    card.querySelector('.z-in').addEventListener('click', function () { go(target * 1.25); });
+    card.querySelector('.z-out').addEventListener('click', function () { go(target / 1.25); });
+    card.querySelector('.z-reset').addEventListener('click', function () { go(1); });
+    render(1);
+  });
+
+  /* ============================ R7 ============================ */
+  document.querySelectorAll('[data-r7]').forEach(function (card) {
+    var row = card.querySelector('.thumbrow');
+    var overlay = card.querySelector('.overlay');
+    var panel = card.querySelector('.overlay-panel');
+    var frame = card.querySelector('.frame');
+    var readout = card.querySelector('.readout');
+    var animate = card.dataset.anim === '1';
+    var labels = [['Crisp', 'Paper'], ['Sketch', 'Nord'], ['Blueprint', 'Dusk']];
+    var lastThumb = null;
+
+    labels.forEach(function (pair, i) {
+      var b = document.createElement('button');
+      b.type = 'button'; b.className = 'thumb';
+      b.setAttribute('aria-label', 'Inspect ' + pair[0] + ' × ' + pair[1]);
+      var s = miniDiagram([{ x: 60, y: 48, label: pair[0] }, { x: 160, y: 48, label: pair[1], acc: i === 1 }]);
+      s.setAttribute('width', '132'); s.setAttribute('height', '58');
+      b.appendChild(s);
+      row.appendChild(b);
+      b.addEventListener('click', function () { open(b, pair); });
+    });
+
+    function open(thumb, pair) {
+      frame.innerHTML = '';
+      var s = miniDiagram([{ x: 60, y: 48, label: pair[0] }, { x: 160, y: 48, label: pair[1], acc: true }]);
+      s.setAttribute('width', '100%'); s.removeAttribute('height');
+      frame.appendChild(s);
+      lastThumb = thumb;
+      overlay.classList.add('open');
+      if (animate && !reduced()) {
+        // origin is panel-relative; values outside 0-100% are valid and anchor correctly
+        var pr = panel.getBoundingClientRect(), tr = thumb.getBoundingClientRect();
+        var oxp = ((tr.left + tr.width / 2 - pr.left) / pr.width) * 100;
+        var oyp = ((tr.top + tr.height / 2 - pr.top) / pr.height) * 100;
+        panel.style.transformOrigin = oxp + '% ' + oyp + '%';
+        panel.animate(
+          [{ opacity: 0, transform: 'scale(0.86)' }, { opacity: 1, transform: 'scale(1)' }],
+          { duration: 200, easing: 'cubic-bezier(0.22, 1, 0.36, 1)' });
+        overlay.animate([{ backgroundColor: 'transparent' }, {}], { duration: 200 });
+        readout.textContent = 'origin: the panel you clicked';
+      } else if (animate) {
+        panel.animate([{ opacity: 0 }, { opacity: 1 }], { duration: 150 });
+      }
+      card.querySelector('.ov-close').focus();
+    }
+    function close() {
+      if (animate && !reduced()) {
+        var a = panel.animate(
+          [{ opacity: 1, transform: 'scale(1)' }, { opacity: 0, transform: 'scale(0.86)' }],
+          { duration: 120, easing: 'cubic-bezier(0.4, 0, 1, 1)' });
+        a.onfinish = function () { overlay.classList.remove('open'); if (lastThumb) lastThumb.focus(); };
+      } else {
+        overlay.classList.remove('open');
+        if (lastThumb) lastThumb.focus();
+      }
+    }
+    card.querySelector('.ov-close').addEventListener('click', close);
+    overlay.addEventListener('click', function (e) { if (e.target === overlay) close(); });
+    document.addEventListener('keydown', function (e) {
+      if (e.key === 'Escape' && overlay.classList.contains('open')) close();
+    });
+  });
+
+  /* ============================ R6 ============================ */
+  document.querySelectorAll('[data-r6]').forEach(function (card) {
+    var btn = card.querySelector('.pop-btn');
+    var menu = card.querySelector('.popmenu');
+    var symmetric = card.dataset.exit === '1';
+    var open = false, closing = null;
+
+    function setOpen(next) {
+      if (next === open && !closing) return;
+      if (closing) { closing.cancel(); closing = null; }
+      open = next;
+      btn.setAttribute('aria-expanded', String(open));
+      if (open) {
+        menu.classList.add('open');
+        if (!reduced()) {
+          menu.animate(
+            [{ opacity: 0, transform: 'translateY(-2px) scale(0.96)' }, { opacity: 1, transform: 'none' }],
+            { duration: 160, easing: 'cubic-bezier(0.22, 1, 0.36, 1)' });
+        }
+      } else if (symmetric && !reduced()) {
+        closing = menu.animate(
+          [{ opacity: 1, transform: 'none' }, { opacity: 0, transform: 'translateY(-2px) scale(0.96)' }],
+          { duration: 90, easing: 'cubic-bezier(0.4, 0, 1, 1)' });
+        closing.onfinish = function () { menu.classList.remove('open'); closing = null; };
+      } else {
+        menu.classList.remove('open');
+      }
+    }
+    btn.addEventListener('click', function () { setOpen(!open); });
+    document.addEventListener('pointerdown', function (e) {
+      if (open && !card.contains(e.target)) setOpen(false);
+    });
+    card.addEventListener('keydown', function (e) {
+      if (e.key === 'Escape' && open) { setOpen(false); btn.focus(); }
+    });
+  });
+
+  /* ============================ R8 ============================ */
+  document.querySelectorAll('[data-r8]').forEach(function (card) {
+    var fade = card.dataset.fade === '1';
+    var body = card.querySelector('.phone-body');
+    var views = { src: card.querySelector('.phone-view.src'), pre: card.querySelector('.phone-view.pre') };
+    views.pre.appendChild(miniDiagram([{ x: 60, y: 48, label: 'Parse' }, { x: 160, y: 48, label: 'Verify', acc: true }]));
+    if (fade) body.classList.add('fade-on-show');
+    card.querySelectorAll('.seg button').forEach(function (b) {
+      b.addEventListener('click', function () {
+        card.querySelectorAll('.seg button').forEach(function (o) { o.setAttribute('aria-pressed', String(o === b)); });
+        var show = b.dataset.v;
+        for (var k in views) views[k].hidden = (k !== show);
+        if (fade && !reduced()) {
+          // restart the fade-in animation on the incoming panel
+          var v = views[show];
+          v.style.animation = 'none';
+          void v.offsetWidth;
+          v.style.animation = '';
+        }
+      });
+    });
+  });
+
+  /* ============================ R12 ============================ */
+  document.querySelectorAll('[data-r12]').forEach(function (card) {
+    var pausable = card.dataset.pause === '1';
+    var toast = card.querySelector('.toast');
+    var bar = card.querySelector('.bar i');
+    var readout = card.querySelector('.readout');
+    var DURATION = 2500;
+    var remaining = 0, lastTick = 0, raf = 0, paused = false;
+
+    function tick(now) {
+      if (!paused) {
+        remaining -= (now - lastTick);
+        if (remaining <= 0) { hide(); return; }
+      }
+      lastTick = now;
+      bar.style.transform = 'scaleX(' + Math.max(0, remaining / DURATION) + ')';
+      raf = requestAnimationFrame(tick);
+    }
+    var msg = toast.querySelector('.msg');
+    function show() {
+      cancelAnimationFrame(raf);
+      remaining = DURATION; paused = false; lastTick = performance.now();
+      msg.textContent = 'Share link copied.';
+      toast.classList.add('show');
+      raf = requestAnimationFrame(tick);
+    }
+    function hide() {
+      toast.classList.remove('show');
+      msg.textContent = '';
+      cancelAnimationFrame(raf);
+      if (pausable) readout.textContent = '—';
+    }
+    card.querySelector('.toast-go').addEventListener('click', show);
+    if (pausable) {
+      toast.addEventListener('pointerenter', function () { paused = true; readout.textContent = 'timer paused'; });
+      toast.addEventListener('pointerleave', function () { paused = false; lastTick = performance.now(); readout.textContent = 'timer resumed'; });
+      toast.addEventListener('focusin', function () { paused = true; });
+      toast.addEventListener('focusout', function () { paused = false; lastTick = performance.now(); });
+      toast.tabIndex = 0;
+    }
+  });
+})();
+</script>

--- a/research/apple-design-before-after-mock.html
+++ b/research/apple-design-before-after-mock.html
@@ -750,27 +750,60 @@
     var symmetric = card.dataset.exit === '1';
     var open = false, closing = null;
 
+    function setMenuSemantics(next) {
+      menu.setAttribute('aria-hidden', String(!next));
+      menu.inert = !next;
+      menu.querySelectorAll('button, [href], input, select, textarea, [tabindex]').forEach(function (el) {
+        if (next) el.removeAttribute('tabindex');
+        else el.setAttribute('tabindex', '-1');
+      });
+    }
+    function clearClosing() {
+      if (!closing) return;
+      var state = closing;
+      closing = null;
+      state.animation.cancel();
+      if (state.element.parentNode) state.element.parentNode.removeChild(state.element);
+    }
+    function animateExitTail() {
+      if (!symmetric || reduced()) return;
+      var rect = menu.getBoundingClientRect();
+      var tail = menu.cloneNode(true);
+      tail.setAttribute('aria-hidden', 'true');
+      tail.inert = true;
+      tail.querySelectorAll('button, [href], input, select, textarea, [tabindex]').forEach(function (el) { el.setAttribute('tabindex', '-1'); });
+      tail.style.cssText += ';display:block;position:fixed;z-index:2147483647;top:' + rect.top + 'px;left:' + rect.left + 'px;width:' + rect.width + 'px;height:' + rect.height + 'px;margin:0;pointer-events:none;overflow:hidden';
+      document.body.appendChild(tail);
+      var state = { element: tail, animation: tail.animate(
+        [{ opacity: 1, transform: 'none' }, { opacity: 0, transform: 'translateY(-2px) scale(0.96)' }],
+        { duration: 90, easing: 'cubic-bezier(0.4, 0, 1, 1)' }) };
+      closing = state;
+      state.animation.onfinish = state.animation.oncancel = function () {
+        if (closing === state) closing = null;
+        if (tail.parentNode) tail.parentNode.removeChild(tail);
+      };
+    }
     function setOpen(next) {
       if (next === open && !closing) return;
-      if (closing) { closing.cancel(); closing = null; }
+      clearClosing();
       open = next;
       btn.setAttribute('aria-expanded', String(open));
       if (open) {
+        setMenuSemantics(true);
         menu.classList.add('open');
         if (!reduced()) {
           menu.animate(
             [{ opacity: 0, transform: 'translateY(-2px) scale(0.96)' }, { opacity: 1, transform: 'none' }],
             { duration: 160, easing: 'cubic-bezier(0.22, 1, 0.36, 1)' });
         }
-      } else if (symmetric && !reduced()) {
-        closing = menu.animate(
-          [{ opacity: 1, transform: 'none' }, { opacity: 0, transform: 'translateY(-2px) scale(0.96)' }],
-          { duration: 90, easing: 'cubic-bezier(0.4, 0, 1, 1)' });
-        closing.onfinish = function () { menu.classList.remove('open'); closing = null; };
       } else {
+        if (menu.contains(document.activeElement)) btn.focus();
+        animateExitTail();
         menu.classList.remove('open');
+        setMenuSemantics(false);
       }
     }
+    setMenuSemantics(false);
     btn.addEventListener('click', function () { setOpen(!open); });
     document.addEventListener('pointerdown', function (e) {
       if (open && !card.contains(e.target)) setOpen(false);

--- a/research/apple-design-before-after-mock.html
+++ b/research/apple-design-before-after-mock.html
@@ -664,7 +664,7 @@
     var readout = card.querySelector('.readout');
     var animate = card.dataset.anim === '1';
     var labels = [['Crisp', 'Paper'], ['Sketch', 'Nord'], ['Blueprint', 'Dusk']];
-    var lastThumb = null, dialogAnimation = null, dialogClosing = false;
+    var lastThumb = null, dialogAnimation = null, exitTail = null;
 
     labels.forEach(function (pair, i) {
       var b = document.createElement('button');
@@ -684,6 +684,7 @@
       frame.appendChild(s);
       lastThumb = thumb;
       if (dialogAnimation) dialogAnimation.cancel();
+      clearExitTail();
       overlay.showModal();
       if (animate && !reduced()) {
         var pr = panel.getBoundingClientRect(), tr = thumb.getBoundingClientRect();
@@ -699,16 +700,34 @@
       }
       card.querySelector('.ov-close').focus();
     }
+    function clearExitTail() {
+      if (!exitTail) return;
+      exitTail.animation.cancel();
+      if (exitTail.element.parentNode) exitTail.element.parentNode.removeChild(exitTail.element);
+      exitTail = null;
+    }
+    function makeExitTail() {
+      if (!animate || reduced()) return;
+      clearExitTail();
+      var rect = panel.getBoundingClientRect();
+      var tail = panel.cloneNode(true);
+      tail.setAttribute('aria-hidden', 'true');
+      tail.inert = true;
+      tail.querySelectorAll('[id]').forEach(function (node) { node.removeAttribute('id'); });
+      tail.style.cssText += ';display:block;position:fixed;z-index:2147483647;top:' + rect.top + 'px;left:' + rect.left + 'px;width:' + rect.width + 'px;height:' + rect.height + 'px;margin:0;pointer-events:none;overflow:hidden';
+      document.body.appendChild(tail);
+      var state = { element: tail, animation: tail.animate([{ opacity: 1, transform: 'scale(1)' }, { opacity: 0, transform: 'scale(0.86)' }], { duration: 120, easing: 'cubic-bezier(0.4, 0, 1, 1)' }) };
+      exitTail = state;
+      state.animation.onfinish = state.animation.oncancel = function () {
+        if (exitTail === state) exitTail = null;
+        if (tail.parentNode) tail.parentNode.removeChild(tail);
+      };
+    }
     function close() {
-      if (!overlay.open || dialogClosing) return;
-      if (!animate) { overlay.close(); return; }
-      dialogClosing = true;
+      if (!overlay.open) return;
       if (dialogAnimation) dialogAnimation.cancel();
-      dialogAnimation = reduced()
-        ? panel.animate([{ opacity: 1 }, { opacity: 0 }], { duration: 120 })
-        : panel.animate([{ opacity: 1, transform: 'scale(1)' }, { opacity: 0, transform: 'scale(0.86)' }], { duration: 120, easing: 'cubic-bezier(0.4, 0, 1, 1)' });
-      dialogAnimation.onfinish = function () { dialogClosing = false; if (overlay.open) overlay.close(); };
-      dialogAnimation.oncancel = function () { dialogClosing = false; };
+      makeExitTail();
+      overlay.close();
     }
     card.querySelector('.ov-close').addEventListener('click', close);
     overlay.addEventListener('click', function (e) { if (e.target === overlay) close(); });
@@ -721,7 +740,7 @@
       if (e.shiftKey && document.activeElement === first) { e.preventDefault(); last.focus(); }
       else if (!e.shiftKey && document.activeElement === last) { e.preventDefault(); first.focus(); }
     });
-    overlay.addEventListener('close', function () { dialogClosing = false; if (lastThumb) lastThumb.focus(); });
+    overlay.addEventListener('close', function () { if (lastThumb) lastThumb.focus(); });
   });
 
   /* ============================ R6 ============================ */

--- a/research/apple-design-before-after-mock.html
+++ b/research/apple-design-before-after-mock.html
@@ -135,10 +135,10 @@
   .thumbrow { display: flex; gap: 10px; padding: 16px; }
   .thumb { padding: 0; border: 1px solid var(--line); border-radius: 8px; background: var(--surface); cursor: zoom-in; display: block; }
   .thumb svg { display: block; border-radius: 7px; }
-  .overlay { position: absolute; inset: 0; display: none; place-items: center; background: var(--scrim); z-index: 3; }
-  .overlay.open { display: grid; }
+  .overlay { width: min(78vw, 320px); max-width: 320px; border: 0; padding: 0; background: transparent; }
+  .overlay::backdrop { background: var(--scrim); }
   .overlay-panel {
-    width: 78%; max-width: 320px; border-radius: 12px; background: var(--bg);
+    width: 100%; border-radius: 12px; background: var(--bg);
     border: 1px solid var(--line-strong); box-shadow: var(--shadow-pop); padding: 12px;
     will-change: transform, opacity;
   }
@@ -225,8 +225,8 @@
         </div>
         <div class="card-foot"><button class="ctl primary r1-go" type="button">Edit source</button><span class="readout">—</span></div>
       </div>
-      <div class="card after" data-r1 data-delay="80" data-spinner="0">
-        <div class="card-head"><span class="tag">Proposed</span><small>adaptive ≈ 80 ms, no spinner flash</small></div>
+      <div class="card after" data-r1 data-spinner="0">
+        <div class="card-head"><span class="tag">Proposed</span><small>adaptive 60–300 ms, no spinner flash</small></div>
         <div class="stage r1-stage">
           <div class="minisrc">flowchart TD
   A[Parse] --&gt; B[Verify]<span class="r1-newline"></span><span class="caret"></span></div>
@@ -293,7 +293,7 @@
         <div class="card-head"><span class="tag">Current</span><small>appears / vanishes instantly</small></div>
         <div class="stage">
           <div class="thumbrow"></div>
-          <div class="overlay"><div class="overlay-panel" role="dialog" aria-modal="true" aria-label="Inspect render"><h3>Inspect render</h3><div class="frame"></div><footer><button class="ctl ov-close" type="button">Close</button></footer></div></div>
+          <dialog class="overlay" aria-label="Inspect render"><div class="overlay-panel"><h3>Inspect render</h3><div class="frame"></div><footer><button class="ctl ov-close" type="button">Close</button></footer></div></dialog>
         </div>
         <div class="card-foot"><span class="readout">no origin, no path</span></div>
       </div>
@@ -301,7 +301,7 @@
         <div class="card-head"><span class="tag">Proposed</span><small>origin-aware · 200 ms in, 120 ms out</small></div>
         <div class="stage">
           <div class="thumbrow"></div>
-          <div class="overlay"><div class="overlay-panel" role="dialog" aria-modal="true" aria-label="Inspect render"><h3>Inspect render</h3><div class="frame"></div><footer><button class="ctl ov-close" type="button">Close</button></footer></div></div>
+          <dialog class="overlay" aria-label="Inspect render"><div class="overlay-panel"><h3>Inspect render</h3><div class="frame"></div><footer><button class="ctl ov-close" type="button">Close</button></footer></div></dialog>
         </div>
         <div class="card-foot"><span class="readout">—</span></div>
       </div>
@@ -501,9 +501,14 @@
     var btn = card.querySelector('.r1-go');
     var newline = card.querySelector('.r1-newline');
     var caret = card.querySelector('.caret');
-    var delay = parseInt(card.dataset.delay, 10);
+    var fixedDelay = parseInt(card.dataset.delay, 10);
     var showSpinner = card.dataset.spinner === '1';
+    var lastRenderMs = showSpinner ? null : 53;
     var extended = false, busy = false;
+    function delayForNextRender() {
+      if (showSpinner) return fixedDelay;
+      return Math.max(60, Math.min(300, lastRenderMs * 1.5));
+    }
 
     function draw() {
       wrap.innerHTML = '';
@@ -520,11 +525,14 @@
       newline.textContent = extended ? '\n  B --> C[Render]' : '';
       caret.classList.add('on');
       if (showSpinner) spinner.classList.add('on');
-      readout.textContent = 'debouncing…';
+      var delay = delayForNextRender();
+      readout.textContent = 'debouncing ' + Math.round(delay) + ' ms…';
       var t0 = performance.now();
       setTimeout(function () {                       // the debounce
         setTimeout(function () {                     // the (fast) render itself
           draw();
+          var renderMs = performance.now() - t0 - delay;
+          if (!showSpinner) lastRenderMs = renderMs;
           spinner.classList.remove('on');
           caret.classList.remove('on');
           readout.textContent = 'updated in ' + Math.round(performance.now() - t0) + ' ms';
@@ -557,7 +565,7 @@
     }
     content.appendChild(svg);
 
-    var x = -220, y = -60, dragging = false, startX = 0, startY = 0, ox = 0, oy = 0;
+    var x = -220, y = -60, dragging = false, pointerId = null, startX = 0, startY = 0, ox = 0, oy = 0;
     var tracker = makeVelocityTracker(), cancelCoast = null;
     function bounds() {
       var r = box.getBoundingClientRect();
@@ -574,6 +582,7 @@
     box.addEventListener('pointerdown', function (e) {
       if (cancelCoast) { cancelCoast(); cancelCoast = null; readout.textContent = 'grabbed mid-coast'; }
       dragging = true;
+      pointerId = e.pointerId;
       box.classList.add('grabbing');
       box.setPointerCapture(e.pointerId);
       startX = e.clientX; startY = e.clientY; ox = x; oy = y;
@@ -582,17 +591,18 @@
       e.preventDefault();
     });
     box.addEventListener('pointermove', function (e) {
-      if (!dragging) return;
+      if (!dragging || e.pointerId !== pointerId) return;
       x = ox + (e.clientX - startX);
       y = oy + (e.clientY - startY);
       tracker.push(performance.now(), e.clientX, e.clientY);
       apply();
     });
-    function up(e) {
-      if (!dragging) return;
+    function up(e, cancelled) {
+      if (!dragging || e.pointerId !== pointerId) return;
       dragging = false;
+      pointerId = null;
       box.classList.remove('grabbing');
-      if (!momentum || reduced()) return;
+      if (cancelled || !momentum || reduced()) return;
       tracker.push(performance.now(), e.clientX, e.clientY); // a hold before release reads as ~0 velocity
       var v = tracker.get();
       if (Math.hypot(v.vx, v.vy) < 50) return;
@@ -601,8 +611,8 @@
         x += dx; y += dy; apply();
       }, function () { cancelCoast = null; readout.textContent = 'settled'; });
     }
-    box.addEventListener('pointerup', up);
-    box.addEventListener('pointercancel', up);
+    box.addEventListener('pointerup', function (e) { up(e, false); });
+    box.addEventListener('pointercancel', function (e) { up(e, true); });
     box.tabIndex = 0;
     box.setAttribute('aria-label', 'Pannable diagram canvas. Use arrow keys to pan.');
     box.addEventListener('keydown', function (e) {
@@ -654,7 +664,7 @@
     var readout = card.querySelector('.readout');
     var animate = card.dataset.anim === '1';
     var labels = [['Crisp', 'Paper'], ['Sketch', 'Nord'], ['Blueprint', 'Dusk']];
-    var lastThumb = null;
+    var lastThumb = null, dialogAnimation = null, dialogClosing = false;
 
     labels.forEach(function (pair, i) {
       var b = document.createElement('button');
@@ -673,39 +683,45 @@
       s.setAttribute('width', '100%'); s.removeAttribute('height');
       frame.appendChild(s);
       lastThumb = thumb;
-      overlay.classList.add('open');
+      if (dialogAnimation) dialogAnimation.cancel();
+      overlay.showModal();
       if (animate && !reduced()) {
-        // origin is panel-relative; values outside 0-100% are valid and anchor correctly
         var pr = panel.getBoundingClientRect(), tr = thumb.getBoundingClientRect();
         var oxp = ((tr.left + tr.width / 2 - pr.left) / pr.width) * 100;
         var oyp = ((tr.top + tr.height / 2 - pr.top) / pr.height) * 100;
         panel.style.transformOrigin = oxp + '% ' + oyp + '%';
-        panel.animate(
+        dialogAnimation = panel.animate(
           [{ opacity: 0, transform: 'scale(0.86)' }, { opacity: 1, transform: 'scale(1)' }],
           { duration: 200, easing: 'cubic-bezier(0.22, 1, 0.36, 1)' });
-        overlay.animate([{ backgroundColor: 'transparent' }, {}], { duration: 200 });
         readout.textContent = 'origin: the panel you clicked';
       } else if (animate) {
-        panel.animate([{ opacity: 0 }, { opacity: 1 }], { duration: 150 });
+        dialogAnimation = panel.animate([{ opacity: 0 }, { opacity: 1 }], { duration: 150 });
       }
       card.querySelector('.ov-close').focus();
     }
     function close() {
-      if (animate && !reduced()) {
-        var a = panel.animate(
-          [{ opacity: 1, transform: 'scale(1)' }, { opacity: 0, transform: 'scale(0.86)' }],
-          { duration: 120, easing: 'cubic-bezier(0.4, 0, 1, 1)' });
-        a.onfinish = function () { overlay.classList.remove('open'); if (lastThumb) lastThumb.focus(); };
-      } else {
-        overlay.classList.remove('open');
-        if (lastThumb) lastThumb.focus();
-      }
+      if (!overlay.open || dialogClosing) return;
+      if (!animate) { overlay.close(); return; }
+      dialogClosing = true;
+      if (dialogAnimation) dialogAnimation.cancel();
+      dialogAnimation = reduced()
+        ? panel.animate([{ opacity: 1 }, { opacity: 0 }], { duration: 120 })
+        : panel.animate([{ opacity: 1, transform: 'scale(1)' }, { opacity: 0, transform: 'scale(0.86)' }], { duration: 120, easing: 'cubic-bezier(0.4, 0, 1, 1)' });
+      dialogAnimation.onfinish = function () { dialogClosing = false; if (overlay.open) overlay.close(); };
+      dialogAnimation.oncancel = function () { dialogClosing = false; };
     }
     card.querySelector('.ov-close').addEventListener('click', close);
     overlay.addEventListener('click', function (e) { if (e.target === overlay) close(); });
-    document.addEventListener('keydown', function (e) {
-      if (e.key === 'Escape' && overlay.classList.contains('open')) close();
+    overlay.addEventListener('cancel', function (e) { e.preventDefault(); close(); });
+    overlay.addEventListener('keydown', function (e) {
+      if (e.key !== 'Tab') return;
+      var focusable = Array.prototype.slice.call(overlay.querySelectorAll('button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'));
+      if (!focusable.length) return;
+      var first = focusable[0], last = focusable[focusable.length - 1];
+      if (e.shiftKey && document.activeElement === first) { e.preventDefault(); last.focus(); }
+      else if (!e.shiftKey && document.activeElement === last) { e.preventDefault(); first.focus(); }
     });
+    overlay.addEventListener('close', function () { dialogClosing = false; if (lastThumb) lastThumb.focus(); });
   });
 
   /* ============================ R6 ============================ */

--- a/research/apple-design-fluid-interactions.md
+++ b/research/apple-design-fluid-interactions.md
@@ -1,0 +1,556 @@
+# Applying the `apple-design` skill to the Agentic Mermaid website — stack-ranked
+
+**Purpose of this document.** Implementation-ready recommendations for elevating the Agentic
+Mermaid website (public site + `/editor/`) using Emil Kowalski's `apple-design` skill
+(<https://www.skills.sh/emilkowalski/skill/apple-design>, source:
+`emilkowalski/skills` → `skills/apple-design/SKILL.md`). The skill distills Apple's
+*Designing Fluid Interfaces* (WWDC 2018), the materials/typography talks, and the eight
+design principles into web-platform techniques. Its through-line:
+
+> An interface feels alive when motion starts from the current on-screen value, inherits
+> the user's velocity, projects momentum forward, and can be grabbed and reversed at any
+> instant.
+
+This document was produced after auditing the actual code; every item cites current state
+with file:line references and includes acceptance criteria. An earlier draft held 17
+items; a five-lens ranking review (felt user impact, engineering value, skill fidelity,
+brand fit, accessibility) stack-ranked them and **five were removed from scope** (see
+"Removed from scope" at the end). The **12 items below appear in final rank order**,
+grouped into the review's quality tiers. Original audit IDs (R1, R11, F1, …) are retained
+for traceability — do not renumber them.
+
+An **interactive before/after mock** of the demoable items (working spring/decay
+simulations styled with the site's own tokens) lives next to this file:
+`research/apple-design-before-after-mock.html` — open it directly in a browser.
+
+## Stack rank at a glance
+
+| Rank | ID | Item | Tier |
+|------|----|------|------|
+| 1 | R1 | Adaptive render debounce + delayed spinner | 1 — Do first |
+| 2 | R11 | Curated reduced-motion (replace blanket kill) | 1 — Do first |
+| 3 | F1 | Vanilla motion utility (prerequisite) | 2 — Core fluid-feel block |
+| 4 | R3 | Momentum panning with grab-to-interrupt | 2 — Core fluid-feel block |
+| 5 | R2 | Smooth, interruptible, compositor-friendly zoom | 2 — Core fluid-feel block |
+| 6 | R10 | `prefers-reduced-transparency` / `prefers-contrast` fallbacks | 3 — High-value cheap wins |
+| 7 | R7 | Origin-aware comparison lightbox (public site) | 3 — High-value cheap wins |
+| 8 | R12 | Toast micro-fixes (pausable timer) | 3 — High-value cheap wins |
+| 9 | R5 | Two-finger pinch zoom + pan on touch | 3 — High-value cheap wins |
+| 10 | R6 | Symmetric, fast popover exits | 3 — High-value cheap wins |
+| 11 | R8 | Mobile editor panel crossfade | 3 — High-value cheap wins |
+| 12 | R15 | Design-page motion specimens + DESIGN.md rulings | 4 — Durability |
+
+---
+
+## 0. Read this first (context for the implementing agent)
+
+### What the site already gets right — do not "improve" these
+
+The site is unusually well-crafted; several skill principles are already implemented.
+Preserve them:
+
+- **Press feedback on pointer-down** (skill §1): `:active { transform: scale(0.96) }` with a
+  fast `--dur-press: 0.1s` exists on every control (`website/source/assets/styles.css:786`,
+  `editor/css/affordances.css:18`). ✔
+- **Typography** (skill §15): size-specific tracking is already exact — display `-0.022em`,
+  headings `-0.018em`, body `0`; tight leading on display (1.03) and loose on body (1.6)
+  (`styles.css:128–147`). Hierarchy is built from weight+size+leading as a set. ✔ No action.
+- **Origin-aware popovers** (skill §7): editor popovers scale in from their trigger with
+  correct `transform-origin` (`editor/css/affordances.css:52–59`). ✔ (exits need work — R6.)
+- **Hit targets**: 44 px minimums on coarse pointers (`affordances.css:83–107`), invisible
+  hit-halo on the dialog close button (`editor/css/misc.css:97`), 16 px input font on touch
+  to prevent iOS zoom. ✔
+- **`setPointerCapture` on drags** (skill §2): pan (`editor/js/pan.js:29`) and resize
+  (`editor/js/resize.js:41`) both capture. ✔
+- **Design foundations** (skill §16): direct nav labels, wayfinding, semantic status colors
+  paired with text, forced-colors coverage, tiered warning feedback. ✔
+- **One deliberate entrance** (home diagram staggered node-settle on the mark's clock,
+  `styles.css:738–755`) rather than scroll-triggered animation soup. ✔
+
+### House rules that constrain the skill — rulings on conflicts
+
+`DESIGN.md` defines the north star: *"A standards manual attached to a capable workbench."*
+It **prohibits** glass panels, glowing gradients, broad soft shadows, and SaaS gloss. The
+skill's §12 (translucent materials) partially conflicts. Rulings for this work:
+
+1. **No new translucent surfaces anywhere.** The only materials work in scope is adding
+   accessibility fallbacks to the frosted surfaces that already exist (the shortcuts
+   dialog, `editor/css/misc.css:53–69`; the comparison lightbox backdrop,
+   `styles.css:451`) — that is R10.
+2. **No new dependencies.** The editor is dependency-free vanilla JS. Do not add
+   framer-motion/Motion. All spring/decay work is a ~60-line helper (F1).
+3. **No overshoot on click-triggered UI.** The skill itself says bounce is earned only when
+   the user's gesture carried momentum. Popovers, toasts, copy feedback stay critically
+   damped.
+4. **Never animate the render path.** Typing → preview must stay an instant swap
+   (skill §1: response beats choreography). Latency work = R1, not crossfades.
+5. **Determinism and tests**: `bun test src/__tests__/` is the CI gate.
+   `website-build.test.ts` pins selectors that must exist in `styles.css` (e.g. lines
+   758–766 of the test file), `chrome-token-lockstep.test.ts` pins editor/site token
+   parity, and `website-browser-a11y.test.ts` drives the comparison lightbox. Run the full
+   suite and `bun run website` after CSS/token changes.
+6. Respect the three-layer CSS architecture (BRAND / THEME / SCHEME) documented at the top
+   of `website/source/assets/styles.css:1–15`. Motion tokens live in the BRAND layer.
+
+---
+
+## Tier 1 — Do first: kill latency, stop the reduced-motion harm
+
+### Rank 1 · R1 — Adaptive render debounce + spinner that never flashes
+
+**Why ranked #1:** four of five review lenses ranked it first. Typing is the product's
+highest-traffic interaction, latency is the skill's stated foundation ("Response is the
+foundation everything else is built on"), and the change is small, standalone, and
+low-risk — the best value-per-effort in the list.
+
+**Skill:** §1 — "Be vigilant about every latency… audit debounces, artificial timers."
+
+**Current state:**
+- Every keystroke schedules a render behind a fixed **300 ms debounce**
+  (`editor/js/rendering.js:13–20`, `scheduleRender(delay ?? 300)`).
+- The spinner turns on **immediately** for every render (`rendering.js:430`,
+  `spinner.classList.add("visible")`) and off in `finally` — so even a 25 ms render
+  flashes a spinner in the corner.
+- The status bar prints "Rendered in Nms", so real render cost is already measured.
+
+**Change:**
+1. Track the last successful render duration (`ms` is already computed at
+   `rendering.js:436`). Set the next debounce adaptively:
+   `delay = clamp(lastRenderMs * 1.5, 60, 300)`. A typical small diagram renders in tens
+   of ms → typing feedback lands ~4–5× sooner. Big diagrams keep the protective 300 ms.
+2. Delay spinner visibility: start a `setTimeout(showSpinner, 250)` when the render
+   begins; clear it in `finally`. The spinner then only ever appears for genuinely slow
+   renders, and quick renders read as instantaneous.
+3. Keep the existing version-guard (`isCurrentRender`) exactly as is — it already prevents
+   stale results landing (good interruptibility).
+
+**Acceptance:** with the default flowchart loaded, a character edit updates the preview in
+≤ ~120 ms end-to-end; no spinner is visible for renders < 250 ms; a 300-line diagram still
+debounces at 300 ms. No test changes expected.
+
+**Risk:** low. Purely timing.
+
+### Rank 2 · R11 — Curated reduced-motion instead of the blanket kill-switch
+
+**Why ranked #2:** the accessibility lens's unanimous top pick — the current rule actively
+punishes the exact population that opted into an accessibility preference — and it
+protects every motion item ranked below it, so it must land **before** new animations
+ship.
+
+**Skill:** §14 — "Reduced motion doesn't mean *no* feedback — it means a gentler,
+non-vestibular equivalent… Keep opacity/color changes that aid comprehension. Replace
+slides/springs with cross-fades."
+
+**Current state:** both stylesheets nuke *everything* to 0.01 ms:
+`styles.css:760` and `editor/css/variables.css:235–244`
+(`* { animation-duration: .01ms !important; transition-duration: .01ms !important }`).
+That also kills pure opacity fades (toast, tab panel fade, copy status) and even *color*
+transitions — reduced-motion users get a strictly harsher UI than necessary, which is
+precisely what §14 argues against.
+
+**Change:** keep the blanket rule as the base (it's a safe default), then re-allow the
+comprehension-aiding, non-vestibular set after it:
+```css
+@media (prefers-reduced-motion: reduce) {
+  /* after the blanket kill: restore short, transform-free fades */
+  .toast, .tabs-ready .tab-panel:not([hidden]), .copy-prompt-status,
+  body, .doc, a, button /* color/background transitions */ {
+    transition-duration: 0.15s !important;
+    transition-property: opacity, color, background-color, border-color !important;
+  }
+  .toast.show { transform: translateX(-50%); } /* position without the slide */
+}
+```
+Audit each animation once: transforms (slides, scales, the home-page node settle, the
+copy-pop) stay dead; opacity/color fades ≤ 200 ms come back. Dark↔light scheme changes
+keep their 0.2 s color ease (skill: "ease dark↔light theme changes" — the current blanket
+rule ironically makes theme flips *abrupt* for reduced-motion users).
+
+**Acceptance:** with reduced motion on — no element translates or scales anywhere; toasts
+and tab switches still fade; theme/scheme flips still ease; everything else instant.
+
+**Risk:** low, but requires a careful pass over both stylesheets. Keep the override block
+adjacent to the existing kill rules with a comment explaining the §14 rationale.
+
+---
+
+## Tier 2 — Core fluid-feel block (build as one coordinated effort)
+
+The three items below share code and a risk seam: F1 supplies the physics, R3 and R2 both
+live on the preview canvas and share cancel paths. Land them consecutively.
+
+### Rank 3 · F1 — Tiny spring/decay utility: `editor/js/motion.js` (prerequisite)
+
+**Why ranked #3:** zero user-visible change by itself — its position is inherited from the
+gestures it unlocks (R3, R2, R5), so it belongs immediately before its first dependent,
+not higher.
+
+**Skill principles:** §3 interruptibility ("always animate from the presentation value"),
+§4 behavior over animation, §5 velocity handoff, §6 momentum projection.
+
+The editor loads plain scripts in order (see how `pan.js`/`zoom.js` share globals). Add
+`motion.js` before them with three primitives, parameterized the way Apple does (damping
+ratio + response, not mass/stiffness):
+
+```js
+// Critically damped spring (damping ratio 1.0). Closed form — no library needed.
+// response ≈ time-to-target feel in seconds (Apple's "response"; 0.3–0.4 for UI).
+// Returns a cancel function; onFrame receives the current value each rAF.
+function springTo(from, to, initialVelocity, response, onFrame, onDone) {
+  var omega = (2 * Math.PI) / response;         // undamped angular frequency
+  var A = from - to;
+  var B = initialVelocity + omega * A;
+  var start = performance.now(), raf = 0;
+  function frame(now) {
+    var t = (now - start) / 1000;
+    var e = Math.exp(-omega * t);
+    var x = to + (A + B * t) * e;
+    var v = (B - omega * (A + B * t)) * e;
+    if (Math.abs(x - to) < 0.001 * Math.max(1, Math.abs(A)) && Math.abs(v) < 0.01) {
+      onFrame(to); if (onDone) onDone(); return;
+    }
+    onFrame(x);
+    raf = requestAnimationFrame(frame);
+  }
+  raf = requestAnimationFrame(frame);
+  return function cancel() { cancelAnimationFrame(raf); };
+}
+
+// Exponential decay for momentum (UIScrollView-style). rate 0.998 = normal scroll feel.
+function decay(velocity, rate, onFrame /* (delta) */, onDone) { /* v *= rate^dt_ms per frame,
+  emit v*dt movement, stop below ~4 px/s; return cancel fn */ }
+
+// Apple's momentum projection (from the WWDC sample code — use exactly this form):
+function project(initialVelocity /* px/s */, rate) {
+  rate = rate || 0.998;
+  return (initialVelocity / 1000) * rate / (1 - rate);
+}
+
+// Pointer velocity tracker: keep the last ~100 ms of {t, x, y} samples from
+// pointermove; velocity = least-squares or first/last delta over the window.
+function makeVelocityTracker() { /* push(t,x,y); getVelocity() -> {vx, vy} px/s */ }
+```
+
+**Notes.** Every consumer must (a) start from the *current* on-screen value, (b) accept a
+retarget mid-flight (cancel + re-spring with the live velocity — the closed form above
+takes `initialVelocity`, so this is free), and (c) be cancelled by any new pointerdown.
+That is the skill's §3 in one sentence.
+
+**Acceptance:** unit-testable pure functions; no `Date.now` (use `performance.now`); zero
+allocations per frame beyond the closure.
+
+### Rank 4 · R3 — Momentum panning with grab-to-interrupt (the flagship "feel" upgrade)
+
+**Why ranked #4:** skill-fidelity #2 (interruptibility + velocity handoff on a core
+gesture is the doctrine's textbook combination) and the most viscerally noticeable
+fluid-vs-clunky difference a non-designer will feel. The accessibility lens flagged
+self-moving content as a vestibular risk — which is exactly why R11 (rank 2) must ship
+first.
+
+**Skill:** §2 (1:1 tracking — already done), §5 (velocity handoff), §6 (momentum
+projection), §3 (grabbable mid-flight).
+
+**Current state:** `editor/js/pan.js` tracks 1:1 via `scrollLeft/scrollTop` (correct), but
+on `pointerup` motion stops dead (`endPan`, `pan.js:42–47`). A flick feels like hitting a
+wall — the exact seam the skill says separates "fluid" from "fine".
+
+**Change:**
+1. Feed `pointermove` events into the velocity tracker (F1) during a pan.
+2. On `pointerup`, read release velocity; if speed > ~50 px/s start a `decay` loop
+   (rate 0.998) applying deltas to `scrollLeft/scrollTop`. Clamp at scroll bounds
+   (stop the axis that hits an edge).
+3. Interruption: any `pointerdown` on `previewBody`, any wheel event, or a new render
+   cancels the decay instantly — the user "grabs" the moving canvas. This is
+   non-negotiable per skill §3.
+4. Applies to both pan-mode and `⌘/Ctrl`-drag pan. Touch pans in pan-mode get it too
+   (`touch-action: none` is already set, `preview.css:105–113`).
+5. Keep momentum under `prefers-reduced-motion` (native scroll deceleration persists under
+   reduced motion on every platform; it is user-generated motion, not vestibular
+   decoration) — but see R11: everything else around it must already be calm.
+
+**Acceptance:** a flick on a large zoomed-in diagram coasts and decelerates naturally;
+touching the canvas mid-coast stops it exactly where it is and a new drag starts from
+there with no jump; wheel input cancels coasting; velocity at handoff is continuous (no
+visible seam between finger-up and coast — review frame-by-frame at 0.25×).
+
+**Risk:** low-medium. Self-contained in `pan.js` + `motion.js`.
+
+### Rank 5 · R2 — Preview zoom becomes smooth, interruptible, and compositor-friendly
+
+**Why ranked #5:** felt-impact #2 — zoom fires constantly and today produces discrete
+jumps plus layout-thrash jank on big diagrams — but it carries the list's riskiest
+integration seam (transform-then-commit), so it lands right behind its sibling R3, which
+shares that seam and its cancel paths.
+
+**Skill:** §3 (interruptible, retarget from current value), §11 (animate only
+`transform`/`opacity`; commit layout when settled), §1 (respond instantly).
+
+**Current state:**
+- Zoom buttons step ×1.25 and apply instantly by rewriting the SVG's `width`/`height`
+  (`editor/js/zoom.js:9–19`) — a full layout + repaint of a potentially huge SVG per step.
+- `Ctrl/⌘+wheel` zoom does the same per wheel tick with cursor anchoring
+  (`editor/js/pan.js:58–76`). On large diagrams every tick relayouts.
+- "Fit" and the 100% reset jump instantly (`zoom.js:28–45`).
+
+**Change:**
+1. Introduce a single animated `zoomValue` driven by `springTo` (response ≈ 0.3,
+   critically damped). `applyZoom` becomes the *commit* function; a new
+   `animateZoomTo(target, anchorPoint)` retargets the spring from the live value —
+   pressing `+` three times fast must glide to the final target with no jumps
+   (this is the skill's §3 litmus test).
+2. During any *continuous* zoom (spring in flight, or a wheel-tick stream), scale with
+   `transform: scale()` on the SVG relative to the last committed layout size
+   (compositor-only), keeping the cursor-anchor math. When the interaction goes idle for
+   ~120 ms, commit once via the existing width/height path and clear the transform, so
+   scrollbars/pan metrics stay truthful.
+3. Anchor rules: buttons and reset anchor at the viewport center of `preview-body`; wheel
+   keeps the cursor anchor; "Fit" springs both zoom and scroll offsets.
+4. Reduced motion: `matchMedia('(prefers-reduced-motion: reduce)')` → skip the spring,
+   call `applyZoom` directly (current behavior).
+
+**Acceptance:** repeated `+` presses produce one continuous glide; grabbing the canvas
+(pan) mid-zoom-animation cancels the zoom spring cleanly; wheel-zooming a large example
+(load one from Examples) no longer relayouts per tick (verify with a DevTools performance
+trace — layout should appear only on commit); zoom label still reads correct percentages.
+
+**Risk:** medium — the transform-then-commit seam must not visibly shift the diagram.
+Guard: compute the committed scroll offsets from the same anchor math already in
+`pan.js:69–75`.
+
+---
+
+## Tier 3 — High-value cheap wins (safe to sprinkle into any PR)
+
+### Rank 6 · R10 — Accessibility fallbacks for the existing frosted surfaces
+
+**Why ranked #6:** trivial, risk-free closure of a genuine gap; the brand lens called the
+omission "a credibility hole in a standards manual."
+
+**Skill:** §14 — `prefers-reduced-transparency` and `prefers-contrast` are independent
+signals; translucent surfaces must have frostier/solid equivalents.
+
+**Current state:** the shortcuts dialog panel is 88%-opaque + blur
+(`editor/css/misc.css:53–69`) and the comparison dialog backdrop blurs
+(`styles.css:451`) — **neither has a `prefers-reduced-transparency` or
+`prefers-contrast` fallback.** Both files handle `forced-colors` and `reduced-motion`
+but miss these two signals entirely.
+
+**Change:** add to both stylesheets:
+```css
+@media (prefers-reduced-transparency: reduce) {
+  .shortcuts-dialog-panel { background: var(--popover-bg); backdrop-filter: none; -webkit-backdrop-filter: none; }
+  .shortcuts-dialog { backdrop-filter: none; -webkit-backdrop-filter: none; }
+  /* site: */ .comparison-dialog::backdrop { backdrop-filter: none; }
+}
+@media (prefers-contrast: more) {
+  .shortcuts-dialog-panel { background: var(--popover-bg); border-color: var(--line-strong); }
+}
+```
+
+**Acceptance:** toggling "Reduce transparency" in OS settings (or DevTools emulation)
+yields fully solid overlays.
+
+**Risk:** trivial.
+
+### Rank 7 · R7 — Origin-aware comparison lightbox on the public site
+
+**Why ranked #7:** brand lens #2 — the comparisons dialog is the marketing centerpiece
+where evaluating engineers form their quality judgment, and this is the only motion
+upgrade on the public site. No dependency on F1.
+
+**Skill:** §7 (anchor interactions to their source), §12 (materialize, don't just fade).
+
+**Current state:** clicking a comparison grid opens a `<dialog>` via `showModal()` with
+**no entrance or exit animation at all** (inline site JS in `website/build.ts:1137–1445`;
+dialog styles `styles.css:449–455`). The backdrop already blurs (`styles.css:451`).
+
+**Change:** on open, set the dialog's `transform-origin` from the invoking panel's center
+(the click target rect is available in the `data-comparison-lightbox-panel` handler,
+`build.ts:1358, 1445`), then animate `opacity 0→1` + `scale(0.98)→1` over ~200 ms
+`--ease-out`; on close, reverse along the same path at ~120 ms before calling `close()`.
+Backdrop fades in sync. Reduced motion: fade only, no scale.
+
+**Acceptance:** the lightbox visibly grows out of the panel the user clicked and returns
+into it; `website-browser-a11y.test.ts:125` (which clicks a panel) still passes; keyboard
+open (Enter on the "Inspect" button) uses the button as origin.
+
+**Risk:** low. Pure enhancement in the inline script + CSS.
+
+### Rank 8 · R12 — Toast micro-fixes
+
+**Why ranked #8:** near-infinite value/effort ratio; the accessibility lens flagged the
+unpausable dismiss timer as a WCAG 2.2.1-class timing barrier (slow readers race failure
+messages).
+
+**Skill:** §16 agency/utility, §13 harmony.
+
+**Current state:** `editor/js/toast.js` — fixed 2.5 s timer, no pause; new messages
+replace text mid-flight abruptly. Style at `misc.css:19–41` (fade + 4 px rise — fine).
+
+**Change:** pause the dismiss timer on `pointerenter`/`focusin`, resume on leave (users
+reading a share-link failure toast shouldn't race it); when a toast is already visible,
+restart with a quick 80 ms fade-out/in so the text swap doesn't teleport.
+
+**Risk:** trivial.
+
+### Rank 9 · R5 — Two-finger pinch zoom + pan on touch
+
+**Why ranked #9:** the only outright capability gap in the list — a missing feature reads
+as "broken," not "unpolished" — tempered by minority touch usage of a code workbench and
+by medium risk on the same transform seam as R2. Ship after R2/R3 settle.
+
+**Skill:** §2, §10 (detect plausible gestures in parallel).
+
+**Current state:** in pan mode `touch-action: none` claims touch input, but a second
+pointer is ignored (`pan.js:26` tracks a single `panPointerId`), so touch users have no
+diagram zoom at all — only the toolbar buttons.
+
+**Change:** track up to two active pointers in pan mode; two pointers = pinch (scale about
+the midpoint using the R2 transform path, committing on gesture end) + midpoint pan;
+releasing one finger degrades gracefully to a 1:1 pan from the current value. Reuse the
+wheel-zoom anchor math.
+
+**Acceptance:** on a touch device (or DevTools touch emulation) pinch zooms about the
+pinch center, tracks 1:1, and hands off into the momentum/zoom systems.
+
+**Risk:** medium. Requires F1 + the R2 transform path.
+
+### Rank 10 · R6 — Symmetric, fast popover exits
+
+**Why ranked #10:** real but subtle — menus are touched many times per session, but an
+instant close is low-pain asymmetry rather than a felt defect, and the popup state
+machine needs care.
+
+**Skill:** §7 — "If something disappears one way, we expect it to emerge from where it
+came"; enter and exit along the same path.
+
+**Current state:** editor popovers (export dropdown, theme/style menus, font/color
+pickers) enter with a 160 ms origin-anchored fade/scale, but **exit instantly** —
+`affordances.css:48–59` documents this as intentional ("dismissal should never lag").
+The shortcuts dialog likewise has enter-only animation (`affordances.css:60–68`).
+
+**Change:** keep dismissal *feeling* instant but honor path symmetry: add a `.closing`
+state that plays the exact inverse (fade/scale back into the trigger) at **~90 ms** —
+faster than the 160 ms entrance, well under perception-of-lag, then hide on
+`animationend` (with a `setTimeout` fallback). Input must not be blocked during exit: the
+popup controller (`createListboxPopupController`, `editor/js/helpers.js:126`) should drop
+its open state and release focus immediately on close, with only the visual trailing.
+Apply the same to the shortcuts dialog scrim/panel and the export dropdown. Reduced
+motion: exits stay instant.
+
+**Acceptance:** menus visibly retreat into their trigger; mashing the trigger to
+open/close rapidly never gets stuck (the `.closing` animation is cancelled/replaced by a
+reopen — interruptibility again); Escape/blur dismissal begins on the same frame as the
+event.
+
+**Risk:** low-medium (state machine care in `helpers.js`).
+
+### Rank 11 · R8 — Mobile editor panel switch: cut → crossfade
+
+**Why ranked #11:** trivial softening of a jarring full-viewport hard cut, on a minority
+(mobile) path — cheap, self-contained, ships in minutes.
+
+**Skill:** §7/§14 — abrupt full-viewport content swaps are disorienting; a gentle fade
+aids comprehension.
+
+**Current state:** on ≤760 px, switching Source/Style/Preview flips `display: none`
+(`editor/css/panels.css:278–287`, driven by `editor/js/tabs.js:4–8`) — a hard cut of the
+entire viewport.
+
+**Change:** mirror the site's existing tab idiom (`styles.css:757–758`, `panel-in`
+keyframe): when `data-mobile-panel` changes, the incoming panel plays a one-way ~120 ms
+opacity fade-in (`animation: panel-in var(--dur-control) var(--ease-out)`). No exit
+animation (the outgoing panel is gone — correct for a display toggle), no slide (nothing
+spatial is being asserted between these views). Reduced motion: none (the global override
+already flattens animations).
+
+**Acceptance:** panel switches read as a soft cut; no layout shift; rapid tab mashing
+never shows two panels.
+
+**Risk:** trivial.
+
+---
+
+## Tier 4 — Durability
+
+### Rank 12 · R15 — Add the motion vocabulary to the living design page
+
+**Why ranked #12:** changes almost nothing a current user perceives, but the brand lens
+ranked it #3 — codified restraint rules survive future contributors, and it only pays off
+after the motion vocabulary above it has shipped. Do it last.
+
+**Skill:** §17 — prototype interactively; the site's own `/about/design` page already
+renders specimens off live tokens (`styles.css:862–885`, `.dz-motion`, `.dz-press`).
+
+**Change:** add specimens for whatever ships from the tiers above: the spring response
+values in use, a momentum-pan demo strip, and a note codifying the rulings from §0
+("bounce only after momentum", "no new translucent surfaces", "never animate the render
+path"). Append the same rulings to `DESIGN.md` so future agents inherit them — including
+the list of descoped items below, so they aren't reintroduced from the skill by a future
+pass.
+
+**Risk:** none.
+
+---
+
+## Explicit non-goals (things the skill suggests that this site should refuse)
+
+1. **No spring library dependency** — F1 covers every need in ~60 lines.
+2. **No bounce/overshoot on click-triggered UI** (popovers, dialogs, copy feedback, tabs).
+   The skill authorizes overshoot only when the user's gesture carried momentum; the only
+   in-scope candidate is R3's coast (a decay, not a bounce).
+3. **No new translucent materials anywhere** — on the public site's document surfaces per
+   `DESIGN.md`, and on editor chrome per the ranking review (see R9 below). Materials work
+   is limited to R10's fallbacks for the frosted overlays that already exist.
+4. **No crossfade on the render swap** — render latency work is R1; choreography on the
+   typing path would *add* perceived latency.
+5. **No global page transitions** — `styles.css:212–218` deliberately disables root view
+   transitions; leave that decision alone in this pass.
+6. **Don't touch the home-page entrance stagger or the shader mark** — both already follow
+   the skill (one entrance on load; sweep only on hover/focus; static under reduced
+   motion; WebGL fallback).
+
+## Removed from scope by the ranking review (do not reintroduce)
+
+Five items from the original 17-item audit were cut after the five-lens stack rank.
+Listed so a future pass doesn't rediscover them from the skill and re-propose them:
+
+- **R4 — rubber-band splitter bounds.** Once-per-session control; the brand lens judged a
+  springy splitter "the closest item to a bouncy gimmick on a precision instrument," and a
+  firm clamp communicates the bound honestly. (F1's rubber-band helper was dropped with
+  it.)
+- **R9 — translucent floating preview toolbar.** The accessibility lens ranked it dead
+  last for cause: it deliberately places chrome over arbitrary busy diagram content,
+  manufacturing the exact legibility-risk surface class R10 exists to remediate, and it
+  flirts with `DESIGN.md`'s no-glass prohibition.
+- **R13 — haptic tick on copy.** Bottom-three for four of five lenses; the brand lens
+  called it exactly the category of gimmick that damages this brand.
+- **R14 — px→rem spacing/control conversion.** A legitimate text-scaling accessibility
+  win, but the widest blast radius in the list (site-wide mechanical change, screenshot
+  diffing, test updates). Removed from this effort's scope; if the text-scaling harm is
+  revisited later, it should be its own carefully staged project, not a motion-polish
+  rider.
+- **R16 — standalone review-recipe item.** Ships nothing itself; its substance survives as
+  the per-PR checklist in the sequencing section below.
+
+## Suggested sequencing
+
+| PR | Contents | Effort |
+|----|----------|--------|
+| 1 | R1 (adaptive debounce, delayed spinner) | S |
+| 2 | R11 curated reduced-motion (site + editor) — before any new animation ships | M |
+| 3 | F1 + R3 (motion utils, momentum pan) | M |
+| 4 | R2 smooth zoom (coordinate with R3's cancel paths) | M |
+| 5 | R10 + R12 + R8 (trivial wins, no interdependencies) | S |
+| 6 | R6 popover exits | S–M |
+| 7 | R7 lightbox origin (public site) | S–M |
+| 8 | R5 pinch zoom (after the R2/R3 seam has settled) | M |
+| 9 | R15 design-page specimens + DESIGN.md rulings | S |
+
+Each PR: run `bun test src/__tests__/`, `bunx tsc --noEmit`, `bun run website` (stamp
+sync), and apply the repo's `good-pr` skill checklist — for these visual changes, §2
+(captioned before/after renders or short recordings) and §4 (tests that fail when the fix
+is reverted, e.g. debounce-adaptivity unit tests on `scheduleRender`) matter most. For
+every motion PR, review the interaction frame-by-frame (Playwright slow-mo; Chromium is
+pre-installed) and answer three questions before merge: does it start from the current
+value? can it be interrupted by input? what does it do under reduced motion?

--- a/research/apple-design-fluid-interactions.md
+++ b/research/apple-design-fluid-interactions.md
@@ -136,8 +136,9 @@ new message resets the full timer. Hidden toasts are noninteractive and leave th
 
 Popup controllers close semantically on the event frame: ARIA, `inert`, tab stops, focus, and peer
 state release immediately. Eligible popups then retain only a noninteractive `.closing` visual tail
-for 90 ms; reopening cancels that tail. Reduced motion skips the tail. The shortcuts dialog follows
-the same rule without retaining its focus trap.
+for 90 ms; reopening cancels that tail. Reduced motion skips the tail. The shortcuts dialog is
+ported to a direct body child while open, makes its editor siblings `inert`, and restores them on
+the same close event before its noninteractive visual tail.
 
 At phone widths, the incoming editor Source/Style/Preview panel uses a one-way 160 ms opacity
 entrance under `prefers-reduced-motion: no-preference`. The outgoing panel remains `display:none`;

--- a/research/apple-design-fluid-interactions.md
+++ b/research/apple-design-fluid-interactions.md
@@ -115,9 +115,11 @@ passes its actual invoking element to `openComparison(section, origin)`. The sou
 captured before it is moved into the dialog, then a 200 ms scale/fade uses that origin.
 
 All close paths are centralized in `requestClose()`: Close, native `cancel`/Escape, and backdrop
-click defer native `dialog.close()` until the 120 ms exit completes. The `close` event remains the
-single restoration point for the moved grid, controls, overflow, trigger attributes, and focus.
-Reduced motion uses an opacity-only open/close.
+click snapshot a noninteractive visual tail, then call native `dialog.close()` on the same event
+frame. The `close` event remains the single restoration point for the moved grid, controls,
+overflow, trigger attributes, and focus; the 120 ms tail is a detached, `inert`, `aria-hidden`
+copy and cannot retain modality or focus. Reduced motion skips the exit tail; opening remains
+opacity-only.
 
 `src/__tests__/website-browser-a11y.test.ts` covers grid and header openers, animated close, Escape,
 and focus return. The standalone research mock now uses native dialogs too; it is an interaction

--- a/research/apple-design-fluid-interactions.md
+++ b/research/apple-design-fluid-interactions.md
@@ -1,556 +1,169 @@
-# Applying the `apple-design` skill to the Agentic Mermaid website — stack-ranked
+# Fluid interactions for Agentic Mermaid
 
-**Purpose of this document.** Implementation-ready recommendations for elevating the Agentic
-Mermaid website (public site + `/editor/`) using Emil Kowalski's `apple-design` skill
-(<https://www.skills.sh/emilkowalski/skill/apple-design>, source:
-`emilkowalski/skills` → `skills/apple-design/SKILL.md`). The skill distills Apple's
-*Designing Fluid Interfaces* (WWDC 2018), the materials/typography talks, and the eight
-design principles into web-platform techniques. Its through-line:
+This is the implementation record for the `apple-design` review. It is deliberately a
+qualitative, repository-specific priority order—not a claim of measured traffic, user-study,
+or five-reviewer scores. The code and tests are the source of truth for shipped behavior.
 
-> An interface feels alive when motion starts from the current on-screen value, inherits
-> the user's velocity, projects momentum forward, and can be grabbed and reversed at any
-> instant.
+## Boundaries
 
-This document was produced after auditing the actual code; every item cites current state
-with file:line references and includes acceptance criteria. An earlier draft held 17
-items; a five-lens ranking review (felt user impact, engineering value, skill fidelity,
-brand fit, accessibility) stack-ranked them and **five were removed from scope** (see
-"Removed from scope" at the end). The **12 items below appear in final rank order**,
-grouped into the review's quality tiers. Original audit IDs (R1, R11, F1, …) are retained
-for traceability — do not renumber them.
+- No new runtime dependency: editor motion remains vanilla browser JavaScript.
+- No animation is added to the typing → render result swap. Rendering is made more responsive
+  instead; the preview still changes atomically.
+- No click-triggered control bounces or overshoots. Momentum is reserved for direct drag
+  gestures.
+- No new translucent chrome. Existing frosted overlays gain solid accessibility fallbacks.
+- Reduced motion preserves brief opacity and colour feedback only; it does not restore
+  transforms, springs, or decorative movement.
 
-An **interactive before/after mock** of the demoable items (working spring/decay
-simulations styled with the site's own tokens) lives next to this file:
-`research/apple-design-before-after-mock.html` — open it directly in a browser.
+## Delivered order
 
-## Stack rank at a glance
+| Rank | ID | Delivered behavior |
+|---|---|---|
+| 1 | R1 | Adaptive render debounce and a delayed spinner |
+| 2 | R11 | Curated reduced-motion opacity/colour feedback |
+| 3 | F1 | Testable spring, decay, and velocity primitives |
+| 4 | R3 | Interruptible momentum pan |
+| 5 | R2 | Presentation-transform zoom with one layout commit |
+| 6 | R10 | Opaque transparency/contrast fallbacks |
+| 7 | R7 | Origin-aware native comparison dialog motion |
+| 8 | R12 | Pausable, replaceable toast timer |
+| 9 | R5 | Two-pointer pinch zoom and pan |
+| 10 | R6 | Semantic-immediate, visual 90 ms popup exits |
+| 11 | R8 | Mobile panel opacity entrance |
+| 12 | R15 | Motion specimens and durable design rulings |
 
-| Rank | ID | Item | Tier |
-|------|----|------|------|
-| 1 | R1 | Adaptive render debounce + delayed spinner | 1 — Do first |
-| 2 | R11 | Curated reduced-motion (replace blanket kill) | 1 — Do first |
-| 3 | F1 | Vanilla motion utility (prerequisite) | 2 — Core fluid-feel block |
-| 4 | R3 | Momentum panning with grab-to-interrupt | 2 — Core fluid-feel block |
-| 5 | R2 | Smooth, interruptible, compositor-friendly zoom | 2 — Core fluid-feel block |
-| 6 | R10 | `prefers-reduced-transparency` / `prefers-contrast` fallbacks | 3 — High-value cheap wins |
-| 7 | R7 | Origin-aware comparison lightbox (public site) | 3 — High-value cheap wins |
-| 8 | R12 | Toast micro-fixes (pausable timer) | 3 — High-value cheap wins |
-| 9 | R5 | Two-finger pinch zoom + pan on touch | 3 — High-value cheap wins |
-| 10 | R6 | Symmetric, fast popover exits | 3 — High-value cheap wins |
-| 11 | R8 | Mobile editor panel crossfade | 3 — High-value cheap wins |
-| 12 | R15 | Design-page motion specimens + DESIGN.md rulings | 4 — Durability |
+## R1 — render response, debounce, and spinner
 
----
+`editor/js/rendering.js` records only the duration of a current, successful render. The next
+ordinary edit uses `EditorMotion.adaptiveRenderDelay(lastSuccessfulMs)`, clamped to 60–300 ms.
+An explicit `scheduleRender(0)` remains immediate for deliberate actions such as choosing a
+theme or example.
 
-## 0. Read this first (context for the implementing agent)
+The spinner is version-scoped and delayed by 250 ms. A new edit, an empty source, a completed
+current render, or a cancelled/stale render clears its pending timer. This preserves the existing
+version/source guard and prevents an obsolete timer from revealing a spinner during a newer
+request.
 
-### What the site already gets right — do not "improve" these
+**Acceptance:** inspect a fast edit and a large diagram in a browser; fast renders do not flash a
+spinner, and expensive typing retains a bounded debounce. This is a performance observation, not
+a deterministic wall-clock assertion. `src/__tests__/editor-motion.test.ts` pins the delay
+function's initial and clamp behavior.
 
-The site is unusually well-crafted; several skill principles are already implemented.
-Preserve them:
+## R11 — reduced motion
 
-- **Press feedback on pointer-down** (skill §1): `:active { transform: scale(0.96) }` with a
-  fast `--dur-press: 0.1s` exists on every control (`website/source/assets/styles.css:786`,
-  `editor/css/affordances.css:18`). ✔
-- **Typography** (skill §15): size-specific tracking is already exact — display `-0.022em`,
-  headings `-0.018em`, body `0`; tight leading on display (1.03) and loose on body (1.6)
-  (`styles.css:128–147`). Hierarchy is built from weight+size+leading as a set. ✔ No action.
-- **Origin-aware popovers** (skill §7): editor popovers scale in from their trigger with
-  correct `transform-origin` (`editor/css/affordances.css:52–59`). ✔ (exits need work — R6.)
-- **Hit targets**: 44 px minimums on coarse pointers (`affordances.css:83–107`), invisible
-  hit-halo on the dialog close button (`editor/css/misc.css:97`), 16 px input font on touch
-  to prevent iOS zoom. ✔
-- **`setPointerCapture` on drags** (skill §2): pan (`editor/js/pan.js:29`) and resize
-  (`editor/js/resize.js:41`) both capture. ✔
-- **Design foundations** (skill §16): direct nav labels, wayfinding, semantic status colors
-  paired with text, forced-colors coverage, tiered warning feedback. ✔
-- **One deliberate entrance** (home diagram staggered node-settle on the mark's clock,
-  `styles.css:738–755`) rather than scroll-triggered animation soup. ✔
+The universal near-zero-duration rule remains the safe default. After it, the site restores only
+a 150 ms opacity `panel-in-reduced` animation for channel tabs and opacity/colour/background/
+border transitions. The editor restores only the toast opacity fade and forces its resting
+translation. Mobile panel switches, popovers, dialogs, press feedback, springs, and the home
+mark remain non-animated under the preference.
 
-### House rules that constrain the skill — rulings on conflicts
+**Acceptance:** under `prefers-reduced-motion: reduce`, no shipped element translates or scales
+as an effect; tab and status comprehension fades remain short and transform-free.
 
-`DESIGN.md` defines the north star: *"A standards manual attached to a capable workbench."*
-It **prohibits** glass panels, glowing gradients, broad soft shadows, and SaaS gloss. The
-skill's §12 (translucent materials) partially conflicts. Rulings for this work:
+## F1 — shared motion contract
 
-1. **No new translucent surfaces anywhere.** The only materials work in scope is adding
-   accessibility fallbacks to the frosted surfaces that already exist (the shortcuts
-   dialog, `editor/css/misc.css:53–69`; the comparison lightbox backdrop,
-   `styles.css:451`) — that is R10.
-2. **No new dependencies.** The editor is dependency-free vanilla JS. Do not add
-   framer-motion/Motion. All spring/decay work is a ~60-line helper (F1).
-3. **No overshoot on click-triggered UI.** The skill itself says bounce is earned only when
-   the user's gesture carried momentum. Popovers, toasts, copy feedback stay critically
-   damped.
-4. **Never animate the render path.** Typing → preview must stay an instant swap
-   (skill §1: response beats choreography). Latency work = R1, not crossfades.
-5. **Determinism and tests**: `bun test src/__tests__/` is the CI gate.
-   `website-build.test.ts` pins selectors that must exist in `styles.css` (e.g. lines
-   758–766 of the test file), `chrome-token-lockstep.test.ts` pins editor/site token
-   parity, and `website-browser-a11y.test.ts` drives the comparison lightbox. Run the full
-   suite and `bun run website` after CSS/token changes.
-6. Respect the three-layer CSS architecture (BRAND / THEME / SCHEME) documented at the top
-   of `website/source/assets/styles.css:1–15`. Motion tokens live in the BRAND layer.
+`editor/js/motion.js` loads before zoom and pan. Its public global is `EditorMotion`:
 
----
+- `springTo({ from, to, velocity, response, onFrame, onDone })` reports both current value and
+  velocity every frame and returns `{ cancel, getState }`.
+- `decay2d({ vx, vy, rate, onFrame, onDone })` reports signed deltas and stops if its consumer
+  returns `false`; it returns `{ cancel, getVelocity }`.
+- `makeVelocityTracker()` retains the recent 100 ms pointer window.
+- `adaptiveRenderDelay()` and `clamp()` are pure helpers.
 
-## Tier 1 — Do first: kill latency, stop the reduced-motion harm
+`src/__tests__/editor-motion.test.ts` uses a fake clock and fake rAF to exercise delay bounds,
+velocity signs, a spring's live velocity/final state, and cancellation. This is intentionally a
+real behavior test of the primitives, not a snapshot of their implementation details.
 
-### Rank 1 · R1 — Adaptive render debounce + spinner that never flashes
+## R3, R2, and R5 — preview gesture contract
 
-**Why ranked #1:** four of five review lenses ranked it first. Typing is the product's
-highest-traffic interaction, latency is the skill's stated foundation ("Response is the
-foundation everything else is built on"), and the change is small, standalone, and
-low-risk — the best value-per-effort in the list.
+`editor/js/pan.js` owns pointer identity and scroll-space panning. A one-pointer drag preserves
+the existing 1:1 rule: moving the pointer right reduces `scrollLeft`; momentum applies the same
+signed direction. It samples release velocity, decays at `0.998`, stops an axis at its scroll
+bound, and is cancelled by a pointerdown, wheel input, or render replacement. Pointer cancellation
+never starts a coast. Under reduced motion, release does not start a coast: the preview stays at
+its final direct-manipulation position.
 
-**Skill:** §1 — "Be vigilant about every latency… audit debounces, artificial timers."
+`editor/js/zoom.js` separates a temporary presentation zoom from the committed layout zoom. A
+button press uses a critically damped 0.3 s spring; continuous modifier-wheel input uses a
+transform and commits once after 120 ms idle. Every transform and commit preserves its cursor or
+viewport-center anchor. A new pan commits and cancels a current zoom before taking control; an
+input/rerender cancels active preview motion before replacing the SVG.
 
-**Current state:**
-- Every keystroke schedules a render behind a fixed **300 ms debounce**
-  (`editor/js/rendering.js:13–20`, `scheduleRender(delay ?? 300)`).
-- The spinner turns on **immediately** for every render (`rendering.js:430`,
-  `spinner.classList.add("visible")`) and off in `finally` — so even a 25 ms render
-  flashes a spinner in the corner.
-- The status bar prints "Rendered in Nms", so real render cost is already measured.
+Two active pointers in pan mode form a pinch: distance drives presentation zoom about the moving
+midpoint and midpoint movement pans. Releasing one pointer re-bases a normal one-pointer drag;
+releasing both commits the presentation zoom. This deliberately shares the same transform/commit
+path as wheel and button zoom rather than inventing a second coordinate model.
 
-**Change:**
-1. Track the last successful render duration (`ms` is already computed at
-   `rendering.js:436`). Set the next debounce adaptively:
-   `delay = clamp(lastRenderMs * 1.5, 60, 300)`. A typical small diagram renders in tens
-   of ms → typing feedback lands ~4–5× sooner. Big diagrams keep the protective 300 ms.
-2. Delay spinner visibility: start a `setTimeout(showSpinner, 250)` when the render
-   begins; clear it in `finally`. The spinner then only ever appears for genuinely slow
-   renders, and quick renders read as instantaneous.
-3. Keep the existing version-guard (`isCurrentRender`) exactly as is — it already prevents
-   stale results landing (good interruptibility).
+**Acceptance:** verify at 0.25× speed that pointer release has no sign seam, bounds stop coasting,
+pointerdown grabs a coast, repeated zoom presses retarget from the visible scale, and pinch
+hands off without a jump. Review a DevTools trace on a large diagram: continuous zoom should not
+commit width/height per wheel tick.
 
-**Acceptance:** with the default flowchart loaded, a character edit updates the preview in
-≤ ~120 ms end-to-end; no spinner is visible for renders < 250 ms; a 300-line diagram still
-debounces at 300 ms. No test changes expected.
+## R10 — solid overlay accessibility fallbacks
 
-**Risk:** low. Purely timing.
+The shortcuts dialog and public comparison dialog disable both prefixed and unprefixed backdrop
+blur under either `prefers-reduced-transparency: reduce` or `prefers-contrast: more`. They use
+opaque token backgrounds and strong borders. These media features are progressive enhancements;
+the default surfaces remain readable in engines that do not expose the preference.
 
-### Rank 2 · R11 — Curated reduced-motion instead of the blanket kill-switch
+## R7 — native comparison dialog lifecycle
 
-**Why ranked #2:** the accessibility lens's unanimous top pick — the current rule actively
-punishes the exact population that opted into an accessibility preference — and it
-protects every motion item ranked below it, so it must land **before** new animations
-ship.
+The public comparison lightbox remains a native `<dialog>`; it is never replaced by a positioned
+`div`, so top-layer modality, Escape, and browser focus behavior remain intact. Every opener
+passes its actual invoking element to `openComparison(section, origin)`. The source grid's rect is
+captured before it is moved into the dialog, then a 200 ms scale/fade uses that origin.
 
-**Skill:** §14 — "Reduced motion doesn't mean *no* feedback — it means a gentler,
-non-vestibular equivalent… Keep opacity/color changes that aid comprehension. Replace
-slides/springs with cross-fades."
+All close paths are centralized in `requestClose()`: Close, native `cancel`/Escape, and backdrop
+click defer native `dialog.close()` until the 120 ms exit completes. The `close` event remains the
+single restoration point for the moved grid, controls, overflow, trigger attributes, and focus.
+Reduced motion uses an opacity-only open/close.
 
-**Current state:** both stylesheets nuke *everything* to 0.01 ms:
-`styles.css:760` and `editor/css/variables.css:235–244`
-(`* { animation-duration: .01ms !important; transition-duration: .01ms !important }`).
-That also kills pure opacity fades (toast, tab panel fade, copy status) and even *color*
-transitions — reduced-motion users get a strictly harsher UI than necessary, which is
-precisely what §14 argues against.
+`src/__tests__/website-browser-a11y.test.ts` covers grid and header openers, animated close, Escape,
+and focus return. The standalone research mock now uses native dialogs too; it is an interaction
+prototype, not the production implementation.
 
-**Change:** keep the blanket rule as the base (it's a safe default), then re-allow the
-comprehension-aiding, non-vestibular set after it:
-```css
-@media (prefers-reduced-motion: reduce) {
-  /* after the blanket kill: restore short, transform-free fades */
-  .toast, .tabs-ready .tab-panel:not([hidden]), .copy-prompt-status,
-  body, .doc, a, button /* color/background transitions */ {
-    transition-duration: 0.15s !important;
-    transition-property: opacity, color, background-color, border-color !important;
-  }
-  .toast.show { transform: translateX(-50%); } /* position without the slide */
-}
-```
-Audit each animation once: transforms (slides, scales, the home-page node settle, the
-copy-pop) stay dead; opacity/color fades ≤ 200 ms come back. Dark↔light scheme changes
-keep their 0.2 s color ease (skill: "ease dark↔light theme changes" — the current blanket
-rule ironically makes theme flips *abrupt* for reduced-motion users).
+## R12 — toast agency
 
-**Acceptance:** with reduced motion on — no element translates or scales anywhere; toasts
-and tab switches still fade; theme/scheme flips still ease; everything else instant.
+A shown editor toast enables pointer interaction and a temporary tab stop. Its one live region
+keeps remaining duration, start time, pause state, and replacement timer. Pointer hover or focus
+pauses dismissal; leave/focus departure resumes it; a replacement fades out for 80 ms before the
+new message resets the full timer. Hidden toasts are noninteractive and leave the tab order.
 
-**Risk:** low, but requires a careful pass over both stylesheets. Keep the override block
-adjacent to the existing kill rules with a comment explaining the §14 rationale.
+## R6 and R8 — small state transitions
 
----
+Popup controllers close semantically on the event frame: ARIA, `inert`, tab stops, focus, and peer
+state release immediately. Eligible popups then retain only a noninteractive `.closing` visual tail
+for 90 ms; reopening cancels that tail. Reduced motion skips the tail. The shortcuts dialog follows
+the same rule without retaining its focus trap.
 
-## Tier 2 — Core fluid-feel block (build as one coordinated effort)
+At phone widths, the incoming editor Source/Style/Preview panel uses a one-way 160 ms opacity
+entrance under `prefers-reduced-motion: no-preference`. The outgoing panel remains `display:none`;
+there is no spatial claim and no two-panel overlap.
 
-The three items below share code and a risk seam: F1 supplies the physics, R3 and R2 both
-live on the preview canvas and share cancel paths. Land them consecutively.
+## R15 — durable rules
 
-### Rank 3 · F1 — Tiny spring/decay utility: `editor/js/motion.js` (prerequisite)
+`/about/design` now documents press, enter, exit, interruption, momentum, reduced-motion, and
+opaque-overlay rules. Its draggable momentum strip is a small public specimen, not editor code.
+`DESIGN.md` carries the same durable rulings, including exclusions: rubber-band splitters,
+translucent floating preview toolbars, haptic copy ticks, global page transitions, and broad
+px-to-rem conversion require a separately justified review.
 
-**Why ranked #3:** zero user-visible change by itself — its position is inherited from the
-gestures it unlocks (R3, R2, R5), so it belongs immediately before its first dependent,
-not higher.
+## Validation
 
-**Skill principles:** §3 interruptibility ("always animate from the presentation value"),
-§4 behavior over animation, §5 velocity handoff, §6 momentum projection.
+Run after changes to these inputs:
 
-The editor loads plain scripts in order (see how `pan.js`/`zoom.js` share globals). Add
-`motion.js` before them with three primitives, parameterized the way Apple does (damping
-ratio + response, not mass/stiffness):
-
-```js
-// Critically damped spring (damping ratio 1.0). Closed form — no library needed.
-// response ≈ time-to-target feel in seconds (Apple's "response"; 0.3–0.4 for UI).
-// Returns a cancel function; onFrame receives the current value each rAF.
-function springTo(from, to, initialVelocity, response, onFrame, onDone) {
-  var omega = (2 * Math.PI) / response;         // undamped angular frequency
-  var A = from - to;
-  var B = initialVelocity + omega * A;
-  var start = performance.now(), raf = 0;
-  function frame(now) {
-    var t = (now - start) / 1000;
-    var e = Math.exp(-omega * t);
-    var x = to + (A + B * t) * e;
-    var v = (B - omega * (A + B * t)) * e;
-    if (Math.abs(x - to) < 0.001 * Math.max(1, Math.abs(A)) && Math.abs(v) < 0.01) {
-      onFrame(to); if (onDone) onDone(); return;
-    }
-    onFrame(x);
-    raf = requestAnimationFrame(frame);
-  }
-  raf = requestAnimationFrame(frame);
-  return function cancel() { cancelAnimationFrame(raf); };
-}
-
-// Exponential decay for momentum (UIScrollView-style). rate 0.998 = normal scroll feel.
-function decay(velocity, rate, onFrame /* (delta) */, onDone) { /* v *= rate^dt_ms per frame,
-  emit v*dt movement, stop below ~4 px/s; return cancel fn */ }
-
-// Apple's momentum projection (from the WWDC sample code — use exactly this form):
-function project(initialVelocity /* px/s */, rate) {
-  rate = rate || 0.998;
-  return (initialVelocity / 1000) * rate / (1 - rate);
-}
-
-// Pointer velocity tracker: keep the last ~100 ms of {t, x, y} samples from
-// pointermove; velocity = least-squares or first/last delta over the window.
-function makeVelocityTracker() { /* push(t,x,y); getVelocity() -> {vx, vy} px/s */ }
+```bash
+bun test src/__tests__/editor-motion.test.ts
+bun test src/__tests__/website-build.test.ts
+bun test src/__tests__/website-browser-a11y.test.ts
+bun run test:browser
+bunx tsc --noEmit
+bun run website
+bun run website:check
 ```
 
-**Notes.** Every consumer must (a) start from the *current* on-screen value, (b) accept a
-retarget mid-flight (cancel + re-spring with the live velocity — the closed form above
-takes `initialVelocity`, so this is free), and (c) be cancelled by any new pointerdown.
-That is the skill's §3 in one sentence.
-
-**Acceptance:** unit-testable pure functions; no `Date.now` (use `performance.now`); zero
-allocations per frame beyond the closure.
-
-### Rank 4 · R3 — Momentum panning with grab-to-interrupt (the flagship "feel" upgrade)
-
-**Why ranked #4:** skill-fidelity #2 (interruptibility + velocity handoff on a core
-gesture is the doctrine's textbook combination) and the most viscerally noticeable
-fluid-vs-clunky difference a non-designer will feel. The accessibility lens flagged
-self-moving content as a vestibular risk — which is exactly why R11 (rank 2) must ship
-first.
-
-**Skill:** §2 (1:1 tracking — already done), §5 (velocity handoff), §6 (momentum
-projection), §3 (grabbable mid-flight).
-
-**Current state:** `editor/js/pan.js` tracks 1:1 via `scrollLeft/scrollTop` (correct), but
-on `pointerup` motion stops dead (`endPan`, `pan.js:42–47`). A flick feels like hitting a
-wall — the exact seam the skill says separates "fluid" from "fine".
-
-**Change:**
-1. Feed `pointermove` events into the velocity tracker (F1) during a pan.
-2. On `pointerup`, read release velocity; if speed > ~50 px/s start a `decay` loop
-   (rate 0.998) applying deltas to `scrollLeft/scrollTop`. Clamp at scroll bounds
-   (stop the axis that hits an edge).
-3. Interruption: any `pointerdown` on `previewBody`, any wheel event, or a new render
-   cancels the decay instantly — the user "grabs" the moving canvas. This is
-   non-negotiable per skill §3.
-4. Applies to both pan-mode and `⌘/Ctrl`-drag pan. Touch pans in pan-mode get it too
-   (`touch-action: none` is already set, `preview.css:105–113`).
-5. Keep momentum under `prefers-reduced-motion` (native scroll deceleration persists under
-   reduced motion on every platform; it is user-generated motion, not vestibular
-   decoration) — but see R11: everything else around it must already be calm.
-
-**Acceptance:** a flick on a large zoomed-in diagram coasts and decelerates naturally;
-touching the canvas mid-coast stops it exactly where it is and a new drag starts from
-there with no jump; wheel input cancels coasting; velocity at handoff is continuous (no
-visible seam between finger-up and coast — review frame-by-frame at 0.25×).
-
-**Risk:** low-medium. Self-contained in `pan.js` + `motion.js`.
-
-### Rank 5 · R2 — Preview zoom becomes smooth, interruptible, and compositor-friendly
-
-**Why ranked #5:** felt-impact #2 — zoom fires constantly and today produces discrete
-jumps plus layout-thrash jank on big diagrams — but it carries the list's riskiest
-integration seam (transform-then-commit), so it lands right behind its sibling R3, which
-shares that seam and its cancel paths.
-
-**Skill:** §3 (interruptible, retarget from current value), §11 (animate only
-`transform`/`opacity`; commit layout when settled), §1 (respond instantly).
-
-**Current state:**
-- Zoom buttons step ×1.25 and apply instantly by rewriting the SVG's `width`/`height`
-  (`editor/js/zoom.js:9–19`) — a full layout + repaint of a potentially huge SVG per step.
-- `Ctrl/⌘+wheel` zoom does the same per wheel tick with cursor anchoring
-  (`editor/js/pan.js:58–76`). On large diagrams every tick relayouts.
-- "Fit" and the 100% reset jump instantly (`zoom.js:28–45`).
-
-**Change:**
-1. Introduce a single animated `zoomValue` driven by `springTo` (response ≈ 0.3,
-   critically damped). `applyZoom` becomes the *commit* function; a new
-   `animateZoomTo(target, anchorPoint)` retargets the spring from the live value —
-   pressing `+` three times fast must glide to the final target with no jumps
-   (this is the skill's §3 litmus test).
-2. During any *continuous* zoom (spring in flight, or a wheel-tick stream), scale with
-   `transform: scale()` on the SVG relative to the last committed layout size
-   (compositor-only), keeping the cursor-anchor math. When the interaction goes idle for
-   ~120 ms, commit once via the existing width/height path and clear the transform, so
-   scrollbars/pan metrics stay truthful.
-3. Anchor rules: buttons and reset anchor at the viewport center of `preview-body`; wheel
-   keeps the cursor anchor; "Fit" springs both zoom and scroll offsets.
-4. Reduced motion: `matchMedia('(prefers-reduced-motion: reduce)')` → skip the spring,
-   call `applyZoom` directly (current behavior).
-
-**Acceptance:** repeated `+` presses produce one continuous glide; grabbing the canvas
-(pan) mid-zoom-animation cancels the zoom spring cleanly; wheel-zooming a large example
-(load one from Examples) no longer relayouts per tick (verify with a DevTools performance
-trace — layout should appear only on commit); zoom label still reads correct percentages.
-
-**Risk:** medium — the transform-then-commit seam must not visibly shift the diagram.
-Guard: compute the committed scroll offsets from the same anchor math already in
-`pan.js:69–75`.
-
----
-
-## Tier 3 — High-value cheap wins (safe to sprinkle into any PR)
-
-### Rank 6 · R10 — Accessibility fallbacks for the existing frosted surfaces
-
-**Why ranked #6:** trivial, risk-free closure of a genuine gap; the brand lens called the
-omission "a credibility hole in a standards manual."
-
-**Skill:** §14 — `prefers-reduced-transparency` and `prefers-contrast` are independent
-signals; translucent surfaces must have frostier/solid equivalents.
-
-**Current state:** the shortcuts dialog panel is 88%-opaque + blur
-(`editor/css/misc.css:53–69`) and the comparison dialog backdrop blurs
-(`styles.css:451`) — **neither has a `prefers-reduced-transparency` or
-`prefers-contrast` fallback.** Both files handle `forced-colors` and `reduced-motion`
-but miss these two signals entirely.
-
-**Change:** add to both stylesheets:
-```css
-@media (prefers-reduced-transparency: reduce) {
-  .shortcuts-dialog-panel { background: var(--popover-bg); backdrop-filter: none; -webkit-backdrop-filter: none; }
-  .shortcuts-dialog { backdrop-filter: none; -webkit-backdrop-filter: none; }
-  /* site: */ .comparison-dialog::backdrop { backdrop-filter: none; }
-}
-@media (prefers-contrast: more) {
-  .shortcuts-dialog-panel { background: var(--popover-bg); border-color: var(--line-strong); }
-}
-```
-
-**Acceptance:** toggling "Reduce transparency" in OS settings (or DevTools emulation)
-yields fully solid overlays.
-
-**Risk:** trivial.
-
-### Rank 7 · R7 — Origin-aware comparison lightbox on the public site
-
-**Why ranked #7:** brand lens #2 — the comparisons dialog is the marketing centerpiece
-where evaluating engineers form their quality judgment, and this is the only motion
-upgrade on the public site. No dependency on F1.
-
-**Skill:** §7 (anchor interactions to their source), §12 (materialize, don't just fade).
-
-**Current state:** clicking a comparison grid opens a `<dialog>` via `showModal()` with
-**no entrance or exit animation at all** (inline site JS in `website/build.ts:1137–1445`;
-dialog styles `styles.css:449–455`). The backdrop already blurs (`styles.css:451`).
-
-**Change:** on open, set the dialog's `transform-origin` from the invoking panel's center
-(the click target rect is available in the `data-comparison-lightbox-panel` handler,
-`build.ts:1358, 1445`), then animate `opacity 0→1` + `scale(0.98)→1` over ~200 ms
-`--ease-out`; on close, reverse along the same path at ~120 ms before calling `close()`.
-Backdrop fades in sync. Reduced motion: fade only, no scale.
-
-**Acceptance:** the lightbox visibly grows out of the panel the user clicked and returns
-into it; `website-browser-a11y.test.ts:125` (which clicks a panel) still passes; keyboard
-open (Enter on the "Inspect" button) uses the button as origin.
-
-**Risk:** low. Pure enhancement in the inline script + CSS.
-
-### Rank 8 · R12 — Toast micro-fixes
-
-**Why ranked #8:** near-infinite value/effort ratio; the accessibility lens flagged the
-unpausable dismiss timer as a WCAG 2.2.1-class timing barrier (slow readers race failure
-messages).
-
-**Skill:** §16 agency/utility, §13 harmony.
-
-**Current state:** `editor/js/toast.js` — fixed 2.5 s timer, no pause; new messages
-replace text mid-flight abruptly. Style at `misc.css:19–41` (fade + 4 px rise — fine).
-
-**Change:** pause the dismiss timer on `pointerenter`/`focusin`, resume on leave (users
-reading a share-link failure toast shouldn't race it); when a toast is already visible,
-restart with a quick 80 ms fade-out/in so the text swap doesn't teleport.
-
-**Risk:** trivial.
-
-### Rank 9 · R5 — Two-finger pinch zoom + pan on touch
-
-**Why ranked #9:** the only outright capability gap in the list — a missing feature reads
-as "broken," not "unpolished" — tempered by minority touch usage of a code workbench and
-by medium risk on the same transform seam as R2. Ship after R2/R3 settle.
-
-**Skill:** §2, §10 (detect plausible gestures in parallel).
-
-**Current state:** in pan mode `touch-action: none` claims touch input, but a second
-pointer is ignored (`pan.js:26` tracks a single `panPointerId`), so touch users have no
-diagram zoom at all — only the toolbar buttons.
-
-**Change:** track up to two active pointers in pan mode; two pointers = pinch (scale about
-the midpoint using the R2 transform path, committing on gesture end) + midpoint pan;
-releasing one finger degrades gracefully to a 1:1 pan from the current value. Reuse the
-wheel-zoom anchor math.
-
-**Acceptance:** on a touch device (or DevTools touch emulation) pinch zooms about the
-pinch center, tracks 1:1, and hands off into the momentum/zoom systems.
-
-**Risk:** medium. Requires F1 + the R2 transform path.
-
-### Rank 10 · R6 — Symmetric, fast popover exits
-
-**Why ranked #10:** real but subtle — menus are touched many times per session, but an
-instant close is low-pain asymmetry rather than a felt defect, and the popup state
-machine needs care.
-
-**Skill:** §7 — "If something disappears one way, we expect it to emerge from where it
-came"; enter and exit along the same path.
-
-**Current state:** editor popovers (export dropdown, theme/style menus, font/color
-pickers) enter with a 160 ms origin-anchored fade/scale, but **exit instantly** —
-`affordances.css:48–59` documents this as intentional ("dismissal should never lag").
-The shortcuts dialog likewise has enter-only animation (`affordances.css:60–68`).
-
-**Change:** keep dismissal *feeling* instant but honor path symmetry: add a `.closing`
-state that plays the exact inverse (fade/scale back into the trigger) at **~90 ms** —
-faster than the 160 ms entrance, well under perception-of-lag, then hide on
-`animationend` (with a `setTimeout` fallback). Input must not be blocked during exit: the
-popup controller (`createListboxPopupController`, `editor/js/helpers.js:126`) should drop
-its open state and release focus immediately on close, with only the visual trailing.
-Apply the same to the shortcuts dialog scrim/panel and the export dropdown. Reduced
-motion: exits stay instant.
-
-**Acceptance:** menus visibly retreat into their trigger; mashing the trigger to
-open/close rapidly never gets stuck (the `.closing` animation is cancelled/replaced by a
-reopen — interruptibility again); Escape/blur dismissal begins on the same frame as the
-event.
-
-**Risk:** low-medium (state machine care in `helpers.js`).
-
-### Rank 11 · R8 — Mobile editor panel switch: cut → crossfade
-
-**Why ranked #11:** trivial softening of a jarring full-viewport hard cut, on a minority
-(mobile) path — cheap, self-contained, ships in minutes.
-
-**Skill:** §7/§14 — abrupt full-viewport content swaps are disorienting; a gentle fade
-aids comprehension.
-
-**Current state:** on ≤760 px, switching Source/Style/Preview flips `display: none`
-(`editor/css/panels.css:278–287`, driven by `editor/js/tabs.js:4–8`) — a hard cut of the
-entire viewport.
-
-**Change:** mirror the site's existing tab idiom (`styles.css:757–758`, `panel-in`
-keyframe): when `data-mobile-panel` changes, the incoming panel plays a one-way ~120 ms
-opacity fade-in (`animation: panel-in var(--dur-control) var(--ease-out)`). No exit
-animation (the outgoing panel is gone — correct for a display toggle), no slide (nothing
-spatial is being asserted between these views). Reduced motion: none (the global override
-already flattens animations).
-
-**Acceptance:** panel switches read as a soft cut; no layout shift; rapid tab mashing
-never shows two panels.
-
-**Risk:** trivial.
-
----
-
-## Tier 4 — Durability
-
-### Rank 12 · R15 — Add the motion vocabulary to the living design page
-
-**Why ranked #12:** changes almost nothing a current user perceives, but the brand lens
-ranked it #3 — codified restraint rules survive future contributors, and it only pays off
-after the motion vocabulary above it has shipped. Do it last.
-
-**Skill:** §17 — prototype interactively; the site's own `/about/design` page already
-renders specimens off live tokens (`styles.css:862–885`, `.dz-motion`, `.dz-press`).
-
-**Change:** add specimens for whatever ships from the tiers above: the spring response
-values in use, a momentum-pan demo strip, and a note codifying the rulings from §0
-("bounce only after momentum", "no new translucent surfaces", "never animate the render
-path"). Append the same rulings to `DESIGN.md` so future agents inherit them — including
-the list of descoped items below, so they aren't reintroduced from the skill by a future
-pass.
-
-**Risk:** none.
-
----
-
-## Explicit non-goals (things the skill suggests that this site should refuse)
-
-1. **No spring library dependency** — F1 covers every need in ~60 lines.
-2. **No bounce/overshoot on click-triggered UI** (popovers, dialogs, copy feedback, tabs).
-   The skill authorizes overshoot only when the user's gesture carried momentum; the only
-   in-scope candidate is R3's coast (a decay, not a bounce).
-3. **No new translucent materials anywhere** — on the public site's document surfaces per
-   `DESIGN.md`, and on editor chrome per the ranking review (see R9 below). Materials work
-   is limited to R10's fallbacks for the frosted overlays that already exist.
-4. **No crossfade on the render swap** — render latency work is R1; choreography on the
-   typing path would *add* perceived latency.
-5. **No global page transitions** — `styles.css:212–218` deliberately disables root view
-   transitions; leave that decision alone in this pass.
-6. **Don't touch the home-page entrance stagger or the shader mark** — both already follow
-   the skill (one entrance on load; sweep only on hover/focus; static under reduced
-   motion; WebGL fallback).
-
-## Removed from scope by the ranking review (do not reintroduce)
-
-Five items from the original 17-item audit were cut after the five-lens stack rank.
-Listed so a future pass doesn't rediscover them from the skill and re-propose them:
-
-- **R4 — rubber-band splitter bounds.** Once-per-session control; the brand lens judged a
-  springy splitter "the closest item to a bouncy gimmick on a precision instrument," and a
-  firm clamp communicates the bound honestly. (F1's rubber-band helper was dropped with
-  it.)
-- **R9 — translucent floating preview toolbar.** The accessibility lens ranked it dead
-  last for cause: it deliberately places chrome over arbitrary busy diagram content,
-  manufacturing the exact legibility-risk surface class R10 exists to remediate, and it
-  flirts with `DESIGN.md`'s no-glass prohibition.
-- **R13 — haptic tick on copy.** Bottom-three for four of five lenses; the brand lens
-  called it exactly the category of gimmick that damages this brand.
-- **R14 — px→rem spacing/control conversion.** A legitimate text-scaling accessibility
-  win, but the widest blast radius in the list (site-wide mechanical change, screenshot
-  diffing, test updates). Removed from this effort's scope; if the text-scaling harm is
-  revisited later, it should be its own carefully staged project, not a motion-polish
-  rider.
-- **R16 — standalone review-recipe item.** Ships nothing itself; its substance survives as
-  the per-PR checklist in the sequencing section below.
-
-## Suggested sequencing
-
-| PR | Contents | Effort |
-|----|----------|--------|
-| 1 | R1 (adaptive debounce, delayed spinner) | S |
-| 2 | R11 curated reduced-motion (site + editor) — before any new animation ships | M |
-| 3 | F1 + R3 (motion utils, momentum pan) | M |
-| 4 | R2 smooth zoom (coordinate with R3's cancel paths) | M |
-| 5 | R10 + R12 + R8 (trivial wins, no interdependencies) | S |
-| 6 | R6 popover exits | S–M |
-| 7 | R7 lightbox origin (public site) | S–M |
-| 8 | R5 pinch zoom (after the R2/R3 seam has settled) | M |
-| 9 | R15 design-page specimens + DESIGN.md rulings | S |
-
-Each PR: run `bun test src/__tests__/`, `bunx tsc --noEmit`, `bun run website` (stamp
-sync), and apply the repo's `good-pr` skill checklist — for these visual changes, §2
-(captioned before/after renders or short recordings) and §4 (tests that fail when the fix
-is reverted, e.g. debounce-adaptivity unit tests on `scheduleRender`) matter most. For
-every motion PR, review the interaction frame-by-frame (Playwright slow-mo; Chromium is
-pre-installed) and answer three questions before merge: does it start from the current
-value? can it be interrupted by input? what does it do under reduced motion?
+Browser tests prove observable contracts—dialog lifecycle/focus, mobile panel reachability, and
+popup inertness. They do not claim a machine-independent frame-rate benchmark; review the
+performance and gesture acceptance cases manually on representative large diagrams and touch
+emulation before merging.

--- a/scripts/site/editor.ts
+++ b/scripts/site/editor.ts
@@ -100,6 +100,7 @@ async function readJsFiles(): Promise<string> {
     'js/elements.js',
     'js/sharing.js',
     'js/rendering.js',
+    'js/motion.js',
     'js/zoom.js',
     'js/pan.js',
     'js/editor-helpers.js',

--- a/src/__tests__/editor-motion.test.ts
+++ b/src/__tests__/editor-motion.test.ts
@@ -64,6 +64,10 @@ describe('editor motion primitives', () => {
       onFrame(value, velocity) { frames.push({ value, velocity }) },
       onDone() { done++ },
     })
+    step(16)
+    expect(frames).toHaveLength(1)
+    expect(frames[0]!.velocity).toBeGreaterThan(0)
+    expect(spring.getState().velocity).toBeGreaterThan(0)
     for (let i = 0; i < 120 && pending(); i++) step(16)
     expect(done).toBe(1)
     expect(frames.at(-1)).toEqual({ value: 2, velocity: 0 })

--- a/src/__tests__/editor-motion.test.ts
+++ b/src/__tests__/editor-motion.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, test } from 'bun:test'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+const source = readFileSync(join(import.meta.dir, '..', '..', 'editor', 'js', 'motion.js'), 'utf8')
+
+type Frame = (time: number) => void
+type Motion = {
+  adaptiveRenderDelay(value: number | null): number
+  makeVelocityTracker(): { push(time: number, x: number, y: number): void; get(): { vx: number; vy: number }; reset(): void }
+  springTo(options: { from: number; to: number; velocity?: number; response?: number; onFrame?(value: number, velocity: number): void; onDone?(): void }): { cancel(): void; getState(): { value: number; velocity: number } }
+  decay2d(options: { vx: number; vy: number; rate?: number; onFrame(dx: number, dy: number, vx: number, vy: number): boolean | void; onDone?(): void }): { cancel(): void }
+}
+
+function loadMotion() {
+  let now = 0
+  let nextId = 1
+  const frames = new Map<number, Frame>()
+  const motion = new Function('window', 'performance', 'requestAnimationFrame', 'cancelAnimationFrame', `${source}; return EditorMotion;`)(
+    { matchMedia: () => ({ matches: false }) },
+    { now: () => now },
+    (frame: Frame) => { const id = nextId++; frames.set(id, frame); return id },
+    (id: number) => { frames.delete(id) },
+  ) as Motion
+  return {
+    motion,
+    step(ms: number) {
+      now += ms
+      const queued = [...frames.entries()]
+      frames.clear()
+      queued.forEach(([, frame]) => frame(now))
+    },
+    pending: () => frames.size,
+  }
+}
+
+describe('editor motion primitives', () => {
+  test('bounds adaptive render debounce from measured successful work', () => {
+    const { motion } = loadMotion()
+    expect(motion.adaptiveRenderDelay(null)).toBe(300)
+    expect(motion.adaptiveRenderDelay(10)).toBe(60)
+    expect(motion.adaptiveRenderDelay(80)).toBe(120)
+    expect(motion.adaptiveRenderDelay(400)).toBe(300)
+  })
+
+  test('tracks signed pointer velocity over the recent sample window', () => {
+    const { motion } = loadMotion()
+    const tracker = motion.makeVelocityTracker()
+    tracker.push(0, 10, 20)
+    tracker.push(50, 35, 5)
+    expect(tracker.get()).toEqual({ vx: 500, vy: -300 })
+    tracker.reset()
+    expect(tracker.get()).toEqual({ vx: 0, vy: 0 })
+  })
+
+  test('exposes live spring velocity for interruption and settles exactly once', () => {
+    const { motion, step, pending } = loadMotion()
+    const frames: Array<{ value: number; velocity: number }> = []
+    let done = 0
+    const spring = motion.springTo({
+      from: 1,
+      to: 2,
+      response: 0.3,
+      onFrame(value, velocity) { frames.push({ value, velocity }) },
+      onDone() { done++ },
+    })
+    for (let i = 0; i < 120 && pending(); i++) step(16)
+    expect(done).toBe(1)
+    expect(frames.at(-1)).toEqual({ value: 2, velocity: 0 })
+    expect(spring.getState()).toEqual({ value: 2, velocity: 0 })
+  })
+
+  test('cancels decay without calling its completion callback', () => {
+    const { motion, step, pending } = loadMotion()
+    let done = 0
+    let frames = 0
+    const decay = motion.decay2d({ vx: 800, vy: 0, onFrame() { frames++ }, onDone() { done++ } })
+    step(16)
+    decay.cancel()
+    for (let i = 0; i < 20 && pending(); i++) step(16)
+    expect(frames).toBe(1)
+    expect(done).toBe(0)
+  })
+})

--- a/src/__tests__/website-browser-a11y.test.ts
+++ b/src/__tests__/website-browser-a11y.test.ts
@@ -154,8 +154,10 @@ describeBrowser('website browser accessibility smoke', () => {
   test('design motion specimen supports keyboard and direct manipulation without reduced-motion coast', async () => {
     const page = await browser.newPage({ viewport: { width: 390, height: 900 } })
     const trackTransform = () => page.locator('.dz-motion-track').evaluate((el) => (el as HTMLElement).style.transform)
-    async function dragLeft() {
-      const box = await page.locator('[data-motion-strip]').boundingBox()
+    async function dragLeft(stationaryBeforeReleaseMs = 0) {
+      const strip = page.locator('[data-motion-strip]')
+      await strip.scrollIntoViewIfNeeded()
+      const box = await strip.boundingBox()
       expect(box).not.toBeNull()
       const x = box!.x + box!.width * 0.8
       const y = box!.y + box!.height / 2
@@ -163,7 +165,10 @@ describeBrowser('website browser accessibility smoke', () => {
       await page.mouse.down()
       await new Promise((resolve) => setTimeout(resolve, 24))
       await page.mouse.move(x - box!.width * 0.5, y)
+      if (stationaryBeforeReleaseMs) await new Promise((resolve) => setTimeout(resolve, stationaryBeforeReleaseMs))
+      const beforeRelease = await trackTransform()
       await page.mouse.up()
+      return beforeRelease
     }
 
     await page.goto(baseUrl + '/about/design/', { waitUntil: 'networkidle' })
@@ -174,15 +179,23 @@ describeBrowser('website browser accessibility smoke', () => {
     await page.keyboard.press('ArrowRight')
     expect(await trackTransform()).not.toBe(beforeKeyboard)
     const beforeDrag = await trackTransform()
-    await dragLeft()
-    expect(await trackTransform()).not.toBe(beforeDrag)
+    const afterNormalRelease = await dragLeft()
+    expect(afterNormalRelease).not.toBe(beforeDrag)
+    await new Promise((resolve) => setTimeout(resolve, 120))
+    expect(await trackTransform()).not.toBe(afterNormalRelease)
+
+    // A release after holding still must not reuse the preceding drag velocity.
+    await page.goto(baseUrl + '/about/design/', { waitUntil: 'networkidle' })
+    await page.waitForFunction(() => Boolean((document.querySelector('.dz-motion-track') as HTMLElement | null)?.style.transform), undefined, { timeout: 2_000 })
+    const afterStationaryRelease = await dragLeft(150)
+    await new Promise((resolve) => setTimeout(resolve, 180))
+    expect(await trackTransform()).toBe(afterStationaryRelease)
 
     try {
       await page.emulateMedia({ reducedMotion: 'reduce' })
       await page.goto(baseUrl + '/about/design/', { waitUntil: 'networkidle' })
       await page.waitForFunction(() => Boolean((document.querySelector('.dz-motion-track') as HTMLElement | null)?.style.transform), undefined, { timeout: 2_000 })
-      await dragLeft()
-      const afterRelease = await trackTransform()
+      const afterRelease = await dragLeft()
       await new Promise((resolve) => setTimeout(resolve, 180))
       expect(await trackTransform()).toBe(afterRelease)
     } finally {
@@ -379,12 +392,24 @@ describeBrowser('website browser accessibility smoke', () => {
     await page.locator('#examples-sidebar-btn').focus()
     await page.evaluate(() => document.dispatchEvent(new KeyboardEvent('keydown', { key: '?', bubbles: true, cancelable: true })))
     expect(await page.locator('#shortcuts-dialog').getAttribute('aria-hidden')).toBe('false')
+    expect(await page.evaluate(() => document.getElementById('code-editor')?.closest('[inert]') !== null)).toBe(true)
+    await page.evaluate(() => (document.getElementById('code-editor') as HTMLTextAreaElement).focus())
     expect(await page.evaluate(() => document.activeElement === document.querySelector('#shortcuts-dialog-close'))).toBe(true)
     await page.keyboard.press('Tab')
     expect(await page.evaluate(() => document.activeElement === document.querySelector('#shortcuts-dialog-close'))).toBe(true)
     await page.keyboard.press('Escape')
     expect(await page.locator('#shortcuts-dialog').getAttribute('aria-hidden')).toBe('true')
     expect(await page.evaluate(() => document.activeElement === document.querySelector('#examples-sidebar-btn'))).toBe(true)
+    expect(await page.evaluate(() => document.getElementById('code-editor')?.closest('[inert]') === null)).toBe(true)
+    expect(await page.evaluate(() => document.getElementById('shortcuts-dialog')?.parentElement !== document.body)).toBe(true)
+
+    // Opening shortcuts closes peer popups, so focus must return to the peer's
+    // usable trigger rather than an element that became inert with the popup.
+    await page.locator('#settings-btn').click()
+    await page.locator('#font-select-btn').focus()
+    await page.evaluate(() => document.dispatchEvent(new KeyboardEvent('keydown', { key: '?', bubbles: true, cancelable: true })))
+    await page.keyboard.press('Escape')
+    expect(await page.evaluate(() => document.activeElement === document.querySelector('#settings-btn'))).toBe(true)
 
     await page.locator('#settings-btn').click()
     for (const spec of [

--- a/src/__tests__/website-browser-a11y.test.ts
+++ b/src/__tests__/website-browser-a11y.test.ts
@@ -137,7 +137,13 @@ describeBrowser('website browser accessibility smoke', () => {
         expect(await page.locator('.comparison-dialog[open]').count()).toBe(1)
         expect(await page.locator('.comparison-dialog .comparison-panel').count()).toBeGreaterThanOrEqual(2)
         await page.locator('.comparison-dialog-close').click()
+        await page.waitForFunction(() => document.querySelector('.comparison-dialog[open]') === null)
         expect(await page.locator('.comparison-dialog[open]').count()).toBe(0)
+        await page.locator('[data-comparison-open]').first().click()
+        expect(await page.locator('.comparison-dialog[open]').count()).toBe(1)
+        await page.keyboard.press('Escape')
+        await page.waitForFunction(() => document.querySelector('.comparison-dialog[open]') === null)
+        expect(await page.evaluate(() => document.activeElement === document.querySelector('[data-comparison-open]'))).toBe(true)
       }
       expect(await page.locator('.theme-switch').count()).toBe(0)
     }

--- a/src/__tests__/website-browser-a11y.test.ts
+++ b/src/__tests__/website-browser-a11y.test.ts
@@ -137,7 +137,8 @@ describeBrowser('website browser accessibility smoke', () => {
         expect(await page.locator('.comparison-dialog[open]').count()).toBe(1)
         expect(await page.locator('.comparison-dialog .comparison-panel').count()).toBeGreaterThanOrEqual(2)
         await page.locator('.comparison-dialog-close').click()
-        await page.waitForFunction(() => document.querySelector('.comparison-dialog[open]') === null)
+        // Close removes native modality on the event frame; any fade-out tail
+        // is noninteractive and cannot hold focus or the background inert.
         expect(await page.locator('.comparison-dialog[open]').count()).toBe(0)
         await page.locator('[data-comparison-open]').first().click()
         expect(await page.locator('.comparison-dialog[open]').count()).toBe(1)
@@ -148,6 +149,46 @@ describeBrowser('website browser accessibility smoke', () => {
       expect(await page.locator('.theme-switch').count()).toBe(0)
     }
     await page.close()
+  }, 30_000)
+
+  test('design motion specimen supports keyboard and direct manipulation without reduced-motion coast', async () => {
+    const page = await browser.newPage({ viewport: { width: 390, height: 900 } })
+    const trackTransform = () => page.locator('.dz-motion-track').evaluate((el) => (el as HTMLElement).style.transform)
+    async function dragLeft() {
+      const box = await page.locator('[data-motion-strip]').boundingBox()
+      expect(box).not.toBeNull()
+      const x = box!.x + box!.width * 0.8
+      const y = box!.y + box!.height / 2
+      await page.mouse.move(x, y)
+      await page.mouse.down()
+      await new Promise((resolve) => setTimeout(resolve, 24))
+      await page.mouse.move(x - box!.width * 0.5, y)
+      await page.mouse.up()
+    }
+
+    await page.goto(baseUrl + '/about/design/', { waitUntil: 'networkidle' })
+    await page.waitForFunction(() => Boolean((document.querySelector('.dz-motion-track') as HTMLElement | null)?.style.transform), undefined, { timeout: 2_000 })
+    const strip = page.locator('[data-motion-strip]')
+    await strip.focus()
+    const beforeKeyboard = await trackTransform()
+    await page.keyboard.press('ArrowRight')
+    expect(await trackTransform()).not.toBe(beforeKeyboard)
+    const beforeDrag = await trackTransform()
+    await dragLeft()
+    expect(await trackTransform()).not.toBe(beforeDrag)
+
+    try {
+      await page.emulateMedia({ reducedMotion: 'reduce' })
+      await page.goto(baseUrl + '/about/design/', { waitUntil: 'networkidle' })
+      await page.waitForFunction(() => Boolean((document.querySelector('.dz-motion-track') as HTMLElement | null)?.style.transform), undefined, { timeout: 2_000 })
+      await dragLeft()
+      const afterRelease = await trackTransform()
+      await new Promise((resolve) => setTimeout(resolve, 180))
+      expect(await trackTransform()).toBe(afterRelease)
+    } finally {
+      await page.emulateMedia({ reducedMotion: 'no-preference' })
+      await page.close()
+    }
   }, 30_000)
 
   test('public typography keeps the Examples-width document column and safe code wrapping', async () => {

--- a/src/__tests__/website-build.test.ts
+++ b/src/__tests__/website-build.test.ts
@@ -994,7 +994,9 @@ describe('Workers Static Assets website contract', () => {
     expect(editor).toContain('id="copy-link-btn"')
     // "?" opens the cheat sheet without a trigger button, and it renders as a
     // Gmail-style scrim + panel (aria-modal, backdrop click closes).
-    expect(editorAll).toContain("shortcutsReturnFocus = document.activeElement")
+    expect(editorAll).toContain("shortcutsReturnFocus = shortcutsReturnTarget(document.activeElement)")
+    expect(editorAll).toContain('portalShortcutsDialog()')
+    expect(editorAll).toContain('setShortcutsBackgroundInert(true)')
     expect(editor).toContain('id="shortcuts-dialog" role="dialog" aria-modal="true"')
     expect(editor).toContain('class="shortcuts-dialog-panel"')
     expect(styles).toContain('@media (forced-colors: active)')

--- a/website/build.ts
+++ b/website/build.ts
@@ -1221,7 +1221,7 @@ ${comparisonStyleSupportHtml()}
   var note = dialog.querySelector('[data-comparison-dialog-note]');
   var current = null;
   var dialogAnimation = null;
-  var dialogClosing = false;
+  var dialogExitTail = null;
   var ENGINES = {
     agentic: 'Agentic Mermaid',
     mermaid: 'Mermaid',
@@ -1481,23 +1481,48 @@ ${comparisonStyleSupportHtml()}
       { duration: 200, easing: 'cubic-bezier(0.22, 1, 0.36, 1)' }
     );
   }
-  function requestClose() {
-    if (!dialog.open || dialogClosing) return;
-    dialogClosing = true;
-    if (dialogAnimation) dialogAnimation.cancel();
-    dialogAnimation = reducedMotion()
-      ? dialog.animate([{ opacity: 1 }, { opacity: 0 }], { duration: 120, easing: 'ease-out' })
-      : dialog.animate(
-        [{ opacity: 1, transform: 'scale(1)' }, { opacity: 0, transform: 'scale(0.98)' }],
-        { duration: 120, easing: 'cubic-bezier(0.4, 0, 1, 1)' }
-      );
-    dialogAnimation.onfinish = function() {
-      dialogClosing = false;
-      if (dialog.open) dialog.close();
+  function clearDialogExitTail() {
+    if (!dialogExitTail) return;
+    var tail = dialogExitTail;
+    dialogExitTail = null;
+    if (tail.animation) tail.animation.cancel();
+    if (tail.element.parentNode) tail.element.parentNode.removeChild(tail.element);
+  }
+  function animateDialogExitTail() {
+    if (reducedMotion()) return;
+    clearDialogExitTail();
+    var rect = dialog.getBoundingClientRect();
+    var tail = dialog.cloneNode(true);
+    tail.removeAttribute('open');
+    tail.removeAttribute('aria-modal');
+    tail.removeAttribute('aria-labelledby');
+    tail.removeAttribute('aria-describedby');
+    tail.setAttribute('aria-hidden', 'true');
+    tail.inert = true;
+    tail.querySelectorAll('[id]').forEach(function(node) { node.removeAttribute('id'); });
+    tail.style.cssText += ';display:block;position:fixed;z-index:2147483647;inset:auto;top:' + rect.top + 'px;left:' + rect.left + 'px;width:' + rect.width + 'px;height:' + rect.height + 'px;margin:0;pointer-events:none;overflow:hidden';
+    document.body.appendChild(tail);
+    var state = { element: tail, animation: null };
+    dialogExitTail = state;
+    state.animation = tail.animate(
+      [{ opacity: 1, transform: 'scale(1)' }, { opacity: 0, transform: 'scale(0.98)' }],
+      { duration: 120, easing: 'cubic-bezier(0.4, 0, 1, 1)' }
+    );
+    state.animation.onfinish = state.animation.oncancel = function() {
+      if (dialogExitTail === state) dialogExitTail = null;
+      if (tail.parentNode) tail.parentNode.removeChild(tail);
     };
-    dialogAnimation.oncancel = function() { dialogClosing = false; };
+  }
+  function requestClose() {
+    if (!dialog.open) return;
+    if (dialogAnimation) dialogAnimation.cancel();
+    animateDialogExitTail();
+    // Native close restores the document's semantics and focus immediately;
+    // any remaining visual tail is an inert, non-modal snapshot.
+    dialog.close();
   }
   function openComparison(section, origin) {
+    clearDialogExitTail();
     restore();
     var grid = section && section.querySelector('.comparison-grid');
     if (!section || !grid || !body) return;
@@ -1595,7 +1620,6 @@ ${comparisonStyleSupportHtml()}
   });
   window.addEventListener('resize', refreshFit);
   dialog.addEventListener('close', function() {
-    dialogClosing = false;
     restore();
   });
   dialog.addEventListener('click', function (event) {

--- a/website/build.ts
+++ b/website/build.ts
@@ -1133,13 +1133,13 @@ function comparisonsHtml() {
 </div><div class="comparisons" data-mermaid-runtime="/${mermaidRuntimeRel}">${sections}
 ${comparisonStyleSupportHtml()}
 <dialog class="comparison-dialog" data-comparison-dialog aria-labelledby="comparison-dialog-title">
-  <form class="comparison-dialog-bar" method="dialog">
+  <div class="comparison-dialog-bar">
     <div>
       <h2 id="comparison-dialog-title">Comparison</h2>
       <p class="comparison-dialog-note" data-comparison-dialog-note hidden></p>
     </div>
-    <button class="comparison-dialog-close" type="submit">Close</button>
-  </form>
+    <button class="comparison-dialog-close" type="button">Close</button>
+  </div>
   <div class="comparison-dialog-body" data-comparison-dialog-body></div>
 </dialog>
 <script>
@@ -1220,6 +1220,8 @@ ${comparisonStyleSupportHtml()}
   var title = dialog.querySelector('#comparison-dialog-title');
   var note = dialog.querySelector('[data-comparison-dialog-note]');
   var current = null;
+  var dialogAnimation = null;
+  var dialogClosing = false;
   var ENGINES = {
     agentic: 'Agentic Mermaid',
     mermaid: 'Mermaid',
@@ -1450,18 +1452,58 @@ ${comparisonStyleSupportHtml()}
   }
   function restore() {
     if (!current) return;
+    var returnFocus = current.origin;
     document.documentElement.style.overflow = current.previousOverflow || '';
     resetGrid(current.grid);
     body.textContent = '';
     current.marker.parentNode.replaceChild(current.grid, current.marker);
     setLightboxTriggers(current.section, true);
+    dialog.style.transformOrigin = '';
     current = null;
+    if (returnFocus && typeof returnFocus.focus === 'function') returnFocus.focus({ preventScroll: true });
   }
-  function openComparison(section) {
+  function reducedMotion() {
+    return !!(window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches);
+  }
+  function animateDialogFrom(originRect) {
+    if (dialogAnimation) dialogAnimation.cancel();
+    if (reducedMotion()) {
+      dialogAnimation = dialog.animate([{ opacity: 0 }, { opacity: 1 }], { duration: 150, easing: 'ease-out' });
+      return;
+    }
+    if (!originRect) return;
+    var rect = dialog.getBoundingClientRect();
+    var originX = ((originRect.left + originRect.width / 2 - rect.left) / (rect.width || 1)) * 100;
+    var originY = ((originRect.top + originRect.height / 2 - rect.top) / (rect.height || 1)) * 100;
+    dialog.style.transformOrigin = originX + '% ' + originY + '%';
+    dialogAnimation = dialog.animate(
+      [{ opacity: 0, transform: 'scale(0.98)' }, { opacity: 1, transform: 'scale(1)' }],
+      { duration: 200, easing: 'cubic-bezier(0.22, 1, 0.36, 1)' }
+    );
+  }
+  function requestClose() {
+    if (!dialog.open || dialogClosing) return;
+    dialogClosing = true;
+    if (dialogAnimation) dialogAnimation.cancel();
+    dialogAnimation = reducedMotion()
+      ? dialog.animate([{ opacity: 1 }, { opacity: 0 }], { duration: 120, easing: 'ease-out' })
+      : dialog.animate(
+        [{ opacity: 1, transform: 'scale(1)' }, { opacity: 0, transform: 'scale(0.98)' }],
+        { duration: 120, easing: 'cubic-bezier(0.4, 0, 1, 1)' }
+      );
+    dialogAnimation.onfinish = function() {
+      dialogClosing = false;
+      if (dialog.open) dialog.close();
+    };
+    dialogAnimation.oncancel = function() { dialogClosing = false; };
+  }
+  function openComparison(section, origin) {
     restore();
     var grid = section && section.querySelector('.comparison-grid');
     if (!section || !grid || !body) return;
     section.dispatchEvent(new CustomEvent('am:render-comparison-panels', { bubbles: true }));
+    var originEl = origin || grid;
+    var originRect = originEl.getBoundingClientRect();
     setLightboxTriggers(section, false);
     var marker = document.createComment('comparison-grid');
     grid.parentNode.insertBefore(marker, grid);
@@ -1473,7 +1515,7 @@ ${comparisonStyleSupportHtml()}
     var noteText = section.querySelector('.comparison-note')?.textContent || section.querySelector('.comparison-takeaway')?.textContent || '';
     note.textContent = noteText;
     note.hidden = !noteText;
-    current = { section: section, grid: grid, marker: marker, controls: controls, family: family, editorHref: editorHrefForSection(section), pair: null, view: 'compare', zoom: 1, previousOverflow: document.documentElement.style.overflow };
+    current = { section: section, grid: grid, marker: marker, controls: controls, family: family, editorHref: editorHrefForSection(section), pair: null, view: 'compare', zoom: 1, origin: originEl, originRect: originRect, previousOverflow: document.documentElement.style.overflow };
     document.documentElement.style.overflow = 'hidden';
     controls.addEventListener('input', function (event) {
       var target = event.target;
@@ -1510,6 +1552,7 @@ ${comparisonStyleSupportHtml()}
       applyDetailState();
     });
     dialog.showModal();
+    animateDialogFrom(originRect);
     updateSourceControls();
     applyDetailState();
     setTimeout(refreshFit, 80);
@@ -1521,25 +1564,42 @@ ${comparisonStyleSupportHtml()}
   });
   document.querySelectorAll('[data-comparison-open]').forEach(function (button) {
     button.addEventListener('click', function () {
-      openComparison(button.closest('.comparison-case'));
+      openComparison(button.closest('.comparison-case'), button);
     });
   });
   document.querySelectorAll('[data-comparison-lightbox-panel]').forEach(function (group) {
     group.addEventListener('click', function () {
       if (group.closest('[data-comparison-dialog]')) return;
-      openComparison(group.closest('.comparison-case'));
+      openComparison(group.closest('.comparison-case'), group);
     });
     group.addEventListener('keydown', function (event) {
       if (group.closest('[data-comparison-dialog]')) return;
       if (event.key !== 'Enter' && event.key !== ' ') return;
       event.preventDefault();
-      openComparison(group.closest('.comparison-case'));
+      openComparison(group.closest('.comparison-case'), group);
     });
   });
+  dialog.querySelector('.comparison-dialog-close').addEventListener('click', requestClose);
+  document.addEventListener('keydown', function(event) {
+    if (!dialog.open || event.key !== 'Tab') return;
+    var focusable = Array.prototype.slice.call(dialog.querySelectorAll('button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])'));
+    if (!focusable.length) return;
+    var first = focusable[0], last = focusable[focusable.length - 1];
+    if (!dialog.contains(document.activeElement)) { event.preventDefault(); first.focus(); }
+    else if (event.shiftKey && document.activeElement === first) { event.preventDefault(); last.focus(); }
+    else if (!event.shiftKey && document.activeElement === last) { event.preventDefault(); first.focus(); }
+  });
+  dialog.addEventListener('cancel', function(event) {
+    event.preventDefault();
+    requestClose();
+  });
   window.addEventListener('resize', refreshFit);
-  dialog.addEventListener('close', restore);
+  dialog.addEventListener('close', function() {
+    dialogClosing = false;
+    restore();
+  });
   dialog.addEventListener('click', function (event) {
-    if (event.target === dialog) dialog.close();
+    if (event.target === dialog) requestClose();
   });
 })();
 </script>
@@ -2248,11 +2308,15 @@ const designBody = `
 </div>
 
 <h2>Motion</h2>
-<p>Three durations, one curve. Presses run <code>--dur-press</code> 0.1s, control state changes <code>--dur-control</code> 0.16s, page-level fades <code>--dur-ui</code> 0.2s, all on <code>--ease-out</code> <code>cubic-bezier(0.22,&nbsp;1,&nbsp;0.36,&nbsp;1)</code> — fast start, soft landing, the curve for anything answering the user. Every press lands at <code>scale(0.96)</code>. Popovers enter with a short fade-and-scale from the corner that anchors them and exit instantly; <code>prefers-reduced-motion</code> flattens all of it.</p>
+<p>Three durations, one curve. Presses run <code>--dur-press</code> 0.1s, control state changes <code>--dur-control</code> 0.16s, page-level fades <code>--dur-ui</code> 0.2s, all on <code>--ease-out</code> <code>cubic-bezier(0.22,&nbsp;1,&nbsp;0.36,&nbsp;1)</code> — fast start, soft landing, the curve for anything answering the user. Every press lands at <code>scale(0.96)</code>. Popovers enter from their anchor and visually return along the same path in 90ms, while their semantic close and focus release happen immediately.</p>
 <div class="dz-motion">
   <button class="dz-press" type="button">Press me — 0.96 at 0.1s</button>
-  <span style="font-family:var(--mono);font-size:var(--t-label);color:var(--ink-faint)">hover 0.16s · enter 0.16s ease-out · exit instant</span>
+  <span style="font-family:var(--mono);font-size:var(--t-label);color:var(--ink-faint)">hover 0.16s · enter 0.16s ease-out · exit 0.09s</span>
 </div>
+<div class="dz-motion-strip" data-motion-strip tabindex="0" aria-label="Momentum pan specimen. Drag or use arrow keys to move the diagram strip.">
+  <div class="dz-motion-track"><span>Parse</span><i></i><span>Narrow</span><i></i><span>Mutate</span><i></i><span>Verify</span><i></i><span>Serialize</span></div>
+</div>
+<ul class="dz-motion-rules"><li>Start from the current visible value; a new gesture cancels and takes over immediately.</li><li>Only momentum-bearing gestures may coast. Click-triggered controls never bounce or overshoot.</li><li>Reduced motion keeps brief opacity and colour feedback, never translation or scale; rendering itself never animates.</li><li>No new translucent surfaces: existing overlays offer opaque reduced-transparency and contrast fallbacks.</li></ul>
 
 <h2>Iconography</h2>
 <p>Interface icons are hairline strokes with round caps and joins: <code>stroke-width</code> 2 up to 14px, 1.75 from 15px, so optical weight stays even as size grows. The graph mark is exempt — it is brand art with its own drawn weights, isolated in the brand layer.</p>

--- a/website/source/assets/styles.css
+++ b/website/source/assets/styles.css
@@ -451,6 +451,10 @@ hr { border: 0; margin: var(--sp-6) 0; }
 .comparison-dialog { width: min(calc(100vw - 24px), 1800px); height: min(calc(100dvh - 24px), 1120px); max-width: none; max-height: none; padding: 0; border: 1px solid var(--surface-border-strong); border-radius: var(--radius-lg); background: var(--bg); color: var(--ink); box-shadow: var(--shadow-popover); }
 .comparison-dialog[open] { display: grid; grid-template-rows: auto minmax(0, 1fr); }
 .comparison-dialog::backdrop { background: rgb(24 22 18 / 0.68); backdrop-filter: blur(4px); }
+@media (prefers-reduced-transparency: reduce), (prefers-contrast: more) {
+  .comparison-dialog::backdrop { background: var(--bg); backdrop-filter: none; -webkit-backdrop-filter: none; }
+  .comparison-dialog { border-color: var(--line-strong); }
+}
 .comparison-dialog-bar { position: sticky; top: 0; z-index: 1; display: flex; align-items: flex-start; justify-content: space-between; gap: 18px; padding: 14px 16px; border-bottom: 1px solid var(--line); background: color-mix(in srgb, var(--bg) 92%, transparent); }
 .comparison-dialog-bar h2 { margin: 0; font-size: var(--t-h3); }
 .comparison-dialog-note { margin: 4px 0 0; color: var(--ink-faint); font-size: var(--t-label); line-height: var(--lh-ui); }
@@ -759,7 +763,16 @@ figcaption { color: var(--ink-faint); font-size: var(--t-label); line-height: 1.
   @keyframes panel-in { from { opacity: 0; } to { opacity: 1; } }
   .tabs-ready .tab-panel:not([hidden]) { animation: panel-in var(--dur-control) var(--ease-out); }
 }
-@media (prefers-reduced-motion: reduce) { *, *::before, *::after { animation-duration: 0.001ms !important; transition-duration: 0.001ms !important; } }
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after { animation-duration: 0.001ms !important; transition-duration: 0.001ms !important; }
+  /* Keep comprehension-only fades; no transform or scale returns under this preference. */
+  @keyframes panel-in-reduced { from { opacity: 0; } to { opacity: 1; } }
+  .tabs-ready .tab-panel:not([hidden]) { animation: panel-in-reduced 0.15s var(--ease-out) !important; }
+  :where(body, .doc, a, button, .copy-prompt-status) {
+    transition-property: opacity, color, background-color, border-color !important;
+    transition-duration: 0.15s !important;
+  }
+}
 
 /* Shared affordance primitives: keep links, controls, metadata, surfaces, and
    status feedback on one visual contract instead of page-specific one-offs. */
@@ -880,6 +893,14 @@ figcaption { color: var(--ink-faint); font-size: var(--t-label); line-height: 1.
 .dz-shadow { height: 72px; border-radius: var(--radius-lg); background: var(--surface); display: grid; place-items: center; font-family: var(--mono); font-size: var(--t-label); color: var(--ink-soft); }
 .dz-motion { display: flex; gap: var(--sp-3); align-items: center; flex-wrap: wrap; margin: var(--sp-4) 0; }
 .dz-press { padding: 0 var(--control-px); font-weight: 650; }
+.dz-motion-strip { overflow: hidden; margin: var(--sp-4) 0 var(--sp-3); border: 1px solid var(--line); border-radius: var(--radius-lg); background: var(--surface); cursor: grab; touch-action: none; }
+.dz-motion-strip:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+.dz-motion-strip.dragging { cursor: grabbing; user-select: none; }
+.dz-motion-track { display: flex; align-items: center; gap: 14px; width: max-content; padding: 18px; color: var(--ink-soft); font-family: var(--mono); font-size: var(--t-label); font-weight: 650; will-change: transform; }
+.dz-motion-track span { display: inline-grid; min-width: 84px; min-height: 38px; place-items: center; border: 1px solid var(--line-strong); border-radius: var(--radius-md); background: var(--paper); }
+.dz-motion-track i { width: 24px; height: 1px; background: var(--line-strong); }
+.dz-motion-rules { display: grid; gap: 5px; margin: 0; padding-left: 20px; color: var(--ink-soft); font-size: var(--t-sm); }
+@media (prefers-reduced-motion: reduce) { .dz-motion-track { will-change: auto; } }
 .dz-mark-row { display: flex; align-items: center; gap: var(--sp-4); margin: var(--sp-4) 0; }
 .dz-icons { display: flex; gap: var(--sp-4); align-items: center; color: var(--ink-soft); }
 .dz-voice li { margin-bottom: var(--sp-2); }

--- a/website/source/assets/theme.js
+++ b/website/source/assets/theme.js
@@ -53,6 +53,66 @@
     });
   }
 
+  function initMotionStrips() {
+    document.querySelectorAll('[data-motion-strip]').forEach((strip) => {
+      const track = strip.querySelector('.dz-motion-track');
+      if (!track) return;
+      let offset = 0;
+      let pointer = null;
+      let start = 0;
+      let origin = 0;
+      let velocity = 0;
+      let last = null;
+      let coast = 0;
+      const reduced = () => window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+      const min = () => Math.min(0, strip.clientWidth - track.scrollWidth);
+      const paint = () => { offset = Math.max(min(), Math.min(0, offset)); track.style.transform = `translateX(${offset}px)`; };
+      const stop = () => { if (coast) cancelAnimationFrame(coast); coast = 0; };
+      const beginCoast = () => {
+        if (reduced() || Math.abs(velocity) < 50) return;
+        let previous = performance.now();
+        const frame = (now) => {
+          const dt = Math.min(0.05, (now - previous) / 1000); previous = now;
+          velocity *= Math.pow(0.998, dt * 1000);
+          if (Math.abs(velocity) < 4) { coast = 0; return; }
+          const before = offset;
+          offset += velocity * dt;
+          paint();
+          if (offset === before) { coast = 0; return; }
+          coast = requestAnimationFrame(frame);
+        };
+        coast = requestAnimationFrame(frame);
+      };
+      strip.addEventListener('pointerdown', (event) => {
+        stop(); pointer = event.pointerId; start = event.clientX; origin = offset; velocity = 0; last = { x: event.clientX, t: performance.now() };
+        strip.setPointerCapture?.(pointer); strip.classList.add('dragging'); event.preventDefault();
+      });
+      strip.addEventListener('pointermove', (event) => {
+        if (event.pointerId !== pointer) return;
+        offset = origin + event.clientX - start;
+        const now = performance.now();
+        const dt = Math.max(1, now - last.t);
+        velocity = (event.clientX - last.x) / dt * 1000;
+        last = { x: event.clientX, t: now };
+        paint();
+      });
+      const end = (event, cancelled) => {
+        if (event.pointerId !== pointer) return;
+        pointer = null; strip.classList.remove('dragging');
+        if (!cancelled) beginCoast();
+      };
+      strip.addEventListener('pointerup', (event) => end(event, false));
+      strip.addEventListener('pointercancel', (event) => end(event, true));
+      strip.addEventListener('keydown', (event) => {
+        const step = event.shiftKey ? 120 : 40;
+        if (event.key === 'ArrowLeft') { stop(); offset += step; paint(); event.preventDefault(); }
+        if (event.key === 'ArrowRight') { stop(); offset -= step; paint(); event.preventDefault(); }
+      });
+      window.addEventListener('resize', paint);
+      paint();
+    });
+  }
+
   /* Homepage style gallery: a prev/next cycler over pre-rendered panels.
      Markup ships as stacked labeled panels (first visible, rest hidden) so the
      content reads without JS; this wires the buttons, keeps exactly one panel
@@ -85,7 +145,8 @@
     });
   }
 
-  function init() { initCopyButtons(); initTabs(); initGallery(); }
+
+  function init() { initCopyButtons(); initTabs(); initGallery(); initMotionStrips(); }
   if (document.readyState !== 'loading') init();
   else document.addEventListener('DOMContentLoaded', init);
 })();

--- a/website/source/assets/theme.js
+++ b/website/source/assets/theme.js
@@ -98,6 +98,9 @@
       });
       const end = (event, cancelled) => {
         if (event.pointerId !== pointer) return;
+        // A stationary hold is not a fling. Keep the last direct-manipulation
+        // velocity only while it is recent enough to describe the release.
+        if (last && performance.now() - last.t > 100) velocity = 0;
         pointer = null; strip.classList.remove('dragging');
         if (!cancelled) beginCoast();
       };


### PR DESCRIPTION
## What & why

This completes the fluid-interaction work planned in this PR, rather than only proposing it. The editor now has dependency-free, interruptible motion primitives and applies them to input paths that previously stopped abruptly or hid latency:

- adaptive render debounce and a delayed loading indicator;
- interruptible pan momentum, pinch zoom, and transform-then-commit zoom;
- pausable/replacing toast feedback and semantic-first popup exits;
- safe comparison-dialog close/focus lifecycle;
- `prefers-reduced-motion`, reduced-transparency, and increased-contrast fallbacks.

The plan and self-contained before/after mock now match the shipped behavior. In particular, preview momentum is suppressed under reduced motion so it never introduces automatic translation. Follow-up audit fixes prevent stale release momentum, prove live spring velocity, cover normal/reduced-motion public-strip behavior, make the shortcuts dialog a true temporary modal, and make mock/production visual exits semantically inert.

## Reproduction / verification

1. Run `bun run website` and `bun run scripts/site/editor.ts`.
2. Open `/editor`, zoom in, enable Pan, drag, and release. A pointerdown (including after disabling Pan) stops an active coast. Pinch or modifier-wheel zoom retargets without a jump.
3. Emulate `prefers-reduced-motion: reduce`; release after panning and verify the viewport does not coast.
4. Trigger Copy twice while the toast is focused or hovered; it remains visible until focus/hover leaves.
5. On `/comparisons/`, open a comparison dialog; Close, Escape, and backdrop remove native modality on the same event frame, restore focus to the opener, and leave only a noninteractive visual tail.
6. Open Settings, focus Font, press `?`, then Escape. The shortcut dialog temporarily inerts the editor and restores focus to Settings rather than an inert descendant.

## Visual evidence

Static screenshots cannot demonstrate timing, interruption, or reduced-motion behavior honestly. `research/apple-design-before-after-mock.html` is the reviewable, keyboard-operable interactive before/after artifact. Browser integration tests exercise the equivalent live-editor paths.

## Tests

- `bun test src/__tests__/` — 4,804 pass, 2 skipped, 0 fail.
- `bun run test:browser` — 59 pass, 0 fail.
- `bunx tsc --noEmit`
- `bun run website:check`
- `git diff --check`

The new regressions are behavior-discriminating. I mutation-checked the motion paths locally: removing reduced-motion momentum suppression, deferring cancellation until after pan eligibility, retaining stale release velocity, or zeroing a live spring velocity each made their focused tests fail. Removing public motion-strip initialization also made its browser contract fail.

## Scope & risk

No runtime dependency was added. Motion is cancellable by new input and rendering remains atomic. The browser motion tests intentionally wait for observable rAF/timer effects, so CI timing remains the principal residual risk; they passed in the full browser suite locally.
