### PR TITLE
Align hosted PNG smoke payload with MCP schema

### DIFF
--- a/eval/linkrank-feedback-packing/evidence-receipt.json
+++ b/eval/linkrank-feedback-packing/evidence-receipt.json
@@ -67,7 +67,7 @@
     }
   ],
   "inputCount": 726,
-  "inputTreeSha256": "4927b164e15c82b7a49f5b14d020d6809ec3c4b017189879771813ba0cbda523",
+  "inputTreeSha256": "870c13ec2bd7409eeac5439aee145ed1cd12e22d4ee07c14612486dc93923caa",
   "outputs": [
     {
       "path": "docs/pr-assets/issue-87-linkrank-feedback-packing-before-after.png",

--- a/eval/mermaid-doc-showcase/gallery-receipt.json
+++ b/eval/mermaid-doc-showcase/gallery-receipt.json
@@ -2,7 +2,7 @@
   "schemaVersion": 1,
   "generator": "scripts/pr-assets/mermaid-doc-showcase-gallery.ts",
   "inputCount": 714,
-  "inputTreeSha256": "0b7ce04457fbb91fdf40f885dbb3f434ef60021091bc4247b81bc0658fe58ea1",
+  "inputTreeSha256": "92d59a85e01b007f05387869fdda0d604db74f6d0cf73d99641b94a0acfefc12",
   "output": "docs/design/families/mermaid-doc-examples-all-families.png",
   "outputSha256": "2d209aecfa51fe8a0b3ddaef5ef554f2e5efc8d22690ed43294cd927a3205fa2"
 }

--- a/eval/mindmap-gitgraph-content-corpus/gallery-receipt.json
+++ b/eval/mindmap-gitgraph-content-corpus/gallery-receipt.json
@@ -1132,7 +1132,7 @@
     },
     {
       "path": "src/__tests__/png-output-options-contract.test.ts",
-      "sha256": "c7725be392cb652e9a4b88d6ba648d03585bde6b557230741185f2e40d973b07"
+      "sha256": "176d091908894801703718cef8775a93e242b53dc97ab332ebc717d05d0c4b41"
     },
     {
       "path": "src/__tests__/positioned-artifact-convergence.test.ts",

--- a/eval/palette-harmony/evidence-receipt.json
+++ b/eval/palette-harmony/evidence-receipt.json
@@ -2,7 +2,7 @@
   "schemaVersion": 1,
   "generator": "scripts/pr-assets/palette-harmony-experiment.ts",
   "inputCount": 714,
-  "inputTreeSha256": "390e9353f9a91a71fa5021b89641a887f17f44823f5e41f16442175368a470d7",
+  "inputTreeSha256": "90f7a462f630bf5a49b3e8a85a3acf485913d3e1d6ba540777c3d6ea613fec2a",
   "outputs": [
     {
       "path": "eval/palette-harmony/report.json",

--- a/eval/palette-rollout/evidence-receipt.json
+++ b/eval/palette-rollout/evidence-receipt.json
@@ -2,7 +2,7 @@
   "schemaVersion": 1,
   "generator": "scripts/pr-assets/palette-rollout-evidence.ts",
   "inputCount": 722,
-  "inputTreeSha256": "df7e300e13185ac675f952c315b0975aa9758ac415c16a8585febfcba869ae49",
+  "inputTreeSha256": "3bb0930521cbf380c4026cd69d59bbfe87e9740f080052c1f92ae6b152badf0f",
   "outputs": [
     {
       "path": "eval/palette-rollout/report.json",

--- a/eval/pie-highlightslice/evidence-receipt.json
+++ b/eval/pie-highlightslice/evidence-receipt.json
@@ -2,7 +2,7 @@
   "schemaVersion": 1,
   "generator": "scripts/pr-assets/pie-highlightslice-evidence.ts",
   "inputCount": 713,
-  "inputTreeSha256": "49bae1f5e2ac3a41724919d201051e5c73cb280afc44384e1b76a98066684ebd",
+  "inputTreeSha256": "eef46566973904267556c0b0edf0b8f0d127a5a461155e5cf88bf01cc6523854",
   "outputs": [
     {
       "path": "docs/design/families/pie-highlightslice-regression-matrix.png",

--- a/eval/section-b-brand-evidence/evidence-receipt.json
+++ b/eval/section-b-brand-evidence/evidence-receipt.json
@@ -3,7 +3,7 @@
   "generator": "scripts/pr-assets/section-b-brand-evidence.ts",
   "inputs": {
     "count": 720,
-    "treeSha256": "3f7897b9366d4087f63aae56bdd71fdb051e5ae95db1057e41a45f21d3eb28e4"
+    "treeSha256": "2c3fa3c3a3ae5cd4033c25088adb6de58aaa1008480998d0a2d279792bafe2c2"
   },
   "fontInputs": [
     {

--- a/src/__tests__/png-output-options-contract.test.ts
+++ b/src/__tests__/png-output-options-contract.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, test } from 'bun:test'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
 
 import { renderMermaidPNGWithReceipt } from '../agent/png.ts'
 import {
@@ -151,6 +153,30 @@ describe('canonical PNG output-option authority', () => {
       loadSystemFonts: ['system-fonts'],
       onWarning: [],
     })
+  })
+
+  test('the live hosted MCP smoke payload conforms to the canonical render_png tool schema', () => {
+    const script = readFileSync(join(import.meta.dir, '..', '..', 'website', 'e2e-mcp.sh'), 'utf8')
+    const payload = script.match(/png_response="\$\(j '(\{[^\n]+\})'\)"/)?.[1]
+    expect(payload).toBeDefined()
+    const request = JSON.parse(payload!) as {
+      jsonrpc: string
+      method: string
+      params: { name: string; arguments: Record<string, unknown> }
+    }
+    expect(request).toMatchObject({
+      jsonrpc: '2.0',
+      method: 'tools/call',
+      params: { name: 'render_png' },
+    })
+    const args = request.params.arguments
+    expect(args.options).toMatchObject({
+      padding: 19,
+      security: 'strict',
+      style: ['watercolor', 'paper'],
+      seed: 13,
+    })
+    expect(validateMcpToolArguments(createRenderPngTool('hosted'), args)).toEqual([])
   })
 
   test('MCP admission enforces the canonical fit and native-font shapes', () => {

--- a/website/e2e-mcp.sh
+++ b/website/e2e-mcp.sh
@@ -53,7 +53,7 @@ check 'build authors with structured ops' 'class Duck' \
 check 'mutate edits with structured ops' 'class Dog' \
   "$(j '{"jsonrpc":"2.0","id":"mutate","method":"tools/call","params":{"name":"mutate","arguments":{"source":"classDiagram\n  class Animal","ops":[{"kind":"add_class","id":"Dog"}]}}}')"
 
-png_response="$(j '{"jsonrpc":"2.0","id":7,"method":"tools/call","params":{"name":"render_png","arguments":{"source":"flowchart LR\n  A[Start 漢] --> B[Finish]","scale":0.75,"background":"#123456","fitTo":{"width":96},"style":["watercolor","paper"],"seed":13,"options":{"padding":19,"security":"strict"}}}}')"
+png_response="$(j '{"jsonrpc":"2.0","id":7,"method":"tools/call","params":{"name":"render_png","arguments":{"source":"flowchart LR\n  A[Start 漢] --> B[Finish]","scale":0.75,"background":"#123456","fitTo":{"width":96},"options":{"padding":19,"security":"strict","style":["watercolor","paper"],"seed":13}}}}')"
 check 'render_png returns base64 PNG (wasm)' '\"png_base64\":\"iVBOR' "$png_response"
 printf '%s' "$png_response" | bun run scripts/verify-hosted-png-e2e.ts
 pass=$((pass + 1))


### PR DESCRIPTION
## What

Align the committed hosted `render_png` live-smoke request with the canonical MCP tool schema, and add a regression test that validates the exact shell payload against that authority.

## Why

The post-deploy full-surface probe failed even though the deployed Worker was healthy:

```text
Invalid arguments for render_png: arguments.style is not allowed; arguments.seed is not allowed
```

`scale`, `background`, and `fitTo` are dedicated PNG output options and remain top-level. `style` and `seed` are shared `RenderOptions`; the MCP boundary admits those only through the nested `options` object. `website/e2e-mcp.sh` mixed the old top-level shape with the current nested contract, causing a false deployment failure at the PNG step.

## How

```diff
 "fitTo":{"width":96},
-"style":["watercolor","paper"],
-"seed":13,
-"options":{"padding":19,"security":"strict"}
+"options":{
+  "padding":19,
+  "security":"strict",
+  "style":["watercolor","paper"],
+  "seed":13
+}
```

The new test extracts the real JSON-RPC payload from `website/e2e-mcp.sh`, proves it is a `tools/call` for `render_png`, verifies the expected nested options, and validates its arguments with `validateMcpToolArguments(createRenderPngTool('hosted'), args)`. This makes the canonical hosted tool definition—not duplicated expectations—the admission authority.

Seven evidence receipts were refreshed because their existing provenance contract hashes all `src/**/*.ts`; generated visual bytes did not change.

## Reproduction

Before this fix:

```bash
bash website/e2e-mcp.sh https://agentic-mermaid.dev/mcp
```

The first eight probes passed, then `render_png` returned `-32602` for top-level `style` and `seed` and aborted the script.

After this fix, the same unmodified command reaches the real deployed endpoint and reports:

```text
ok   render_png returns base64 PNG (wasm)
ok   render_png enforces portable WASM parity (96x29, sRGB, receipt, runtime, font warning)
...
e2e-mcp: 29 checks passed
```

## Testing

- [x] Red→green: the new focused test failed against the old payload; after the payload fix, **13/13** PNG contract tests pass.
- [x] `bun run test` — **6,748 passed, 39 skipped, 0 failed**, 360,229 expectations.
- [x] `bash website/e2e-mcp.sh https://agentic-mermaid.dev/mcp` — **29/29 live checks passed**.
- [x] `bunx tsc --noEmit`
- [x] `bash -n website/e2e-mcp.sh`
- [x] `bun run website:check` — 13 generated Worker inputs synchronized.
- [x] All seven affected evidence/gallery freshness checks passed.
- [x] `bun run audit:dependencies` — no high/critical advisories.
- [x] `bash scripts/ci/check-pr-readiness.sh origin/main` — clean, exit 0.
- [x] `git diff --check`

## Multi-agent audit

Four independent read-only reviewers covered canonical MCP schema alignment, shell/test discrimination, repository/evidence consistency, and adversarial whole-diff behavior. One found a real P2: the first test version validated the extracted arguments but did not prove the envelope still targeted `tools/call` → `render_png`. The test now asserts both fields before schema validation.

Two independent final reviewers rechecked the repaired test and complete diff; both returned **ACCEPT** with no remaining P0/P1/significant P2 findings.

## Visual evidence

No screenshot is applicable: this changes a shell probe request, not rendered PNG bytes or UI. The meaningful evidence is the same live endpoint moving from a schema error to a verified `96×29` sRGB PNG while retaining all 29 full-surface assertions.

## Risk

Low and bounded:

- No production runtime, public API, dependency, or rendered output changes.
- The smoke request now follows the already-shipped canonical schema.
- The contract test is intentionally coupled to the actual shell payload and fails if its JSON-RPC method, tool name, or arguments drift.
- No redeploy is required; production already implements and passed the correct schema.
