### PR TITLE
Refresh GitHub Actions for Node 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,14 +20,15 @@ jobs:
         shard: [1/3, 2/3, 3/3]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v1
+        uses: oven-sh/setup-bun@v2
         with:
           # Keep CI on the known-good runtime used for local/release validation.
           # `latest` moved underneath this PR and made coverage runs flaky.
           bun-version: 1.3.13
+          no-cache: true
 
       - name: Install dependencies
         run: bun install --frozen-lockfile
@@ -57,7 +58,7 @@ jobs:
 
       - name: Upload shard coverage
         if: ${{ always() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: unit-coverage-${{ strategy.job-index }}
           path: coverage/lcov.info
@@ -70,7 +71,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           # Full history (not the default shallow depth-1). On a pull_request the
           # checkout is the merge ref: HEAD is a merge commit whose parents
@@ -80,9 +81,10 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v1
+        uses: oven-sh/setup-bun@v2
         with:
           bun-version: 1.3.13
+          no-cache: true
 
       - name: Install dependencies
         run: bun install --frozen-lockfile
@@ -117,12 +119,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v1
+        uses: oven-sh/setup-bun@v2
         with:
           bun-version: 1.3.13
+          no-cache: true
 
       - name: Install dependencies
         run: bun install --frozen-lockfile
@@ -141,18 +144,19 @@ jobs:
     if: ${{ always() }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         if: ${{ needs.unit.result == 'success' }}
 
       - name: Setup Bun for coverage merge
         if: ${{ needs.unit.result == 'success' }}
-        uses: oven-sh/setup-bun@v1
+        uses: oven-sh/setup-bun@v2
         with:
           bun-version: 1.3.13
+          no-cache: true
 
       - name: Download shard coverage
         if: ${{ needs.unit.result == 'success' }}
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: unit-coverage-*
           path: coverage-shards
@@ -163,7 +167,7 @@ jobs:
 
       - name: Upload merged coverage
         if: ${{ needs.unit.result == 'success' }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: coverage-lcov
           path: coverage/lcov.info
@@ -193,14 +197,15 @@ jobs:
         suite: [cli, dist-artifact, tarball-consumer, browser]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v1
+        uses: oven-sh/setup-bun@v2
         with:
           # Keep CI on the known-good runtime used for local/release validation.
           # `latest` moved underneath this PR and made coverage runs flaky.
           bun-version: 1.3.13
+          no-cache: true
 
       - name: Install dependencies
         run: bun install --frozen-lockfile
@@ -266,11 +271,12 @@ jobs:
     needs: test
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v1
+        uses: oven-sh/setup-bun@v2
         with:
           bun-version: 1.3.13
+          no-cache: true
       - name: Install dependencies
         run: bun install --frozen-lockfile
       - name: Incremental mutation lane (faithfulness counter)

--- a/.github/workflows/deploy-cloudflare.yml
+++ b/.github/workflows/deploy-cloudflare.yml
@@ -56,16 +56,17 @@ jobs:
           else
             echo "available=true" >> "$GITHUB_OUTPUT"
           fi
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         if: steps.cloudflare-secrets.outputs.available == 'true'
         with:
           # For a workflow_run trigger, build the exact commit CI validated.
           ref: ${{ github.event.workflow_run.head_sha || github.ref }}
       - name: Setup Bun
         if: steps.cloudflare-secrets.outputs.available == 'true'
-        uses: oven-sh/setup-bun@v1
+        uses: oven-sh/setup-bun@v2
         with:
           bun-version: 1.3.13
+          no-cache: true
       - name: Install dependencies
         if: steps.cloudflare-secrets.outputs.available == 'true'
         run: bun install --frozen-lockfile

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,23 +13,24 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           # Full history so the golden-drift gate can diff the release commit
           # (it degrades to HEAD-diff logic outside of `push` events).
           fetch-depth: 0
 
       - name: Setup Bun
-        # Pinned to a commit SHA (not the mutable `v1` tag): this workflow mints
+        # Pinned to a commit SHA (not the mutable `v2` tag): this workflow mints
         # the OIDC publish token, so a retagged/compromised action must not be
-        # able to ride along. SHA is oven-sh/setup-bun v1.
-        uses: oven-sh/setup-bun@f4d14e03ff726c06358e5557344e1da148b56cf7 # v1
+        # able to ride along. SHA is oven-sh/setup-bun v2.2.0.
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           # Pin to the runtime ci.yml validates on (see ci.yml note re: `latest`).
           bun-version: 1.3.13
+          no-cache: true
 
       - name: Setup Node.js (for npm publish)
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           # OIDC trusted publishing requires Node >= 22.14 and npm >= 11.5.1.
           # (Node 20 is also EOL as of 2026-04-30.)
@@ -102,7 +103,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Install MCP Registry publisher
         # This binary shares the job's OIDC permission, so pin both the release

--- a/.github/workflows/sync-mermaid-docs.yml
+++ b/.github/workflows/sync-mermaid-docs.yml
@@ -16,7 +16,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Read the reviewed upstream pin
         id: pin
         run: |
@@ -26,7 +26,7 @@ jobs:
           test "$commit" != "null"
           echo "commit=$commit" >> "$GITHUB_OUTPUT"
       - name: Checkout upstream Mermaid docs
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           repository: mermaid-js/mermaid
           ref: ${{ steps.pin.outputs.commit }}

--- a/eval/mermaid-doc-showcase/gallery-receipt.json
+++ b/eval/mermaid-doc-showcase/gallery-receipt.json
@@ -2,7 +2,7 @@
   "schemaVersion": 1,
   "generator": "scripts/pr-assets/mermaid-doc-showcase-gallery.ts",
   "inputCount": 691,
-  "inputTreeSha256": "01a93299c4654d2f9091d78123ee92375c6e42958974aa3392d85b7348a41b98",
+  "inputTreeSha256": "80e8471b55411e0764c4c47ff84fee049558e2c724495276741f87c4a2d5d8f1",
   "output": "docs/design/families/mermaid-doc-examples-all-families.png",
   "outputSha256": "85458b9b3d146d99ccf158acf623fb238c8efac314b489468429aee264bff05e"
 }

--- a/eval/mindmap-gitgraph-content-corpus/gallery-receipt.json
+++ b/eval/mindmap-gitgraph-content-corpus/gallery-receipt.json
@@ -228,7 +228,7 @@
     },
     {
       "path": "src/__tests__/agent-readiness-standards.test.ts",
-      "sha256": "5016cf20a233b1a0c0e5f7ae9639bfc19a31428fb42421e3d27e406a1a912508"
+      "sha256": "c698fd0bf97d5d5c8d67e63a5ec4b35cfb76764fdf14d05e434b42c17843e053"
     },
     {
       "path": "src/__tests__/agent-region-tree.test.ts",

--- a/eval/pie-highlightslice/evidence-receipt.json
+++ b/eval/pie-highlightslice/evidence-receipt.json
@@ -2,7 +2,7 @@
   "schemaVersion": 1,
   "generator": "scripts/pr-assets/pie-highlightslice-evidence.ts",
   "inputCount": 690,
-  "inputTreeSha256": "5f3f670b43ef1275286b2ff7c1c239c37486fceb2b53b81f3b29377be9f40ff4",
+  "inputTreeSha256": "96096f7b1a43600cf6e1b64c718253968cd3dd7c4b603c9ef9fd1912e9a30359",
   "outputs": [
     {
       "path": "docs/design/families/pie-highlightslice-regression-matrix.png",

--- a/eval/section-b-brand-evidence/evidence-receipt.json
+++ b/eval/section-b-brand-evidence/evidence-receipt.json
@@ -3,7 +3,7 @@
   "generator": "scripts/pr-assets/section-b-brand-evidence.ts",
   "inputs": {
     "count": 697,
-    "treeSha256": "d25e62ddbf321bcd561b9f38954c31e6ca66d23633d8081e86340b0d97af7a92"
+    "treeSha256": "01c08b05fe75df02b99de4933ce8650abef7b79f26166c34f4206e94bb0b70de"
   },
   "fontInputs": [
     {

--- a/src/__tests__/agent-readiness-standards.test.ts
+++ b/src/__tests__/agent-readiness-standards.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'bun:test'
 import { spawnSync } from 'node:child_process'
-import { readFileSync } from 'node:fs'
+import { readFileSync, readdirSync } from 'node:fs'
 import { join } from 'node:path'
 import { parse as parseYaml } from 'yaml'
 
@@ -65,7 +65,7 @@ describe('agent-readiness standards syntax', () => {
     expect(unitSteps.find((step: any) => step.name === 'Run test shard (coverage = under-tested finder, NOT an adequacy target)')?.run)
       .toBe('bun run test -- --shard=${{ matrix.shard }}')
     expect(unitSteps.find((step: any) => step.name === 'Upload shard coverage')?.uses)
-      .toBe('actions/upload-artifact@v4')
+      .toBe('actions/upload-artifact@v7')
     expect(ci.jobs.test.needs).toEqual(['unit', 'quality', 'route-sabotage'])
     expect(aggregateSteps.find((step: any) => step.name === 'Merge shard coverage')?.run)
       .toBe('bun run scripts/ci/merge-lcov.ts coverage-shards coverage/lcov.info 3')
@@ -83,6 +83,40 @@ describe('agent-readiness standards syntax', () => {
     expect(strategy).toContain('`bun run test`')
     expect(pullRequestTemplate).toContain('`bun run test`')
     expect(agentGuide).toContain('`bun run test`')
+  })
+
+  test('GitHub Actions use Node 24 runtimes and skip the flaky Bun executable cache', () => {
+    const workflowsDir = join(REPO, '.github', 'workflows')
+    const actionSteps = readdirSync(workflowsDir)
+      .filter((file) => file.endsWith('.yml') || file.endsWith('.yaml'))
+      .flatMap((file) => {
+        const workflow = parseYaml(readFileSync(join(workflowsDir, file), 'utf8'))
+        return Object.values(workflow.jobs ?? {}).flatMap((job: any) => job.steps ?? [])
+      })
+      .filter((step: any) => typeof step.uses === 'string')
+
+    const actionRefs = actionSteps.map((step: any) => step.uses)
+    const expectedRefs = new Map([
+      ['actions/checkout@', 'actions/checkout@v7'],
+      ['actions/upload-artifact@', 'actions/upload-artifact@v7'],
+      ['actions/download-artifact@', 'actions/download-artifact@v8'],
+      ['actions/setup-node@', 'actions/setup-node@v7'],
+    ])
+    for (const [prefix, expected] of expectedRefs) {
+      const matching = actionRefs.filter((ref: string) => ref.startsWith(prefix))
+      expect(matching.length).toBeGreaterThan(0)
+      expect([...new Set(matching)]).toEqual([expected])
+    }
+
+    const setupBunSteps = actionSteps.filter((step: any) => step.uses.startsWith('oven-sh/setup-bun@'))
+    expect(setupBunSteps.length).toBeGreaterThan(0)
+    for (const step of setupBunSteps) {
+      expect([
+        'oven-sh/setup-bun@v2',
+        'oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6',
+      ]).toContain(step.uses)
+      expect(step.with?.['no-cache']).toBe(true)
+    }
   })
 
   test('llms.txt follows the published parser-compatible Markdown shape', () => {


### PR DESCRIPTION
## Summary

- move GitHub-maintained actions to their Node 24-compatible majors: `checkout@v7`, `upload-artifact@v7`, `download-artifact@v8`, and `setup-node@v7`
- move Bun setup from v1/Node 20 to v2/Node 24, preserving the release workflow's immutable SHA pin at v2.2.0
- disable setup-bun's executable cache in every workflow to prevent the intermittent cache-service restore/save warnings
- add a repository-wide workflow contract test so deprecated action versions or an enabled Bun cache cannot silently return
- refresh the four evidence input-tree receipts affected by the new `src/` workflow contract test; all generated PNGs remain byte-identical

## Root cause

The existing action majors embed Node 20, which GitHub now runs under a forced Node 24 compatibility path and annotates as deprecated. Separately, `oven-sh/setup-bun` enables its executable cache by default, so GitHub cache-service 400s and transient save outages produced warnings despite successful jobs.

## Impact

CI, deploy, scheduled verification, and release workflows run their JavaScript actions directly on Node 24. Bun remains pinned to 1.3.13, but its small executable is downloaded per job instead of depending on the unreliable Actions cache service.

## Validation

- `bun test src/__tests__/agent-readiness-standards.test.ts` — 6 passed
- `bun test src/__tests__/pie-elevation.test.ts --test-name-pattern "pins the generated cross-product evidence"` — 1 passed
- gallery receipt suites — 24 passed across Mermaid docs, Mindmap/GitGraph, and Section B evidence
- all four gallery freshness checks
- `bun run typecheck`
- `git diff --check`
- [PR CI](https://github.com/adewale/agentic-mermaid/actions/runs/29485415663) — all jobs passed; no Node 20 or cache-service warning annotations
