### PR TITLE
Fix Windows editor file URL conversion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This changelog tracks user-facing changes for **Agentic Mermaid**, a fork of `lu
 - Updated the transitive `brace-expansion` development dependency to 5.0.7 so the high-severity dependency audit remains enforced without blocking CI on GHSA-3jxr-9vmj-r5cp. The override stays within `minimatch`'s declared compatible range and is exercised by the retained Stryker mutation lane.
 - Completed the 0.1.2 version projection across package, hosted MCP registry, generated agent guidance, and compatibility tests; host-version assertions now derive from the package authority instead of embedding the previous release.
 - Made installed-resource verification portable to Windows by applying `/proc/self/fd` and `/dev/fd` canonicalization only on Linux and macOS; other platforms retain the rooted post-open file-identity proof instead of probing a nonexistent `/dev/fd` path.
+- Made the editor/website generator's local file URL conversion portable to Windows by using `fileURLToPath` instead of passing `/D:/...` URL pathnames to `Bun.build`.
 
 ### Changed
 - Simplified the published package to compiled ESM entries and removed the internal `./capabilities` and `./resources` subpaths. The supported library entries are `agentic-mermaid`, `agentic-mermaid/agent`, and the browser/workerd-safe `agentic-mermaid/agent/core`.

--- a/docs/contributing/lessons-learned.md
+++ b/docs/contributing/lessons-learned.md
@@ -20,6 +20,8 @@ date; do not delete old ones — supersede them in place.
 
 **A release-only platform gate is still part of the product test topology.** Making Worker outputs ephemeral caused the Windows release smoke to build the website during test preload, exposing a resolver branch that treated every non-Linux host as macOS and probed `/dev/fd`. Rule: enumerate platform capabilities explicitly, keep the portable security proof authoritative when an optional OS proof is unavailable, and exercise release-platform setup before a release event can become the first caller.
 
+**A file URL pathname is not a portable filesystem path.** After the resolver fix, the same Windows release smoke advanced far enough to expose editor generation passing `/D:/...` from `URL.pathname` into `Bun.build`; POSIX CI had hidden the distinction because URL paths and local paths coincide there. Rule: convert `file:` URLs with `fileURLToPath`, join local descendants with `node:path`, and keep a Windows execution lane for generators that feed release tests.
+
 ## 2026-07 — complexity-aware test portfolio (#193)
 
 **Optimize declared obligations, not test count.** The old 4,500-render matrix was exhaustive only for family × Look × Palette while fixing source complexity, output, transport, security, seed, and background. The replacement exhausts cheap Style algebra, covers expensive factors with independently verified variable strength, retains exact goldens and fault probes, and publishes the missing-tuple count. Rule: state what a row proves before optimizing it; fewer rows are useful only when the declared interaction and oracle strength improve.

--- a/scripts/site/editor.ts
+++ b/scripts/site/editor.ts
@@ -17,6 +17,8 @@
  *   - editor/html/ – HTML partials (topbar, left-panel, right-panel)
  */
 
+import { join } from 'node:path'
+import { fileURLToPath } from 'node:url'
 import { EDITOR_EXAMPLES } from '../../editor/examples.ts'
 import { HOSTED_FONT_RESOURCES, hostedFontFaceCss } from '../../src/font-manifest.ts'
 import { knownStyleDescriptors } from '../../src/scene/style-registry.ts'
@@ -25,10 +27,10 @@ import { PNG_DEFAULT_SCALE } from '../../src/png-contract.ts'
 
 // ── File helpers ──────────────────────────────────────────────────────────────
 
-const editorDir = new URL('../../editor/', import.meta.url).pathname
+const editorDir = fileURLToPath(new URL('../../editor/', import.meta.url))
 
 async function readFile(relativePath: string): Promise<string> {
-  const file = Bun.file(editorDir + relativePath)
+  const file = Bun.file(join(editorDir, relativePath))
   return file.text()
 }
 
@@ -174,7 +176,7 @@ async function readHtmlPartials(themeItems: string): Promise<{
 async function generateEditorHtml(): Promise<string> {
   const fontPrefix = process.env.AM_EDITOR_FONT_PREFIX || 'assets/fonts/'
   const buildResult = await Bun.build({
-    entrypoints: [new URL('../../src/browser.ts', import.meta.url).pathname],
+    entrypoints: [fileURLToPath(new URL('../../src/browser.ts', import.meta.url))],
     target: 'browser',
     format: 'esm',
     minify: true,
@@ -256,6 +258,6 @@ ${appJs}
 }
 
 const result = await generateEditorHtml()
-const outPath = new URL('../../editor.html', import.meta.url).pathname
+const outPath = fileURLToPath(new URL('../../editor.html', import.meta.url))
 await Bun.write(outPath, result)
 console.log(`Written to ${outPath} (${(result.length / 1024).toFixed(1)} KB)`)

--- a/src/__tests__/website-build.test.ts
+++ b/src/__tests__/website-build.test.ts
@@ -624,6 +624,8 @@ describe('Workers Static Assets website contract', () => {
     const editorBuilder = readFileSync(join(REPO, 'scripts/site/editor.ts'), 'utf8')
     const websiteBuilder = readFileSync(join(REPO, 'website/build.ts'), 'utf8')
     expect(editorBuilder).toContain("AM_EDITOR_FONT_PREFIX || 'assets/fonts/'")
+    expect(editorBuilder).toContain("fileURLToPath(new URL('../../src/browser.ts', import.meta.url))")
+    expect(editorBuilder).not.toMatch(/new URL\([^\n]+import\.meta\.url\)\.pathname/)
     expect(websiteBuilder).toContain("AM_EDITOR_FONT_PREFIX: '/fonts/'")
   })
 


### PR DESCRIPTION
## What

Make the editor/website generator convert local `file:` URLs into filesystem paths portably so the v0.1.2 Windows release smoke can execute the registry-derived render portfolio.

## Why

The corrected [v0.1.2 publish run](https://github.com/adewale/agentic-mermaid/actions/runs/29817712780) passed macOS and advanced past the previously fixed resource resolver on Windows, then failed while `scripts/site/editor.ts` prepared the website test preload. Three local files were resolved with `new URL(...).pathname`; on Windows, the browser entrypoint became `/D:/a/.../src/browser.ts`, which `Bun.build` rejected as `BadPathName` instead of receiving the native `D:\\a\\...` path.

## How

- Convert the editor directory, browser bundle entrypoint, and generated output URL with Node's cross-platform `fileURLToPath`.
- Join editor descendants with `node:path` instead of concatenating URL-derived text.
- Add a source contract that requires the portable browser entrypoint conversion and rejects local `import.meta.url` `.pathname` conversions.
- Record the release fix and the general file-URL lesson in the changelog and contributor lessons.

## Testing

- `bun run scripts/site/editor.ts`
- `bun run website:check`
- `bun test ./src/__tests__/website-build.test.ts --timeout 120000` — 44/44, 4,094 assertions
- `bun test ./src/__tests__/render-conformance-plan.test.ts --timeout 120000` — 9/9, 9,854 assertions
- `bun run typecheck`
- Regression ablation: restored the failing browser entrypoint expression `new URL('../../src/browser.ts', import.meta.url).pathname`; the focused website contract failed on the portable conversion assertion. Reapplying this commit makes it pass.

## Visual evidence

Screenshots are not applicable. This changes only conversion from local file URLs to host filesystem paths before bundling. The generated editor, website, and renderer portfolio are unchanged; deterministic regeneration and render-contract tests are the relevant evidence.

## Risk

Risk is limited to local path construction in the editor generator. `fileURLToPath` is the Node API defined for this conversion, preserves current POSIX paths, handles Windows drive letters and escaping, and introduces no dependency. The full Windows release platform smoke remains the acceptance proof before publication is retried.

The current v0.1.2 retry again stopped before npm or MCP publication. After this PR passes Windows and canonical `main` CI, the failed GitHub release/tag can be replaced once more on the corrected merge commit.
