### PR TITLE
fix(editor): prevent dropdown startup flicker

### DIFF
--- a/editor/js/helpers.js
+++ b/editor/js/helpers.js
@@ -44,8 +44,9 @@ function setPopupVisibility(popup, trigger, open, opts) {
   if (!popup) return;
   opts = opts || {};
   var className = opts.className || 'open';
+  var wasOpen = popup.classList.contains(className);
   if (open) clearPopupClosing(popup);
-  else startPopupClosing(popup, opts);
+  else if (wasOpen) startPopupClosing(popup, opts);
   popup.classList.toggle(className, open);
   popup.setAttribute('aria-hidden', open ? 'false' : 'true');
   if (opts.inert !== false) popup.inert = !open;

--- a/src/__tests__/editor-popup.test.ts
+++ b/src/__tests__/editor-popup.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, test } from 'bun:test'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+const source = readFileSync(join(import.meta.dir, '..', '..', 'editor', 'js', 'helpers.js'), 'utf8')
+
+type Popup = {
+  _closingTimer?: ReturnType<typeof setTimeout> | null
+  classList: {
+    add(name: string): void
+    contains(name: string): boolean
+    remove(name: string): void
+    toggle(name: string, force: boolean): boolean
+  }
+  getAttribute(name: string): string | null
+  inert: boolean
+  querySelector(): null
+  querySelectorAll(): never[]
+  setAttribute(name: string, value: string): void
+}
+
+type PopupHelpers = {
+  clearPopupClosing(popup: Popup): void
+  setPopupVisibility(popup: Popup, trigger: null, open: boolean, opts: { visualClose: boolean }): void
+}
+
+function loadPopupHelpers(): PopupHelpers {
+  return new Function(`${source}; return { clearPopupClosing, setPopupVisibility };`)() as PopupHelpers
+}
+
+function popup(initialClasses: string[] = []): Popup {
+  const classes = new Set(initialClasses)
+  const attributes = new Map<string, string>()
+  return {
+    classList: {
+      add(name) { classes.add(name) },
+      contains(name) { return classes.has(name) },
+      remove(name) { classes.delete(name) },
+      toggle(name, force) {
+        if (force) classes.add(name)
+        else classes.delete(name)
+        return force
+      },
+    },
+    getAttribute(name) { return attributes.get(name) ?? null },
+    inert: false,
+    querySelector() { return null },
+    querySelectorAll() { return [] },
+    setAttribute(name, value) { attributes.set(name, value) },
+  }
+}
+
+describe('editor popup visibility', () => {
+  test('does not animate an idempotent close', () => {
+    const { setPopupVisibility } = loadPopupHelpers()
+    const menu = popup()
+
+    setPopupVisibility(menu, null, false, { visualClose: true })
+
+    expect(menu.classList.contains('open')).toBe(false)
+    expect(menu.classList.contains('closing')).toBe(false)
+    expect(menu.getAttribute('aria-hidden')).toBe('true')
+    expect(menu.inert).toBe(true)
+  })
+
+  test('keeps the visual tail for a real open to closed transition', () => {
+    const { clearPopupClosing, setPopupVisibility } = loadPopupHelpers()
+    const menu = popup(['open'])
+
+    setPopupVisibility(menu, null, false, { visualClose: true })
+
+    expect(menu.classList.contains('open')).toBe(false)
+    expect(menu.classList.contains('closing')).toBe(true)
+    expect(menu.getAttribute('aria-hidden')).toBe('true')
+    expect(menu.inert).toBe(true)
+    clearPopupClosing(menu)
+  })
+})


### PR DESCRIPTION
## What changed

- animate popup closing only when the popup was actually open
- add focused regression coverage for idempotent closes and genuine open-to-closed transitions

## Why

The Style and Palette menus are initialized with an explicit closed state. The shared popup helper treated those idempotent close calls as real closes and added `.closing`; that class temporarily forces `display: flex`, making both inert menus flash onscreen for 90 ms during startup.

## Impact

The editor now loads with both dropdowns visually closed, while intentional close animations remain unchanged for real open-to-closed transitions.

## Validation

- `bun test src/__tests__/website-build.test.ts src/__tests__/editor-popup.test.ts` — 38 passed
- `bun run typecheck`
- local browser verification at `/editor/?empty=1`: no startup `.closing` class; real Escape close still runs the visual tail