### PR TITLE
Fix hosted MCP e2e error assertion

### DIFF
--- a/website/e2e-mcp.sh
+++ b/website/e2e-mcp.sh
@@ -65,7 +65,7 @@ check 'execute: expression form' '\"value\":42' \
 check 'execute: bare object literal stays an expression' '\"answer\":42' \
   "$(j '{"jsonrpc":"2.0","id":10,"method":"tools/call","params":{"name":"execute","arguments":{"code":"{ answer: 42 }"}}}')"
 
-check 'execute: user errors surface their message' '\"error\":\"boom\"' \
+check 'execute: user errors use the structured envelope' '\"error\":{\"code\":\"EXECUTE_FAILED\",\"message\":\"boom\"}' \
   "$(j '{"jsonrpc":"2.0","id":11,"method":"tools/call","params":{"name":"execute","arguments":{"code":"throw new Error(\"boom\")"}}}')"
 
 check 'execute: isolate has no fetch' '\"value\":\"undefined\"' \


### PR DESCRIPTION
## What changed

- Update the hosted MCP production E2E assertion for user-thrown errors.
- Match the current structured `EXECUTE_FAILED` `{ code, message }` envelope.

## Why

The E2E script still expected the legacy flat `"error":"boom"` payload, so it stopped even though the deployed endpoint was returning the contract implemented and covered by unit tests.

## Impact

The complete production MCP smoke suite can validate the current error response contract without a false failure.

## Validation

- `bash -n website/e2e-mcp.sh`
- `bash website/e2e-mcp.sh https://agentic-mermaid.dev/mcp` — 28 checks passed
- `git diff --check`