### PR TITLE
Harden website build and cache authorities

### DIFF
--- a/scripts/site/website-build-fingerprint.ts
+++ b/scripts/site/website-build-fingerprint.ts
@@ -129,13 +129,9 @@ function gitProvenance(root: string): string[] {
 }
 
 function addPathToHash(hash: Hash, root: string, rel: string): void {
+  if (EXCLUDED_PATHS.some(excluded => rel === excluded || rel.startsWith(`${excluded}/`))) return
   hash.update(rel)
   hash.update('\0')
-  if (EXCLUDED_PATHS.some(excluded => rel === excluded || rel.startsWith(`${excluded}/`))) {
-    hash.update('excluded')
-    hash.update('\0')
-    return
-  }
   const abs = join(root, rel)
   if (!existsSync(abs)) {
     hash.update('missing')

--- a/scripts/site/website-build-fingerprint.ts
+++ b/scripts/site/website-build-fingerprint.ts
@@ -48,6 +48,14 @@ export interface WebsiteBuildFingerprintOptions {
   environment?: Readonly<Record<string, string | undefined>>
 }
 
+export interface WebsiteBuildLockOptions {
+  fingerprint(): string
+  readSentinel(): string | null
+  tryAcquire(): boolean
+  sleep(): void
+  maxAttempts?: number
+}
+
 export interface StableFingerprintBuildOptions {
   fingerprint(): string
   build(): void
@@ -78,6 +86,19 @@ export function computeWebsiteBuildFingerprint(root: string, options: WebsiteBui
   }
   for (const rel of options.paths ?? WEBSITE_BUILD_FINGERPRINT_PATHS) addPathToHash(hash, root, rel)
   return hash.digest('hex')
+}
+
+/** Waits for the build lock while comparing any completed sentinel with a
+ * freshly computed fingerprint on every pass; no pre-wait snapshot is reused. */
+export function acquireWebsiteBuildLock(options: WebsiteBuildLockOptions): boolean {
+  const maxAttempts = options.maxAttempts ?? 600
+  for (let attempt = 0; attempt < maxAttempts; attempt++) {
+    const current = options.fingerprint()
+    if (options.readSentinel() === current) return false
+    if (options.tryAcquire()) return true
+    options.sleep()
+  }
+  throw new Error('Timed out waiting for website/public build preload lock')
 }
 
 /** Runs a synchronous generator only across a stable input snapshot. An input

--- a/scripts/site/website-build-fingerprint.ts
+++ b/scripts/site/website-build-fingerprint.ts
@@ -20,9 +20,18 @@ export const WEBSITE_BUILD_FINGERPRINT_PATHS = Object.freeze([
   'shared',
   'src',
   'eval/agent-usage/homepage-prompt.ts',
+  'eval/mindmap-gitgraph-content-corpus',
   'assets/fonts',
   'package.json',
   'bun.lock',
+] as const)
+
+export const WEBSITE_BUILD_ENVIRONMENT_KEYS = Object.freeze([
+  'SITE_ORIGIN',
+  'SITE_GIT_SHA',
+  'SITE_BUILD_TIME',
+  'SITE_NPM_STATUS',
+  'SITE_NPM_PUBLISHED',
 ] as const)
 
 const EXCLUDED_PATHS = Object.freeze([
@@ -36,6 +45,15 @@ export interface WebsiteBuildFingerprintOptions {
   paths?: readonly string[]
   /** Tests may inject stable provenance instead of consulting a Git checkout. */
   provenance?: readonly string[]
+  environment?: Readonly<Record<string, string | undefined>>
+}
+
+export interface StableFingerprintBuildOptions {
+  fingerprint(): string
+  build(): void
+  reset(): void
+  commit(fingerprint: string): void
+  maxAttempts?: number
 }
 
 export function isWebsiteBuildFingerprintInput(path: string): boolean {
@@ -51,8 +69,35 @@ export function computeWebsiteBuildFingerprint(root: string, options: WebsiteBui
     hash.update(value)
     hash.update('\0')
   }
+  const environment = options.environment ?? process.env
+  for (const key of WEBSITE_BUILD_ENVIRONMENT_KEYS) {
+    hash.update(key)
+    hash.update('=')
+    hash.update(environment[key] ?? '<unset>')
+    hash.update('\0')
+  }
   for (const rel of options.paths ?? WEBSITE_BUILD_FINGERPRINT_PATHS) addPathToHash(hash, root, rel)
   return hash.digest('hex')
+}
+
+/** Runs a synchronous generator only across a stable input snapshot. An input
+ * mutation during generation discards the mixed output and retries boundedly. */
+export function runStableFingerprintBuild(options: StableFingerprintBuildOptions): void {
+  const maxAttempts = options.maxAttempts ?? 3
+  for (let attempt = 0; attempt < maxAttempts; attempt++) {
+    const before = options.fingerprint()
+    try { options.build() } catch (error) {
+      options.reset()
+      throw error
+    }
+    const after = options.fingerprint()
+    if (before === after) {
+      options.commit(after)
+      return
+    }
+    options.reset()
+  }
+  throw new Error(`Website inputs changed during ${maxAttempts} consecutive build attempts`)
 }
 
 function gitProvenance(root: string): string[] {

--- a/scripts/site/website-build-fingerprint.ts
+++ b/scripts/site/website-build-fingerprint.ts
@@ -1,0 +1,90 @@
+import { createHash, type Hash } from 'node:crypto'
+import { execFileSync } from 'node:child_process'
+import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs'
+import { join } from 'node:path'
+
+/** Conservative source authority for the generated website. Directory entries
+ * deliberately trade occasional extra rebuilds for never reusing stale output.
+ * Generated website outputs and test-only sources are excluded below. */
+export const WEBSITE_BUILD_FINGERPRINT_PATHS = Object.freeze([
+  'website',
+  'public',
+  'docs/schemas/style-spec.schema.json',
+  'docs/assets/style-cookbook',
+  'examples/styles',
+  'skills/agentic-mermaid-diagram-workflow',
+  'Instructions_for_agents.md',
+  'editor',
+  'scripts/site',
+  'scripts/docs',
+  'shared',
+  'src',
+  'eval/agent-usage/homepage-prompt.ts',
+  'assets/fonts',
+  'package.json',
+  'bun.lock',
+] as const)
+
+const EXCLUDED_PATHS = Object.freeze([
+  'website/.wrangler',
+  'website/public',
+  'website/src/generated',
+  'src/__tests__',
+] as const)
+
+export interface WebsiteBuildFingerprintOptions {
+  paths?: readonly string[]
+  /** Tests may inject stable provenance instead of consulting a Git checkout. */
+  provenance?: readonly string[]
+}
+
+export function isWebsiteBuildFingerprintInput(path: string): boolean {
+  const normalized = path.replaceAll('\\', '/').replace(/^\.\//, '').replace(/\/$/, '')
+  if (EXCLUDED_PATHS.some(excluded => normalized === excluded || normalized.startsWith(`${excluded}/`))) return false
+  return WEBSITE_BUILD_FINGERPRINT_PATHS.some(input => normalized === input || normalized.startsWith(`${input}/`))
+}
+
+export function computeWebsiteBuildFingerprint(root: string, options: WebsiteBuildFingerprintOptions = {}): string {
+  const hash = createHash('sha256')
+  const provenance = options.provenance ?? gitProvenance(root)
+  for (const value of provenance) {
+    hash.update(value)
+    hash.update('\0')
+  }
+  for (const rel of options.paths ?? WEBSITE_BUILD_FINGERPRINT_PATHS) addPathToHash(hash, root, rel)
+  return hash.digest('hex')
+}
+
+function gitProvenance(root: string): string[] {
+  return [['rev-parse', 'HEAD'], ['status', '--porcelain=v1', '--untracked-files=normal']].map(args => {
+    try { return execFileSync('git', args, { cwd: root, encoding: 'utf8' }) }
+    catch { return 'git-unavailable' }
+  })
+}
+
+function addPathToHash(hash: Hash, root: string, rel: string): void {
+  hash.update(rel)
+  hash.update('\0')
+  if (EXCLUDED_PATHS.some(excluded => rel === excluded || rel.startsWith(`${excluded}/`))) {
+    hash.update('excluded')
+    hash.update('\0')
+    return
+  }
+  const abs = join(root, rel)
+  if (!existsSync(abs)) {
+    hash.update('missing')
+    hash.update('\0')
+    return
+  }
+  const stat = statSync(abs)
+  if (stat.isDirectory()) {
+    hash.update('dir')
+    hash.update('\0')
+    for (const name of readdirSync(abs).sort()) addPathToHash(hash, root, `${rel}/${name}`)
+    return
+  }
+  hash.update('file')
+  hash.update('\0')
+  hash.update(readFileSync(abs))
+  hash.update('\0')
+}

--- a/src/__tests__/website-build-fingerprint.test.ts
+++ b/src/__tests__/website-build-fingerprint.test.ts
@@ -3,9 +3,11 @@ import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'nod
 import { tmpdir } from 'node:os'
 import { dirname, join, normalize, relative, resolve } from 'node:path'
 import {
+  WEBSITE_BUILD_ENVIRONMENT_KEYS,
   WEBSITE_BUILD_FINGERPRINT_PATHS,
   computeWebsiteBuildFingerprint,
   isWebsiteBuildFingerprintInput,
+  runStableFingerprintBuild,
 } from '../../scripts/site/website-build-fingerprint.ts'
 
 const REPO = join(import.meta.dir, '..', '..')
@@ -30,6 +32,7 @@ describe('website build fingerprint authority', () => {
       'editor/css/panels.css',
       'website/wrangler.jsonc',
       'assets/fonts/Inter-Regular.ttf',
+      'eval/mindmap-gitgraph-content-corpus/mindmap/wide-incident-response.mmd',
     ]) expect(isWebsiteBuildFingerprintInput(path), path).toBe(true)
 
     expect(isWebsiteBuildFingerprintInput('website/public/index.html')).toBe(false)
@@ -54,6 +57,33 @@ describe('website build fingerprint authority', () => {
     writeFileSync(join(root, 'inputs', 'second.txt'), 'two')
     expect(computeWebsiteBuildFingerprint(root, options)).not.toBe(initial)
     expect(computeWebsiteBuildFingerprint(root, { ...options, provenance: ['other'] })).not.toBe(initial)
+
+    for (const key of WEBSITE_BUILD_ENVIRONMENT_KEYS) {
+      expect(computeWebsiteBuildFingerprint(root, { ...options, environment: { [key]: 'changed' } }), key).not.toBe(initial)
+    }
+  })
+
+  test('retries a mixed build and commits only a stable fingerprint', () => {
+    const fingerprints = ['A', 'B', 'B', 'B']
+    let builds = 0
+    let resets = 0
+    const committed: string[] = []
+    runStableFingerprintBuild({
+      fingerprint: () => fingerprints.shift()!,
+      build: () => { builds++ },
+      reset: () => { resets++ },
+      commit: value => { committed.push(value) },
+    })
+    expect({ builds, resets, committed }).toEqual({ builds: 2, resets: 1, committed: ['B'] })
+
+    let failures = 0
+    expect(() => runStableFingerprintBuild({
+      fingerprint: () => 'stable',
+      build: () => { throw new Error('build failed') },
+      reset: () => { failures++ },
+      commit: () => { throw new Error('must not commit') },
+    })).toThrow('build failed')
+    expect(failures).toBe(1)
   })
 
   test('keeps the authority conservative without fingerprinting generated output', () => {
@@ -62,6 +92,7 @@ describe('website build fingerprint authority', () => {
     expect(WEBSITE_BUILD_FINGERPRINT_PATHS).toContain('scripts/site')
     expect(WEBSITE_BUILD_FINGERPRINT_PATHS).toContain('scripts/docs')
     expect(WEBSITE_BUILD_FINGERPRINT_PATHS).toContain('shared')
+    expect(WEBSITE_BUILD_FINGERPRINT_PATHS).toContain('eval/mindmap-gitgraph-content-corpus')
 
     const root = mkdtempSync(join(tmpdir(), 'am-website-fingerprint-'))
     temporary.push(root)
@@ -77,5 +108,13 @@ describe('website build fingerprint authority', () => {
     }
     writeFileSync(join(root, 'website/source/input.txt'), 'changed source')
     expect(computeWebsiteBuildFingerprint(root, options)).not.toBe(initial)
+
+    const corpus = join(root, 'eval/mindmap-gitgraph-content-corpus/mindmap/wide-incident-response.mmd')
+    mkdirSync(dirname(corpus), { recursive: true })
+    writeFileSync(corpus, 'mindmap\n  root')
+    const corpusOptions = { provenance: ['fixed'], environment: {} }
+    const corpusFingerprint = computeWebsiteBuildFingerprint(root, corpusOptions)
+    writeFileSync(corpus, 'mindmap\n  changed')
+    expect(computeWebsiteBuildFingerprint(root, corpusOptions)).not.toBe(corpusFingerprint)
   })
 })

--- a/src/__tests__/website-build-fingerprint.test.ts
+++ b/src/__tests__/website-build-fingerprint.test.ts
@@ -1,0 +1,81 @@
+import { afterEach, describe, expect, test } from 'bun:test'
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { dirname, join, normalize, relative, resolve } from 'node:path'
+import {
+  WEBSITE_BUILD_FINGERPRINT_PATHS,
+  computeWebsiteBuildFingerprint,
+  isWebsiteBuildFingerprintInput,
+} from '../../scripts/site/website-build-fingerprint.ts'
+
+const REPO = join(import.meta.dir, '..', '..')
+const temporary: string[] = []
+afterEach(() => { for (const path of temporary.splice(0)) rmSync(path, { recursive: true, force: true }) })
+
+describe('website build fingerprint authority', () => {
+  test('enrolls every direct local module and runtime-read boundary', () => {
+    const build = readFileSync(join(REPO, 'website', 'build.ts'), 'utf8')
+    const imports = Array.from(build.matchAll(/(?:from\s+|import\s*\()\s*['"](\.{1,2}\/[^'"]+)['"]/g), match => match[1]!)
+    expect(imports.length).toBeGreaterThan(10)
+    for (const specifier of imports) {
+      const repoRelative = normalize(relative(REPO, resolve(REPO, 'website', specifier))).replaceAll('\\', '/')
+      expect(isWebsiteBuildFingerprintInput(repoRelative), specifier).toBe(true)
+    }
+
+    for (const path of [
+      'scripts/site/editor.ts',
+      'scripts/site/example-render-state.ts',
+      'shared/browser/copy-feedback.js',
+      'editor/html/topbar.html',
+      'editor/css/panels.css',
+      'website/wrangler.jsonc',
+      'assets/fonts/Inter-Regular.ttf',
+    ]) expect(isWebsiteBuildFingerprintInput(path), path).toBe(true)
+
+    expect(isWebsiteBuildFingerprintInput('website/public/index.html')).toBe(false)
+    expect(isWebsiteBuildFingerprintInput('website/.wrangler/state/v3.json')).toBe(false)
+    expect(isWebsiteBuildFingerprintInput('website/src/generated/deploy-version.ts')).toBe(false)
+    expect(isWebsiteBuildFingerprintInput('src/__tests__/website-build.test.ts')).toBe(false)
+  })
+
+  test('hashes contents, paths, missing inputs, and stable provenance', () => {
+    const root = mkdtempSync(join(tmpdir(), 'am-website-fingerprint-'))
+    temporary.push(root)
+    const first = join(root, 'inputs', 'first.txt')
+    mkdirSync(dirname(first), { recursive: true })
+    writeFileSync(first, 'alpha')
+    const options = { paths: ['inputs', 'missing.txt'], provenance: ['commit', 'clean'] }
+    const initial = computeWebsiteBuildFingerprint(root, options)
+    expect(computeWebsiteBuildFingerprint(root, options)).toBe(initial)
+
+    writeFileSync(first, 'beta')
+    expect(computeWebsiteBuildFingerprint(root, options)).not.toBe(initial)
+    writeFileSync(first, 'alpha')
+    writeFileSync(join(root, 'inputs', 'second.txt'), 'two')
+    expect(computeWebsiteBuildFingerprint(root, options)).not.toBe(initial)
+    expect(computeWebsiteBuildFingerprint(root, { ...options, provenance: ['other'] })).not.toBe(initial)
+  })
+
+  test('keeps the authority conservative without fingerprinting generated output', () => {
+    expect(WEBSITE_BUILD_FINGERPRINT_PATHS).toContain('website')
+    expect(WEBSITE_BUILD_FINGERPRINT_PATHS).toContain('editor')
+    expect(WEBSITE_BUILD_FINGERPRINT_PATHS).toContain('scripts/site')
+    expect(WEBSITE_BUILD_FINGERPRINT_PATHS).toContain('scripts/docs')
+    expect(WEBSITE_BUILD_FINGERPRINT_PATHS).toContain('shared')
+
+    const root = mkdtempSync(join(tmpdir(), 'am-website-fingerprint-'))
+    temporary.push(root)
+    for (const path of ['website/source/input.txt', 'website/public/output.txt', 'website/.wrangler/state/cache.txt', 'website/src/generated/value.ts']) {
+      mkdirSync(dirname(join(root, path)), { recursive: true })
+      writeFileSync(join(root, path), path)
+    }
+    const options = { paths: ['website'], provenance: ['fixed'] }
+    const initial = computeWebsiteBuildFingerprint(root, options)
+    for (const excluded of ['website/public/output.txt', 'website/.wrangler/state/cache.txt', 'website/src/generated/value.ts']) {
+      writeFileSync(join(root, excluded), 'changed output')
+      expect(computeWebsiteBuildFingerprint(root, options), excluded).toBe(initial)
+    }
+    writeFileSync(join(root, 'website/source/input.txt'), 'changed source')
+    expect(computeWebsiteBuildFingerprint(root, options)).not.toBe(initial)
+  })
+})

--- a/src/__tests__/website-build-fingerprint.test.ts
+++ b/src/__tests__/website-build-fingerprint.test.ts
@@ -129,6 +129,10 @@ describe('website build fingerprint authority', () => {
       writeFileSync(join(root, excluded), 'changed output')
       expect(computeWebsiteBuildFingerprint(root, options), excluded).toBe(initial)
     }
+    for (const excludedDir of ['website/public', 'website/.wrangler', 'website/src/generated']) {
+      rmSync(join(root, excludedDir), { recursive: true, force: true })
+      expect(computeWebsiteBuildFingerprint(root, options), `${excludedDir} absent`).toBe(initial)
+    }
     writeFileSync(join(root, 'website/source/input.txt'), 'changed source')
     expect(computeWebsiteBuildFingerprint(root, options)).not.toBe(initial)
 

--- a/src/__tests__/website-build-fingerprint.test.ts
+++ b/src/__tests__/website-build-fingerprint.test.ts
@@ -5,6 +5,7 @@ import { dirname, join, normalize, relative, resolve } from 'node:path'
 import {
   WEBSITE_BUILD_ENVIRONMENT_KEYS,
   WEBSITE_BUILD_FINGERPRINT_PATHS,
+  acquireWebsiteBuildLock,
   computeWebsiteBuildFingerprint,
   isWebsiteBuildFingerprintInput,
   runStableFingerprintBuild,
@@ -61,6 +62,28 @@ describe('website build fingerprint authority', () => {
     for (const key of WEBSITE_BUILD_ENVIRONMENT_KEYS) {
       expect(computeWebsiteBuildFingerprint(root, { ...options, environment: { [key]: 'changed' } }), key).not.toBe(initial)
     }
+  })
+
+  test('lock waiters compare completed output with a fresh fingerprint', () => {
+    let lockAttempts = 0
+    let fingerprintReads = 0
+    const acquired = acquireWebsiteBuildLock({
+      fingerprint: () => { fingerprintReads++; return 'B' },
+      readSentinel: () => 'A',
+      tryAcquire: () => ++lockAttempts === 2,
+      sleep: () => {},
+      maxAttempts: 3,
+    })
+    expect({ acquired, lockAttempts, fingerprintReads }).toEqual({ acquired: true, lockAttempts: 2, fingerprintReads: 2 })
+
+    lockAttempts = 0
+    expect(acquireWebsiteBuildLock({
+      fingerprint: () => 'A',
+      readSentinel: () => 'A',
+      tryAcquire: () => { lockAttempts++; return true },
+      sleep: () => {},
+    })).toBe(false)
+    expect(lockAttempts).toBe(0)
   })
 
   test('retries a mixed build and commits only a stable fingerprint', () => {

--- a/src/__tests__/website-build.test.ts
+++ b/src/__tests__/website-build.test.ts
@@ -6,6 +6,7 @@ import { execFileSync } from 'node:child_process'
 import { EDITOR_EXAMPLES } from '../../editor/examples.ts'
 import { samples as RICH_EXAMPLES } from '../../scripts/site/samples-data.ts'
 import { decodeEditorStateHash, EDITOR_SHARE_STATE_KEYS } from '../../scripts/site/editor-state-url.ts'
+import { WEBSITE_BUILD_FINGERPRINT_PATHS } from '../../scripts/site/website-build-fingerprint.ts'
 import { createStyledExampleRenderState, WEBSITE_EXAMPLE_THEME } from '../../scripts/site/example-render-state.ts'
 import { renderWebsiteSVG } from '../../website/src/rendering.ts'
 import { createWebsiteWorker } from '../../website/src/worker-core.ts'
@@ -318,6 +319,43 @@ describe('Workers Static Assets website contract', () => {
     const js = await worker.fetch(new Request('https://agentic-mermaid.dev/editor/editor-abcdef123456.js'), env(() => new Response('export {}', { headers: { 'content-type': 'text/javascript; charset=utf-8' } })))
     expect(js.headers.get('cache-control')).toBe('public, max-age=31536000, immutable')
 
+    const emittedHashedAssets = files().filter(rel => /(?:^|\/)[^/]+-[a-f0-9]{12}(?:\.min)?\.(?:js|html|woff2)$/i.test(rel)).sort()
+    expect(emittedHashedAssets).toEqual(expect.arrayContaining([
+      expect.stringMatching(/^editor\/editor-[a-f0-9]{12}\.js$/),
+      expect.stringMatching(/^generated\/inline-[a-f0-9]{12}\.js$/),
+      expect.stringMatching(/^vendor\/mermaid-[a-f0-9]{12}\.min\.js$/),
+    ]))
+    for (const rel of emittedHashedAssets) {
+      const contentType = rel.endsWith('.html') ? 'text/html' : rel.endsWith('.woff2') ? 'font/woff2' : 'text/javascript'
+      const asset = await worker.fetch(new Request(`https://agentic-mermaid.dev/${rel}`), env(() => new Response('asset', { headers: { 'content-type': contentType } })))
+      expect({ rel, cache: asset.headers.get('cache-control') }).toEqual({ rel, cache: 'public, max-age=31536000, immutable' })
+    }
+
+    for (const [pathname, response] of [
+      ['/examples/fragments/corpus-deadbeefdead.html', new Response('missing', { status: 404, headers: { 'content-type': 'text/html' } })],
+      ['/editor/editor-abcdef123456.js', new Response('broken', { status: 500, headers: { 'content-type': 'text/javascript' } })],
+      ['/editor/editor-abcdef123456.js', new Response('<!doctype html>', { headers: { 'content-type': 'text/html' } })],
+      ['/editor/editor-abcdef123456.js', new Response('export {}', { headers: { 'content-type': 'text/javascript', 'set-cookie': 'session=unexpected' } })],
+    ] as const) {
+      const rejected = await worker.fetch(new Request(`https://agentic-mermaid.dev${pathname}`), env(() => response.clone()))
+      expect({ pathname, status: rejected.status, cache: rejected.headers.get('cache-control') }).toEqual({ pathname, status: response.status, cache: 'no-store' })
+    }
+
+    const poisoned = await worker.fetch(new Request('https://agentic-mermaid.dev/editor/editor-abcdef123456.js'), env(() => new Response('broken', {
+      status: 500,
+      headers: {
+        'content-type': 'text/javascript',
+        'cdn-cache-control': 'public, max-age=999',
+        'cloudflare-cdn-cache-control': 'public, max-age=888',
+      },
+    })))
+    expect(poisoned.headers.get('cache-control')).toBe('no-store')
+    expect(poisoned.headers.get('cdn-cache-control')).toBeNull()
+    expect(poisoned.headers.get('cloudflare-cdn-cache-control')).toBeNull()
+
+    const mixedCaseHtml = await worker.fetch(new Request('https://agentic-mermaid.dev/about/'), env(() => new Response('<!doctype html>', { headers: { 'content-type': 'Text/HTML; Charset=UTF-8' } })))
+    expect(mixedCaseHtml.headers.get('content-security-policy')).toContain("default-src 'self'")
+
     for (const [pathname, contentType] of [
       ['/apple-touch-icon.png', 'image/png'],
       ['/favicon.ico', 'image/x-icon'],
@@ -412,13 +450,12 @@ describe('Workers Static Assets website contract', () => {
     }
     expect(readRepo('package.json')).toContain('"site:check": "bun run website:check"')
     const preload = readRepo('src/__tests__/website-public.preload.ts')
-    expect(preload).toContain('buildFingerprint')
-    expect(preload).toContain('FINGERPRINT_PATHS')
+    expect(preload).toContain('computeWebsiteBuildFingerprint')
     expect(preload).not.toContain("'--public-only'")
     expect(preload).toContain('GENERATED_FILES')
     expect(preload).toContain("'deploy-version.ts'")
-    for (const rel of ['docs/schemas/style-spec.schema.json', 'docs/assets/style-cookbook', 'examples/styles', 'skills/agentic-mermaid-diagram-workflow', 'Instructions_for_agents.md']) {
-      expect(preload).toContain(`'${rel}'`)
+    for (const rel of ['website', 'editor', 'scripts/site', 'scripts/docs', 'shared', 'docs/schemas/style-spec.schema.json', 'docs/assets/style-cookbook', 'examples/styles', 'skills/agentic-mermaid-diagram-workflow', 'Instructions_for_agents.md']) {
+      expect(WEBSITE_BUILD_FINGERPRINT_PATHS as readonly string[]).toContain(rel)
     }
   })
 
@@ -1611,7 +1648,7 @@ describe('Workers Static Assets website contract', () => {
     expect(examples).not.toContain('aria-labelledby="journey-')
     expect(read('_headers')).not.toContain('Cache-Control')
     expect(workerCore).toContain("headers.delete('Cache-Control')")
-    expect(workerCore).toContain("/^\\/(?:editor\\/editor-[a-f0-9]{12}|vendor\\/mermaid-[a-f0-9]{12}\\.min)\\.js$/i.test(pathname)")
+    expect(workerCore).toContain('classifyWebsiteAssetCache')
     expect(workerCore).toContain("public, max-age=31536000, immutable")
     expect(read('shader-mark.js')).toContain('runs a short sweep only on direct hover/focus')
     expect(read('shader-mark.js')).not.toContain('requestAnimationFrame(frame);\n    }\n    requestAnimationFrame(frame);')

--- a/src/__tests__/website-cache-policy.test.ts
+++ b/src/__tests__/website-cache-policy.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, test } from 'bun:test'
+import { classifyWebsiteAssetCache, type WebsiteAssetCacheInput } from '../../website/src/worker-core.ts'
+
+const IMMUTABLE = 'public, max-age=31536000, immutable'
+const base: WebsiteAssetCacheInput = {
+  pathname: '/editor/editor-abcdef123456.js',
+  method: 'GET',
+  status: 200,
+  contentType: 'text/javascript; charset=utf-8',
+}
+
+function classify(overrides: Partial<WebsiteAssetCacheInput> = {}) {
+  return classifyWebsiteAssetCache({ ...base, ...overrides })
+}
+
+describe('website static asset cache authority', () => {
+  test('admits only complete successful recognized hashed assets as immutable', () => {
+    for (const [pathname, contentType] of [
+      ['/editor/editor-abcdef123456.js', 'text/javascript'],
+      ['/editor/editor-app-abcdef123456.js', 'application/javascript'],
+      ['/editor/editor-renderer-abcdef123456.js', 'text/javascript'],
+      ['/vendor/mermaid-abcdef123456.min.js', 'text/javascript'],
+      ['/examples/fragments/style-palette-abcdef123456.html', 'text/html; charset=utf-8'],
+      ['/examples/fragments/corpus-abcdef123456.html', 'text/html'],
+      ['/examples-abcdef123456.js', 'text/javascript'],
+      ['/fonts/Inter-Regular.subset-abcdef123456.woff2', 'font/woff2'],
+    ] as const) {
+      expect(classify({ pathname, contentType }), pathname).toBe(IMMUTABLE)
+      expect(classify({ pathname, contentType, method: 'HEAD' }), `${pathname} HEAD`).toBe(IMMUTABLE)
+    }
+  })
+
+  test('fails closed for every incomplete or untrusted hashed response dimension', () => {
+    for (const status of [206, 301, 302, 404, 410, 500, 503]) {
+      expect(classify({ status }), `status ${status}`).toBe('no-store')
+    }
+    expect(classify({ method: 'POST' })).toBe('no-store')
+    expect(classify({ method: 'OPTIONS' })).toBe('no-store')
+    expect(classify({ contentType: 'text/html' })).toBe('no-store')
+    expect(classify({ contentType: '' })).toBe('no-store')
+    expect(classify({ hasSetCookie: true })).toBe('no-store')
+
+    const fragment = '/examples/fragments/corpus-deadbeefdead.html'
+    expect(classify({ pathname: fragment, status: 404, contentType: 'text/html' })).toBe('no-store')
+    expect(classify({ pathname: fragment, status: 500, contentType: 'text/html' })).toBe('no-store')
+  })
+
+  test('never promotes malformed or stable-name assets to immutable', () => {
+    expect(classify({ pathname: '/editor/editor-short.js' })).toBe('public, max-age=3600')
+    expect(classify({ pathname: '/editor/editor-abcdef12345g.js' })).toBe('public, max-age=3600')
+    expect(classify({ pathname: '/fonts/Inter-Regular.subset.woff2', contentType: 'font/woff2' })).toBe('public, max-age=3600')
+    expect(classify({ pathname: '/styles.css', contentType: 'text/css' })).toBe('public, max-age=3600')
+    expect(classify({ pathname: '/index.html', contentType: 'text/html' })).toBe('no-cache')
+    expect(classify({ pathname: '/data.unknown', contentType: 'application/octet-stream' })).toBe('no-cache')
+  })
+
+  test('keeps machine-readable success cacheable but never caches its errors', () => {
+    expect(classify({ pathname: '/capabilities.json', contentType: 'application/json' })).toBe('public, max-age=300')
+    expect(classify({ pathname: '/capabilities.json', contentType: 'application/json', status: 500 })).toBe('no-store')
+    expect(classify({ pathname: '/llms.txt', contentType: 'text/plain', method: 'POST' })).toBe('no-store')
+  })
+})

--- a/src/__tests__/website-cache-policy.test.ts
+++ b/src/__tests__/website-cache-policy.test.ts
@@ -23,7 +23,11 @@ describe('website static asset cache authority', () => {
       ['/examples/fragments/style-palette-abcdef123456.html', 'text/html; charset=utf-8'],
       ['/examples/fragments/corpus-abcdef123456.html', 'text/html'],
       ['/examples-abcdef123456.js', 'text/javascript'],
+      ['/generated/inline-abcdef123456.js', 'text/javascript'],
       ['/fonts/Inter-Regular.subset-abcdef123456.woff2', 'font/woff2'],
+      ['/fonts/Inter-Medium.subset-abcdef123456.woff2', 'font/woff2'],
+      ['/fonts/Inter-SemiBold.subset-abcdef123456.woff2', 'font/woff2'],
+      ['/fonts/Inter-Bold.subset-abcdef123456.woff2', 'font/woff2'],
     ] as const) {
       expect(classify({ pathname, contentType }), pathname).toBe(IMMUTABLE)
       expect(classify({ pathname, contentType, method: 'HEAD' }), `${pathname} HEAD`).toBe(IMMUTABLE)
@@ -37,6 +41,8 @@ describe('website static asset cache authority', () => {
     expect(classify({ method: 'POST' })).toBe('no-store')
     expect(classify({ method: 'OPTIONS' })).toBe('no-store')
     expect(classify({ contentType: 'text/html' })).toBe('no-store')
+    expect(classify({ contentType: 'text/javascript-invalid' })).toBe('no-store')
+    expect(classify({ contentType: 'text/html; profile=text/javascript' })).toBe('no-store')
     expect(classify({ contentType: '' })).toBe('no-store')
     expect(classify({ hasSetCookie: true })).toBe('no-store')
 
@@ -50,13 +56,18 @@ describe('website static asset cache authority', () => {
     expect(classify({ pathname: '/editor/editor-abcdef12345g.js' })).toBe('public, max-age=3600')
     expect(classify({ pathname: '/fonts/Inter-Regular.subset.woff2', contentType: 'font/woff2' })).toBe('public, max-age=3600')
     expect(classify({ pathname: '/styles.css', contentType: 'text/css' })).toBe('public, max-age=3600')
+    expect(classify({ pathname: '/styles.css', contentType: 'text/css', method: 'POST' })).toBe('no-store')
+    expect(classify({ pathname: '/styles.css', contentType: 'text/css', hasSetCookie: true })).toBe('no-store')
     expect(classify({ pathname: '/index.html', contentType: 'text/html' })).toBe('no-cache')
+    expect(classify({ pathname: '/index.html', contentType: 'text/html', hasSetCookie: true })).toBe('no-store')
+    expect(classify({ pathname: '/index.html', contentType: 'text/html', status: 500 })).toBe('no-store')
     expect(classify({ pathname: '/data.unknown', contentType: 'application/octet-stream' })).toBe('no-cache')
   })
 
   test('keeps machine-readable success cacheable but never caches its errors', () => {
     expect(classify({ pathname: '/capabilities.json', contentType: 'application/json' })).toBe('public, max-age=300')
     expect(classify({ pathname: '/capabilities.json', contentType: 'application/json', status: 500 })).toBe('no-store')
+    expect(classify({ pathname: '/capabilities.json', contentType: 'application/json', hasSetCookie: true })).toBe('no-store')
     expect(classify({ pathname: '/llms.txt', contentType: 'text/plain', method: 'POST' })).toBe('no-store')
   })
 })

--- a/src/__tests__/website-public.preload.ts
+++ b/src/__tests__/website-public.preload.ts
@@ -1,27 +1,21 @@
 // Ensures the Cloudflare site bundle and generated Worker inputs exist before
 // the tests that read them.
 //
-// website/public/ is a build artifact (gitignored, rebuilt at deploy by
-// .github/workflows/deploy-cloudflare.yml). On a fresh checkout it is absent,
-// so several tests (website-build, editor-*-switch, website-browser-a11y,
-// agent-doc-sync) would fail reading it. Build it once here, in a separate
-// process so the unit run's coverage instrumentation never touches the build.
+// website/public/ and website/src/generated/ are build artifacts (gitignored,
+// rebuilt at deploy). Build them once in a separate process so coverage
+// instrumentation never touches generation.
 //
 // Liveness is tracked by a source fingerprint sentinel written only AFTER a
-// fully successful build. index.html is emitted early in the build, so it is
-// not a reliable marker — a crashed or killed build would leave it behind and
-// the next run would skip the rebuild and test a half-built bundle. On failure
-// the partial output is removed so the next run rebuilds from scratch.
-import { createHash } from 'node:crypto'
-import { execFileSync } from 'node:child_process'
-import { existsSync, mkdirSync, readFileSync, readdirSync, rmSync, statSync, writeFileSync } from 'node:fs'
+// fully successful build across a stable input snapshot.
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { join } from 'node:path'
+import { acquireWebsiteBuildLock, computeWebsiteBuildFingerprint, runStableFingerprintBuild } from '../../scripts/site/website-build-fingerprint.ts'
 
 const ROOT = join(import.meta.dir, '..', '..')
 const OUT = join(ROOT, 'website', 'public')
 const GENERATED = join(ROOT, 'website', 'src', 'generated')
 const SENTINEL = join(OUT, '.preload-built')
-const LOCK = join(OUT, '.preload-build.lock')
+const LOCK = join(ROOT, '.website-preload-build.lock')
 const GENERATED_FILES = [
   'ArchitectsDaughter.ttf',
   'Caveat.ttf',
@@ -37,27 +31,6 @@ const GENERATED_FILES = [
   'execute-harness.js.txt',
   'resvg.wasm',
 ] as const
-const FINGERPRINT_PATHS = [
-  'website/build.ts',
-  'website/source',
-  'website/src',
-  'public',
-  'docs/schemas/style-spec.schema.json',
-  'docs/assets/style-cookbook',
-  'examples/styles',
-  'skills/agentic-mermaid-diagram-workflow',
-  'Instructions_for_agents.md',
-  'editor/examples.ts',
-  'editor/js',
-  'scripts/site/example-render-state.ts',
-  'scripts/site/editor-state-url.ts',
-  'scripts/site/samples-data.ts',
-  'src',
-  'eval/agent-usage/homepage-prompt.ts',
-  'assets/fonts',
-  'package.json',
-  'bun.lock',
-]
 
 ensureBuilt()
 
@@ -66,34 +39,34 @@ function ensureBuilt(): void {
   if (readSentinel() === fingerprint) return
 
   mkdirSync(OUT, { recursive: true })
-  const acquired = acquireLock(fingerprint)
+  const acquired = acquireWebsiteBuildLock({
+    fingerprint: buildFingerprint,
+    readSentinel,
+    tryAcquire() {
+      try { mkdirSync(LOCK, { recursive: false }); return true }
+      catch { return false }
+    },
+    sleep: () => sleepSync(100),
+  })
   if (!acquired) return
   try {
     const latest = buildFingerprint()
     if (readSentinel() === latest) return
-    const r = Bun.spawnSync(['bun', 'run', 'website/build.ts'], { cwd: ROOT, stdout: 'inherit', stderr: 'inherit' })
-    if (r.exitCode !== 0) {
-      rmSync(OUT, { recursive: true, force: true })
-      rmSync(GENERATED, { recursive: true, force: true })
-      throw new Error('website and Worker artifact build (test preload) failed')
-    }
-    writeFileSync(SENTINEL, buildFingerprint())
+    runStableFingerprintBuild({
+      fingerprint: buildFingerprint,
+      build() {
+        const result = Bun.spawnSync(['bun', 'run', 'website/build.ts'], { cwd: ROOT, stdout: 'inherit', stderr: 'inherit' })
+        if (result.exitCode !== 0) throw new Error('website and Worker artifact build (test preload) failed')
+      },
+      reset() {
+        rmSync(OUT, { recursive: true, force: true })
+        rmSync(GENERATED, { recursive: true, force: true })
+      },
+      commit(stableFingerprint) { writeFileSync(SENTINEL, stableFingerprint) },
+    })
   } finally {
     rmSync(LOCK, { recursive: true, force: true })
   }
-}
-
-function acquireLock(fingerprint: string): boolean {
-  for (let attempt = 0; attempt < 600; attempt++) {
-    try {
-      mkdirSync(LOCK, { recursive: false })
-      return true
-    } catch {
-      if (readSentinel() === fingerprint) return false
-      sleepSync(100)
-    }
-  }
-  throw new Error('Timed out waiting for website/public build preload lock')
 }
 
 function sleepSync(ms: number): void {
@@ -106,41 +79,5 @@ function readSentinel(): string | null {
 }
 
 function buildFingerprint(): string {
-  const hash = createHash('sha256')
-  // Generated provenance changes when identical source bytes move from dirty
-  // to committed, or when HEAD advances without touching a website input.
-  for (const args of [['rev-parse', 'HEAD'], ['status', '--porcelain=v1', '--untracked-files=normal']]) {
-    try { hash.update(execFileSync('git', args, { cwd: ROOT, encoding: 'utf8' })) } catch { hash.update('git-unavailable') }
-    hash.update('\0')
-  }
-  for (const rel of FINGERPRINT_PATHS) {
-    addPathToHash(hash, join(ROOT, rel), rel)
-  }
-  return hash.digest('hex')
-}
-
-function addPathToHash(hash: ReturnType<typeof createHash>, abs: string, rel: string): void {
-  hash.update(rel)
-  hash.update('\0')
-  if (!existsSync(abs)) {
-    hash.update('missing')
-    hash.update('\0')
-    return
-  }
-  const stat = statSync(abs)
-  if (stat.isDirectory()) {
-    hash.update('dir')
-    hash.update('\0')
-    for (const name of readdirSync(abs).sort()) {
-      if (rel === 'website' && name === 'public') continue
-      if (rel === 'website/src' && name === 'generated') continue
-      if (rel === 'src' && name === '__tests__') continue
-      addPathToHash(hash, join(abs, name), `${rel}/${name}`)
-    }
-    return
-  }
-  hash.update('file')
-  hash.update('\0')
-  hash.update(readFileSync(abs))
-  hash.update('\0')
+  return computeWebsiteBuildFingerprint(ROOT)
 }

--- a/website/src/worker-core.ts
+++ b/website/src/worker-core.ts
@@ -99,7 +99,7 @@ type ImmutableAssetRule = Readonly<{ path: RegExp, contentTypes: readonly string
 const IMMUTABLE_ASSET_RULES: readonly ImmutableAssetRule[] = Object.freeze([
   Object.freeze({ path: /^\/(?:editor\/editor-(?:(?:app|renderer)-)?[a-f0-9]{12}|vendor\/mermaid-[a-f0-9]{12}\.min)\.js$/i, contentTypes: ['text/javascript', 'application/javascript'] }),
   Object.freeze({ path: /^\/examples\/fragments\/(?:style-palette|corpus)-[a-f0-9]{12}\.html$/i, contentTypes: ['text/html'] }),
-  Object.freeze({ path: /^\/examples-[a-f0-9]{12}\.js$/i, contentTypes: ['text/javascript', 'application/javascript'] }),
+  Object.freeze({ path: /^\/(?:examples|generated\/inline)-[a-f0-9]{12}\.js$/i, contentTypes: ['text/javascript', 'application/javascript'] }),
   Object.freeze({ path: /^\/fonts\/Inter-(?:Regular|Medium|SemiBold|Bold)\.subset-[a-f0-9]{12}\.woff2$/i, contentTypes: ['font/woff2'] }),
 ])
 
@@ -114,20 +114,16 @@ export interface WebsiteAssetCacheInput {
 /** Cache authority for static assets. A hash-shaped path is only immutable
  * when the asset response itself proves it is the complete expected object. */
 export function classifyWebsiteAssetCache(input: WebsiteAssetCacheInput): string {
-  const contentType = input.contentType.toLowerCase()
+  const contentType = input.contentType.split(';', 1)[0]!.trim().toLowerCase()
+  const cacheableMethod = input.method === 'GET' || input.method === 'HEAD'
+  if (!cacheableMethod || input.hasSetCookie || input.status !== 200) return 'no-store'
+
   const immutableRule = IMMUTABLE_ASSET_RULES.find(rule => rule.path.test(input.pathname))
   if (immutableRule) {
-    const complete = input.method === 'GET' || input.method === 'HEAD'
-    const expectedType = immutableRule.contentTypes.some(type => contentType.includes(type))
-    return complete && input.status === 200 && expectedType && !input.hasSetCookie ? IMMUTABLE_CACHE : 'no-store'
+    return immutableRule.contentTypes.includes(contentType) ? IMMUTABLE_CACHE : 'no-store'
   }
-  if (/\.(json|md|txt)$/i.test(input.pathname)) {
-    return input.status === 200 && (input.method === 'GET' || input.method === 'HEAD')
-      ? 'public, max-age=300'
-      : 'no-store'
-  }
-  if (contentType.includes('text/html') || input.status === 404) return 'no-cache'
-  if (input.status !== 200) return 'no-store'
+  if (/\.(json|md|txt)$/i.test(input.pathname)) return 'public, max-age=300'
+  if (contentType === 'text/html') return 'no-cache'
   if (HOURLY_STATIC_ASSET.test(input.pathname)) return 'public, max-age=3600'
   return 'no-cache'
 }
@@ -146,8 +142,11 @@ function withHeaders(response: Response, pathname: string, method: string, negot
   headers.set('Permissions-Policy', 'camera=(), microphone=(), geolocation=(), payment=(), usb=()')
 
   const type = headers.get('content-type') || ''
+  const typeEssence = type.split(';', 1)[0]!.trim().toLowerCase()
   headers.delete('Cache-Control')
-  if (type.includes('text/html')) headers.set('Content-Security-Policy', csp)
+  headers.delete('CDN-Cache-Control')
+  headers.delete('Cloudflare-CDN-Cache-Control')
+  if (typeEssence === 'text/html') headers.set('Content-Security-Policy', csp)
 
   if (/\.(json|md|txt)$/i.test(pathname)) headers.set('Access-Control-Allow-Origin', '*')
   headers.set('Cache-Control', classifyWebsiteAssetCache({

--- a/website/src/worker-core.ts
+++ b/website/src/worker-core.ts
@@ -93,6 +93,44 @@ function prefersMarkdown(accept: string | null): boolean {
 
 const HOURLY_STATIC_ASSET = /\.(?:css|js|svg|ttf|woff2|png|ico)$/i
 const STRICT_TRANSPORT_SECURITY = 'max-age=31536000'
+const IMMUTABLE_CACHE = 'public, max-age=31536000, immutable'
+
+type ImmutableAssetRule = Readonly<{ path: RegExp, contentTypes: readonly string[] }>
+const IMMUTABLE_ASSET_RULES: readonly ImmutableAssetRule[] = Object.freeze([
+  Object.freeze({ path: /^\/(?:editor\/editor-(?:(?:app|renderer)-)?[a-f0-9]{12}|vendor\/mermaid-[a-f0-9]{12}\.min)\.js$/i, contentTypes: ['text/javascript', 'application/javascript'] }),
+  Object.freeze({ path: /^\/examples\/fragments\/(?:style-palette|corpus)-[a-f0-9]{12}\.html$/i, contentTypes: ['text/html'] }),
+  Object.freeze({ path: /^\/examples-[a-f0-9]{12}\.js$/i, contentTypes: ['text/javascript', 'application/javascript'] }),
+  Object.freeze({ path: /^\/fonts\/Inter-(?:Regular|Medium|SemiBold|Bold)\.subset-[a-f0-9]{12}\.woff2$/i, contentTypes: ['font/woff2'] }),
+])
+
+export interface WebsiteAssetCacheInput {
+  pathname: string
+  method: string
+  status: number
+  contentType: string
+  hasSetCookie?: boolean
+}
+
+/** Cache authority for static assets. A hash-shaped path is only immutable
+ * when the asset response itself proves it is the complete expected object. */
+export function classifyWebsiteAssetCache(input: WebsiteAssetCacheInput): string {
+  const contentType = input.contentType.toLowerCase()
+  const immutableRule = IMMUTABLE_ASSET_RULES.find(rule => rule.path.test(input.pathname))
+  if (immutableRule) {
+    const complete = input.method === 'GET' || input.method === 'HEAD'
+    const expectedType = immutableRule.contentTypes.some(type => contentType.includes(type))
+    return complete && input.status === 200 && expectedType && !input.hasSetCookie ? IMMUTABLE_CACHE : 'no-store'
+  }
+  if (/\.(json|md|txt)$/i.test(input.pathname)) {
+    return input.status === 200 && (input.method === 'GET' || input.method === 'HEAD')
+      ? 'public, max-age=300'
+      : 'no-store'
+  }
+  if (contentType.includes('text/html') || input.status === 404) return 'no-cache'
+  if (input.status !== 200) return 'no-store'
+  if (HOURLY_STATIC_ASSET.test(input.pathname)) return 'public, max-age=3600'
+  return 'no-cache'
+}
 
 function withTransportSecurity(response: Response, httpsRequest: boolean): Response {
   if (!httpsRequest) return response
@@ -101,7 +139,7 @@ function withTransportSecurity(response: Response, httpsRequest: boolean): Respo
   return new Response(response.body, { status: response.status, statusText: response.statusText, headers })
 }
 
-function withHeaders(response: Response, pathname: string, negotiatesHomepage = false): Response {
+function withHeaders(response: Response, pathname: string, method: string, negotiatesHomepage = false): Response {
   const headers = new Headers(response.headers)
   headers.set('X-Content-Type-Options', 'nosniff')
   headers.set('Referrer-Policy', 'strict-origin-when-cross-origin')
@@ -111,20 +149,14 @@ function withHeaders(response: Response, pathname: string, negotiatesHomepage = 
   headers.delete('Cache-Control')
   if (type.includes('text/html')) headers.set('Content-Security-Policy', csp)
 
-  if (/\.(json|md|txt)$/i.test(pathname)) {
-    headers.set('Access-Control-Allow-Origin', '*')
-    headers.set('Cache-Control', 'public, max-age=300')
-  } else if (type.includes('text/html') || response.status === 404) {
-    headers.set('Cache-Control', 'no-cache')
-  } else if (/^\/(?:editor\/editor-[a-f0-9]{12}|vendor\/mermaid-[a-f0-9]{12}\.min)\.js$/i.test(pathname)) {
-    headers.set('Cache-Control', 'public, max-age=31536000, immutable')
-  } else if (HOURLY_STATIC_ASSET.test(pathname)) {
-    headers.set('Cache-Control', 'public, max-age=3600')
-  } else {
-    // Deleting the Static Assets header must never leave an unclassified public
-    // file with ambient platform policy. Unknown extensions revalidate.
-    headers.set('Cache-Control', 'no-cache')
-  }
+  if (/\.(json|md|txt)$/i.test(pathname)) headers.set('Access-Control-Allow-Origin', '*')
+  headers.set('Cache-Control', classifyWebsiteAssetCache({
+    pathname,
+    method,
+    status: response.status,
+    contentType: type,
+    hasSetCookie: headers.has('Set-Cookie'),
+  }))
 
   if (negotiatesHomepage) {
     appendVary(headers, 'Accept')
@@ -197,7 +229,7 @@ export function createWebsiteWorker(runtime: WebsiteWorkerRuntime) {
       }
 
       const response = await env.ASSETS.fetch(assetRequest)
-      return finish(withHeaders(response, assetPathname, negotiatesHomepage))
+      return finish(withHeaders(response, assetPathname, assetRequest.method, negotiatesHomepage))
     },
   }
 }


### PR DESCRIPTION
## What

Make website build reuse and immutable caching fail closed before payload optimization resumes.

Closes #206.

## Why

The payload audit found two false-green paths:

1. the test preload could reuse `website/public` after direct or transitive website inputs changed, and could stamp output produced across a changing source snapshot as current;
2. cache policy was distributed through pathname branches, so a future content-hashed asset rule could accidentally make an error response immutable.

These are verification-foundation changes only; public page payloads and UI are unchanged.

## How

### Closed build fingerprint

- Centralize website source enrollment in `scripts/site/website-build-fingerprint.ts`.
- Conservatively include complete website/editor/site-script/shared trees plus promoted corpus inputs, dependency identities, Git state, and every output-affecting `SITE_*` variable.
- Exclude generated website output, Wrangler state, generated worker inputs, and test-only sources.
- Compare a completed sentinel with a freshly computed fingerprint on every lock-wait pass.
- Run generation only across a stable pre/post fingerprint; discard and retry mixed output, bounded to three attempts.
- Keep the lock outside the output directory so cleanup cannot drop mutual exclusion.

### One cache authority

- Centralize static cache classification in `classifyWebsiteAssetCache(...)`.
- Grant immutable caching only to exact recognized content-hashed paths with GET/HEAD, status 200, exact expected MIME essence, no `Set-Cookie`, and complete responses.
- Return `no-store` for unsafe methods, partial/redirect/error responses, wrong MIME, and cookie-bearing responses.
- Remove upstream `CDN-Cache-Control` and `Cloudflare-CDN-Cache-Control` before applying the authority.
- Normalize MIME once and reuse it for CSP detection, including mixed-case HTML.
- Verify every content-hashed asset actually emitted by the website build crosses the Worker and receives immutable caching.

## Reproduction

Before this change, changing a transitive promoted corpus fixture or `scripts/site/editor.ts` after the preload sentinel was written could leave stale generated output. A pathname-shaped hashed response also had no closed reusable policy for status/MIME/method/error admission.

Focused fault injections now prove the guards:

- weakening the immutable status check makes **1/4 cache-policy tests fail** (`206` becomes immutable);
- removing `scripts/site` enrollment makes **2/3 fingerprint tests fail**.

## Testing

- `bun run test` — **6,812 passed**, 40 intentional browser-gated skips, 0 failed.
- `bun run test:browser` — **51 passed**, 0 failed.
- Focused final website/fingerprint/cache suite — **53 passed**, 0 failed.
- `bunx tsc --noEmit` — passed.
- `bun run website:check` — 13 generated inputs synchronized.
- `bun run audit:dependencies` — no vulnerabilities.
- Palette, visual-evidence, benchmark-provenance, and hero checks — synchronized.
- Two fresh-context reviewers rechecked cache/security and fingerprint/concurrency behavior; all findings were fixed and revalidated.

## Risk

- The conservative fingerprint can trigger extra local website rebuilds when unrelated files inside enrolled source directories change. This costs build time but cannot publish stale output.
- Error/static responses now receive stricter cache policy. Successful stable and content-hashed asset behavior remains covered by Worker-level tests.
- Future hashed asset producers still need to add their exact path/MIME rule; the emitted-asset closure test prevents silently shipping an unenrolled content-hashed file.

No visual evidence is included because this PR does not change rendered UI or geometry.
