### PR TITLE
Fix Windows installed-resource verification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This changelog tracks user-facing changes for **Agentic Mermaid**, a fork of `lu
 ### Fixed
 - Updated the transitive `brace-expansion` development dependency to 5.0.7 so the high-severity dependency audit remains enforced without blocking CI on GHSA-3jxr-9vmj-r5cp. The override stays within `minimatch`'s declared compatible range and is exercised by the retained Stryker mutation lane.
 - Completed the 0.1.2 version projection across package, hosted MCP registry, generated agent guidance, and compatibility tests; host-version assertions now derive from the package authority instead of embedding the previous release.
+- Made installed-resource verification portable to Windows by applying `/proc/self/fd` and `/dev/fd` canonicalization only on Linux and macOS; other platforms retain the rooted post-open file-identity proof instead of probing a nonexistent `/dev/fd` path.
 
 ### Changed
 - Simplified the published package to compiled ESM entries and removed the internal `./capabilities` and `./resources` subpaths. The supported library entries are `agentic-mermaid`, `agentic-mermaid/agent`, and the browser/workerd-safe `agentic-mermaid/agent/core`.

--- a/docs/contributing/lessons-learned.md
+++ b/docs/contributing/lessons-learned.md
@@ -18,6 +18,8 @@ date; do not delete old ones — supersede them in place.
 
 **A version bump is a projection update, not a scalar edit.** The canonical package and primary registry metadata advanced together, but the hosted registry copy, generated agent guidance, and compatibility-message assertions still carried the previous version. Rule: keep one version authority wherever runtime behavior permits, derive assertions from it, regenerate declared projections, and let a distribution-version contract enumerate the few copies that must remain materialized.
 
+**A release-only platform gate is still part of the product test topology.** Making Worker outputs ephemeral caused the Windows release smoke to build the website during test preload, exposing a resolver branch that treated every non-Linux host as macOS and probed `/dev/fd`. Rule: enumerate platform capabilities explicitly, keep the portable security proof authoritative when an optional OS proof is unavailable, and exercise release-platform setup before a release event can become the first caller.
+
 ## 2026-07 — complexity-aware test portfolio (#193)
 
 **Optimize declared obligations, not test count.** The old 4,500-render matrix was exhaustive only for family × Look × Palette while fixing source complexity, output, transport, security, seed, and background. The replacement exhausts cheap Style algebra, covers expensive factors with independently verified variable strength, retains exact goldens and fault probes, and publishes the missing-tuple count. Rule: state what a row proves before optimizing it; fewer rows are useful only when the declared interaction and oracle strength improve.

--- a/eval/mindmap-gitgraph-content-corpus/gallery-receipt.json
+++ b/eval/mindmap-gitgraph-content-corpus/gallery-receipt.json
@@ -680,7 +680,7 @@
     },
     {
       "path": "src/node-resource-resolver.ts",
-      "sha256": "6e5241b1e79fb297c9e865b9b6da7c2634e61f717729b36d221b32df715ac24d"
+      "sha256": "916badf287d77c5bf6e848f25c9da0e1f7830ce0942735e9529868f1e936d79a"
     },
     {
       "path": "src/output-color-profile.ts",

--- a/eval/pie-highlightslice/evidence-receipt.json
+++ b/eval/pie-highlightslice/evidence-receipt.json
@@ -2,7 +2,7 @@
   "schemaVersion": 1,
   "generator": "scripts/pr-assets/pie-highlightslice-evidence.ts",
   "inputCount": 259,
-  "inputTreeSha256": "3d89d07448c5a1815657e61f91e4ab2edbd02a313059cf2c789879a51ec59fd8",
+  "inputTreeSha256": "cf3a196d656e822ae00bde832eecbd8d01156a2c501d3310b47652dc6ea5b766",
   "outputs": [
     {
       "path": "docs/design/families/pie-highlightslice-regression-matrix.png",

--- a/eval/section-b-brand-evidence/evidence-receipt.json
+++ b/eval/section-b-brand-evidence/evidence-receipt.json
@@ -3,7 +3,7 @@
   "generator": "scripts/pr-assets/section-b-brand-evidence.ts",
   "inputs": {
     "count": 266,
-    "treeSha256": "96327135ed88800dd8f5d971382660e84fea8909cacc98b444bc685866864574"
+    "treeSha256": "8fc230b0aabd25c7214953936960ed5b857c87f9e6afb98250bb855c71867bce"
   },
   "fontInputs": [
     {

--- a/src/__tests__/resource-manifest-integrity.test.ts
+++ b/src/__tests__/resource-manifest-integrity.test.ts
@@ -16,6 +16,7 @@ import { HOSTED_FONT_RESOURCES, RESOURCE_MANIFEST, validateResourceManifest } fr
 import {
   NodeResourceResolver,
   ResourceResolutionError,
+  openedResourceDescriptorPath,
 } from '../node-resource-resolver.ts'
 import { createExtensionIdentity } from '../shared/extension-identity.ts'
 import { snapshotResourceManifest, verifyResourceBytes, type ResourceManifest, type ResourceManifestEntry } from '../resource-manifest.ts'
@@ -81,6 +82,13 @@ function expectCode(run: () => unknown, code: ResourceResolutionError['code']): 
 }
 
 describe('content-addressed installed resource manifest', () => {
+  test('uses descriptor canonicalization only on platforms that expose a descriptor path', () => {
+    expect(openedResourceDescriptorPath('linux', 7)).toBe('/proc/self/fd/7')
+    expect(openedResourceDescriptorPath('darwin', 7)).toBe('/dev/fd/7')
+    expect(openedResourceDescriptorPath('win32', 7)).toBeUndefined()
+    expect(openedResourceDescriptorPath('freebsd', 7)).toBeUndefined()
+  })
+
   test('the shipped font manifest is structurally valid and every declared byte verifies', () => {
     expect(validateResourceManifest()).toEqual([])
     const root = join(import.meta.dir, '..', '..')

--- a/src/node-resource-resolver.ts
+++ b/src/node-resource-resolver.ts
@@ -74,6 +74,13 @@ function sha256(bytes: Uint8Array): string {
   return createHash('sha256').update(bytes).digest('hex')
 }
 
+/** @internal Exported only so the cross-platform security fallback is testable. */
+export function openedResourceDescriptorPath(platform: NodeJS.Platform, fd: number): string | undefined {
+  if (platform === 'linux') return `/proc/self/fd/${fd}`
+  if (platform === 'darwin') return `/dev/fd/${fd}`
+  return undefined
+}
+
 /**
  * Read-only installed-resource resolver. It has no URL or callback fallback:
  * every returned byte came from the declared package root and passed the
@@ -165,12 +172,17 @@ export class NodeResourceResolver {
       // not: realpathSync('/dev/fd/N') returns the descriptor path unchanged.
       // Treat descriptor canonicalization as an additional proof when the
       // runtime supplies it, never as the only portable proof of rootedness.
-      const descriptorPath = process.platform === 'linux' ? `/proc/self/fd/${fd}` : `/dev/fd/${fd}`
-      const openedPath = realpathSync(descriptorPath)
-      if (openedPath !== descriptorPath && !openedPath.startsWith(`${descriptorPath}${sep}`)) {
-        const escaped = relative(this.#root, openedPath)
-        if (escaped === '..' || escaped.startsWith(`..${sep}`) || isAbsolute(escaped)) {
-          throw new ResourceResolutionError('RESOURCE_PATH_ESCAPE', entry.identity.id, `opened file escapes package root: ${declaredPath}`)
+      // Windows and other platforms do not expose either descriptor path. They
+      // skip this additional proof and use the portable rooted identity re-walk
+      // below; attempting /dev/fd there fails before any resource can verify.
+      const descriptorPath = openedResourceDescriptorPath(process.platform, fd)
+      if (descriptorPath) {
+        const openedPath = realpathSync(descriptorPath)
+        if (openedPath !== descriptorPath && !openedPath.startsWith(`${descriptorPath}${sep}`)) {
+          const escaped = relative(this.#root, openedPath)
+          if (escaped === '..' || escaped.startsWith(`..${sep}`) || isAbsolute(escaped)) {
+            throw new ResourceResolutionError('RESOURCE_PATH_ESCAPE', entry.identity.id, `opened file escapes package root: ${declaredPath}`)
+          }
         }
       }
 


### PR DESCRIPTION
## What

Make installed-resource verification portable to Windows so the v0.1.2 release platform smoke can build the website and run registry-derived rendering contracts.

## Why

The [v0.1.2 publish run](https://github.com/adewale/agentic-mermaid/actions/runs/29815159686) passed on macOS but failed on Windows before publishing npm or MCP artifacts. `NodeResourceResolver.#openSecureFile()` selected `/proc/self/fd/<n>` on Linux and `/dev/fd/<n>` on every other platform. Windows has neither path, so `realpathSync('D:\\dev\\fd\\<n>')` raised `ENOENT` during the test preload's clean website build.

