### PR TITLE
fix(ci): refresh dropdown fix evidence receipts

### DIFF
--- a/eval/mermaid-doc-showcase/gallery-receipt.json
+++ b/eval/mermaid-doc-showcase/gallery-receipt.json
@@ -1,8 +1,8 @@
 {
   "schemaVersion": 1,
   "generator": "scripts/pr-assets/mermaid-doc-showcase-gallery.ts",
-  "inputCount": 675,
-  "inputTreeSha256": "dacc51b7677f08d1e24c01a3bb172fd717960fd57b0f3bd73c1a18de1362998d",
+  "inputCount": 676,
+  "inputTreeSha256": "420544812667bb12e52cfda8653461708bf42e2c1174bc850657f56342fa2aa5",
   "output": "docs/design/families/mermaid-doc-examples-all-families.png",
   "outputSha256": "463141faed2ed844c5c33e6254610bf0e75d94a376a20cde778cbc2c919cbe89"
 }

--- a/eval/pie-highlightslice/evidence-receipt.json
+++ b/eval/pie-highlightslice/evidence-receipt.json
@@ -1,8 +1,8 @@
 {
   "schemaVersion": 1,
   "generator": "scripts/pr-assets/pie-highlightslice-evidence.ts",
-  "inputCount": 674,
-  "inputTreeSha256": "9d41e485aebf9c3c1b606735507e8466d80efb225cebf2a3e41d126413469b36",
+  "inputCount": 675,
+  "inputTreeSha256": "1a1aad4a48d1371eb36720dd63f065b7852d5be6f70cc21314ca732736cf859a",
   "outputs": [
     {
       "path": "docs/design/families/pie-highlightslice-regression-matrix.png",


### PR DESCRIPTION
## What changed

Refresh the Mermaid-doc showcase and pie highlightSlice evidence receipts after #173 added `src/__tests__/editor-popup.test.ts` to the pinned source input tree.

## Why

PR #173 merged before its long CI job completed. That job then reported two receipt input-count mismatches because the new test file increased each generated evidence input tree by one. The generated PNG bytes are unchanged; only `inputCount` and `inputTreeSha256` moved.

## Validation

- regenerated with `bun run gallery:mermaid-docs`
- regenerated with `bun run gallery:pie-highlight`
- reran the two exact receipt assertions plus both popup regression tests: 4 passed, 0 failed