## How

- Map descriptor canonicalization explicitly to Linux (`/proc/self/fd`) and macOS (`/dev/fd`).
- Skip that optional proof on Windows and other platforms while retaining the portable rooted post-open `fstat`/`lstat` file-identity comparison and descriptor-only read.
- Add a pure platform-mapping regression so another catch-all OS branch cannot silently restore the failure.
- Record the release lesson and add the fix to the 0.1.2 changelog.

## Testing

- `bun test src/__tests__/resource-manifest-integrity.test.ts --timeout 120000` — 12/12
- `bun test src/__tests__/render-conformance-plan.test.ts --timeout 120000` — 9/9, 9,854 assertions
- `bun run website:check`
- `bun run typecheck`
- Regenerated and checked the Mindmap/GitGraph, pie-highlight, and Section B evidence receipts affected by the shared resolver input. All output images remained byte-identical; only provenance hashes changed.
- Regression ablation: temporarily restored the previous `platform === 'linux' ? /proc : /dev` selection; the new test failed on the Windows expectation with `Received: "/dev/fd/7"`. Restoring this commit makes it pass.

## Visual evidence

Screenshots are not applicable: this changes only the host filesystem verification path used before reading packaged resources. Renderer output and website markup/CSS are unchanged; the registry-derived cross-format render contract is the relevant behavior check.

## Risk

The sensitive boundary is path-race protection. Linux and macOS retain descriptor-path canonicalization. All platforms still reject symlink components, open the final file without following symlinks where the runtime supports it, require a regular file, re-walk the rooted path, compare the opened and rooted file identities, and read only from the verified descriptor. The change removes only an unavailable extra proof on platforms without a descriptor filesystem.

After this PR passes Windows and canonical CI, the failed v0.1.2 release/tag can be replaced on the corrected merge commit; no immutable npm version was published by the failed run.
