### PR TITLE
fix(website): canonicalize Examples fragment URLs

### DIFF
--- a/docs/project/website-payload-plan.md
+++ b/docs/project/website-payload-plan.md
@@ -21,7 +21,7 @@ The Examples page already uses `content-visibility: auto`; that reduces off-scre
 | Route | requests | raw | gzip | Brotli |
 |---|---:|---:|---:|---:|
 | `/` | 9 | 682,619 B | 406,567 B | 387,899 B |
-| `/examples/` | 6 | 380,408 B | 66,947 B | 53,157 B |
+| `/examples/` | 6 | 380,391 B | 66,938 B | 53,183 B |
 | `/editor/?empty=1` | 2 | 3,314,199 B | 974,886 B | 767,057 B |
 
 The matching ceilings live separately in `scripts/site/website-payload-budgets.ts`. Review policy requires an optimization to ratchet its own route downward without rewriting measurement logic or unrelated route budgets in the same PR. Lighthouse timings remain diagnostic review evidence.
@@ -77,9 +77,9 @@ Inter-subset baseline → deferred Examples ratchet:
 
 | Metric | Before | After | Change |
 |---|---:|---:|---:|
-| Initial route raw | 2,426,844 B | 380,408 B | −84.3% |
-| Initial route gzip | 648,659 B | 66,947 B | −89.7% |
-| Initial route Brotli | 564,048 B | 53,157 B | −90.6% |
+| Initial route raw | 2,426,844 B | 380,391 B | −84.3% |
+| Initial route gzip | 648,659 B | 66,938 B | −89.7% |
+| Initial route Brotli | 564,048 B | 53,183 B | −90.6% |
 | Initial requests | 11 | 6 | −5 |
 | Document raw | 1,966,916 B | 272,449 B | −86.1% |
 | Document gzip | 262,408 B | 39,065 B | −85.1% |

--- a/eval/website-payload/baseline.json
+++ b/eval/website-payload/baseline.json
@@ -112,12 +112,12 @@
       },
       "requests": [
         {
-          "path": "/examples-10966ace99ec.js",
+          "path": "/examples-2793c42e35c7.js",
           "count": 1,
-          "sha256": "10966ace99ec7849d3d7b0a9809921a4653a6affa42a76dbcbfc77bb4312dbb8",
-          "rawBytes": 8414,
-          "gzipBytes": 2518,
-          "brotliBytes": 2110
+          "sha256": "2793c42e35c799716be2884620c4c91fd231345f0bf211e9963c764bba4b44c9",
+          "rawBytes": 8407,
+          "gzipBytes": 2512,
+          "brotliBytes": 2103
         },
         {
           "path": "/examples-da30e4213dd8.css",
@@ -130,10 +130,10 @@
         {
           "path": "/examples/",
           "count": 1,
-          "sha256": "472c668b4daa8ce954a0c04f91b024a31e32dddcbf477a28bf6ab5a70e7fff4f",
-          "rawBytes": 272449,
-          "gzipBytes": 39064,
-          "brotliBytes": 29451
+          "sha256": "2826214969767a90e74ed4fcc6ff8675bb6cd5e513d65ef82afc16d9c37efbc7",
+          "rawBytes": 272439,
+          "gzipBytes": 39061,
+          "brotliBytes": 29484
         },
         {
           "path": "/shader-mark.js",
@@ -162,9 +162,9 @@
       ],
       "totals": {
         "requests": 6,
-        "rawBytes": 380408,
-        "gzipBytes": 66947,
-        "brotliBytes": 53157
+        "rawBytes": 380391,
+        "gzipBytes": 66938,
+        "brotliBytes": 53183
       }
     },
     {

--- a/scripts/site/verify-live-examples-delivery.ts
+++ b/scripts/site/verify-live-examples-delivery.ts
@@ -27,7 +27,7 @@ async function live(path: string, expectedType: string, immutable = false) {
 }
 
 const localIndex = readFileSync(join(PUBLIC, 'examples', 'index.html'), 'utf8')
-const expectedAssets = Array.from(localIndex.matchAll(/(?:href|src)="\/(examples-[a-f0-9]{12}\.(?:css|js))"|data-example-fragment="\/(examples\/fragments\/(?:style-palette|corpus)-[a-f0-9]{12}\.html)"/g))
+const expectedAssets = Array.from(localIndex.matchAll(/(?:href|src)="\/(examples-[a-f0-9]{12}\.(?:css|js))"|data-example-fragment="\/(examples\/fragments\/(?:style-palette|corpus)-[a-f0-9]{12})"/g))
   .map(match => match[1] || match[2])
   .filter((asset): asset is string => Boolean(asset))
   .sort()
@@ -52,7 +52,8 @@ for (const asset of expectedAssets) {
   const response = await live(path, expectedType, true)
   if (asset.includes('/fragments/')) requireCondition(response.headers.get('x-robots-tag') === 'noindex, nofollow', `${path}: missing X-Robots-Tag`)
   const bytes = new Uint8Array(await response.arrayBuffer())
-  const local = new Uint8Array(readFileSync(join(PUBLIC, asset)))
+  const localRel = asset.includes('/fragments/') ? `${asset}.html` : asset
+  const local = new Uint8Array(readFileSync(join(PUBLIC, localRel)))
   requireCondition(bytes.byteLength === local.byteLength && digest(bytes) === digest(local), `${path}: live bytes differ from local output`)
   requireCondition(asset.includes(digest(bytes).slice(0, 12)), `${path}: filename digest mismatch`)
   const head = await fetch(origin + path, { method: 'HEAD', headers: { 'cache-control': 'no-cache' } })
@@ -64,7 +65,7 @@ for (const asset of expectedAssets) {
 for (const missingPath of [
   '/examples-000000000000.js',
   '/examples-000000000000.css',
-  '/examples/fragments/corpus-000000000000.html',
+  '/examples/fragments/corpus-000000000000',
 ]) {
   const response = await fetch(origin + missingPath, { headers: { 'cache-control': 'no-cache' } })
   requireCondition(response.status !== 200, `${missingPath}: nonexistent hash returned 200`)

--- a/scripts/site/website-payload-budgets.ts
+++ b/scripts/site/website-payload-budgets.ts
@@ -17,9 +17,9 @@ export const WEBSITE_PAYLOAD_BUDGETS: WebsitePayloadBudgets = Object.freeze({
   }),
   examples: Object.freeze({
     maxRequests: 6,
-    maxRawBytes: 380_408,
-    maxGzipBytes: 66_947,
-    maxBrotliBytes: 53_157,
+    maxRawBytes: 380_391,
+    maxGzipBytes: 66_938,
+    maxBrotliBytes: 53_183,
     required: Object.freeze([
       '^/examples/$', '^/styles\\.css$', '^/examples-[a-f0-9]{12}\\.js$', '^/examples-[a-f0-9]{12}\\.css$',
     ]),

--- a/src/__tests__/website-browser-a11y.test.ts
+++ b/src/__tests__/website-browser-a11y.test.ts
@@ -90,6 +90,10 @@ function fileForPath(pathname: string) {
   const abs = normalize(join(SITE, candidate))
   if (!abs.startsWith(SITE)) return null
   if (existsSync(abs)) return abs
+  if (/^examples\/fragments\/(?:style-palette|corpus)-[a-f0-9]{12}$/.test(rel)) {
+    const htmlAsset = normalize(join(SITE, `${rel}.html`))
+    if (htmlAsset.startsWith(SITE) && existsSync(htmlAsset)) return htmlAsset
+  }
   const index = normalize(join(SITE, rel, 'index.html'))
   if (index.startsWith(SITE) && existsSync(index)) return index
   return null
@@ -446,7 +450,7 @@ describeBrowser('website browser accessibility smoke', () => {
     async function exerciseFailure(kind: 'abort' | 'status' | 'mime' | 'malformed' | 'active') {
       const context = await browser.newContext({ viewport: { width: 1280, height: 900 } })
       let attempts = 0
-      await context.route(/\/examples\/fragments\/style-palette-[a-f0-9]{12}\.html$/, async route => {
+      await context.route(/\/examples\/fragments\/style-palette-[a-f0-9]{12}$/, async route => {
         attempts++
         if (attempts > 1) { await route.continue(); return }
         if (kind === 'abort') await route.abort('failed')
@@ -483,7 +487,7 @@ describeBrowser('website browser accessibility smoke', () => {
     page.on('request', request => { if (new URL(request.url()).origin !== baseUrl) thirdPartyRequests.push(request.url()) })
     await page.goto(baseUrl + '/examples/', { waitUntil: 'networkidle' })
     const section = page.locator('[data-example-fragment][data-example-kind="style-palette"]')
-    await section.evaluate(element => element.setAttribute('data-example-fragment', 'https://example.com/examples/fragments/style-palette-deadbeefdead.html'))
+    await section.evaluate(element => element.setAttribute('data-example-fragment', 'https://example.com/examples/fragments/style-palette-deadbeefdead'))
     await section.locator('[data-example-load]').click()
     await page.waitForFunction(() => document.querySelector('[data-example-fragment][data-example-kind="style-palette"]')?.getAttribute('data-example-state') === 'failed')
     expect(thirdPartyRequests).toEqual([])
@@ -492,7 +496,7 @@ describeBrowser('website browser accessibility smoke', () => {
 
   test('Examples preserves ordinary navigation when interception or browser APIs are unavailable', async () => {
     const failedContext = await browser.newContext({ viewport: { width: 1280, height: 900 } })
-    await failedContext.route(/\/examples\/fragments\/style-palette-[a-f0-9]{12}\.html$/, route => route.abort('failed'))
+    await failedContext.route(/\/examples\/fragments\/style-palette-[a-f0-9]{12}$/, route => route.abort('failed'))
     const failedPage = await failedContext.newPage()
     await failedPage.goto(baseUrl + '/examples/', { waitUntil: 'networkidle' })
     await failedPage.locator('a[data-example-deferred="style-palette"]').first().click()

--- a/src/__tests__/website-build.test.ts
+++ b/src/__tests__/website-build.test.ts
@@ -55,7 +55,7 @@ function examplesCatalogHtml() {
 }
 
 function exampleFragmentRels(index = read('examples/index.html')) {
-  return Array.from(index.matchAll(/data-example-fragment="\/([^"]+)"/g), match => match[1]!)
+  return Array.from(index.matchAll(/data-example-fragment="\/([^"]+)"/g), match => `${match[1]!}.html`)
 }
 
 function editorExampleIds() {
@@ -340,13 +340,14 @@ describe('Workers Static Assets website contract', () => {
     ]))
     for (const rel of emittedHashedAssets) {
       const contentType = rel.endsWith('.html') ? 'text/html' : rel.endsWith('.woff2') ? 'font/woff2' : rel.endsWith('.css') ? 'text/css' : 'text/javascript'
-      const asset = await worker.fetch(new Request(`https://agentic-mermaid.dev/${rel}`), env(() => new Response('asset', { headers: { 'content-type': contentType } })))
+      const requestRel = rel.startsWith('examples/fragments/') ? rel.replace(/\.html$/, '') : rel
+      const asset = await worker.fetch(new Request(`https://agentic-mermaid.dev/${requestRel}`), env(() => new Response('asset', { headers: { 'content-type': contentType } })))
       expect({ rel, cache: asset.headers.get('cache-control') }).toEqual({ rel, cache: 'public, max-age=31536000, immutable' })
       if (rel.startsWith('examples/fragments/')) expect(asset.headers.get('x-robots-tag'), rel).toBe('noindex, nofollow')
     }
 
     for (const [pathname, response] of [
-      ['/examples/fragments/corpus-deadbeefdead.html', new Response('missing', { status: 404, headers: { 'content-type': 'text/html' } })],
+      ['/examples/fragments/corpus-deadbeefdead', new Response('missing', { status: 404, headers: { 'content-type': 'text/html' } })],
       ['/editor/editor-abcdef123456.js', new Response('broken', { status: 500, headers: { 'content-type': 'text/javascript' } })],
       ['/editor/editor-abcdef123456.js', new Response('<!doctype html>', { headers: { 'content-type': 'text/html' } })],
       ['/editor/editor-abcdef123456.js', new Response('export {}', { headers: { 'content-type': 'text/javascript', 'set-cookie': 'session=unexpected' } })],
@@ -864,6 +865,7 @@ describe('Workers Static Assets website contract', () => {
     const corpusPage = read('examples/corpus/index.html')
     const fragments = exampleFragmentRels(index)
     expect(fragments).toHaveLength(2)
+    expect(index).not.toMatch(/data-example-fragment="[^"]+\.html"/)
     expect(fragments).toEqual(expect.arrayContaining([
       expect.stringMatching(/^examples\/fragments\/style-palette-[a-f0-9]{12}\.html$/),
       expect.stringMatching(/^examples\/fragments\/corpus-[a-f0-9]{12}\.html$/),

--- a/src/__tests__/website-cache-policy.test.ts
+++ b/src/__tests__/website-cache-policy.test.ts
@@ -20,8 +20,8 @@ describe('website static asset cache authority', () => {
       ['/editor/editor-app-abcdef123456.js', 'application/javascript'],
       ['/editor/editor-renderer-abcdef123456.js', 'text/javascript'],
       ['/vendor/mermaid-abcdef123456.min.js', 'text/javascript'],
-      ['/examples/fragments/style-palette-abcdef123456.html', 'text/html; charset=utf-8'],
-      ['/examples/fragments/corpus-abcdef123456.html', 'text/html'],
+      ['/examples/fragments/style-palette-abcdef123456', 'text/html; charset=utf-8'],
+      ['/examples/fragments/corpus-abcdef123456', 'text/html'],
       ['/examples-abcdef123456.js', 'text/javascript'],
       ['/examples-abcdef123456.css', 'text/css'],
       ['/generated/inline-abcdef123456.js', 'text/javascript'],
@@ -48,7 +48,7 @@ describe('website static asset cache authority', () => {
     expect(classify({ contentType: '' })).toBe('no-store')
     expect(classify({ hasSetCookie: true })).toBe('no-store')
 
-    const fragment = '/examples/fragments/corpus-deadbeefdead.html'
+    const fragment = '/examples/fragments/corpus-deadbeefdead'
     expect(classify({ pathname: fragment, status: 404, contentType: 'text/html' })).toBe('no-store')
     expect(classify({ pathname: fragment, status: 500, contentType: 'text/html' })).toBe('no-store')
   })
@@ -57,6 +57,7 @@ describe('website static asset cache authority', () => {
     expect(classify({ pathname: '/editor/editor-short.js' })).toBe('public, max-age=3600')
     expect(classify({ pathname: '/editor/editor-abcdef12345g.js' })).toBe('public, max-age=3600')
     expect(classify({ pathname: '/fonts/Inter-Regular.subset.woff2', contentType: 'font/woff2' })).toBe('public, max-age=3600')
+    expect(classify({ pathname: '/examples/fragments/corpus-abcdef123456.html', contentType: 'text/html' })).toBe('no-cache')
     expect(classify({ pathname: '/styles.css', contentType: 'text/css' })).toBe('public, max-age=3600')
     expect(classify({ pathname: '/styles.css', contentType: 'text/css', method: 'POST' })).toBe('no-store')
     expect(classify({ pathname: '/styles.css', contentType: 'text/css', hasSetCookie: true })).toBe('no-store')

--- a/website/build.ts
+++ b/website/build.ts
@@ -974,14 +974,14 @@ ${examples.map((example) => {
     .map(([id, canonical]) => exampleAliasTarget(id, 'corpus', canonical, '/examples/corpus/')).join('\n')
   const script = `<script src="/${EXAMPLES_LOADER_REL}" defer></script>`
   const deferred = `${styleAliases}\n${corpusCurrentAliases}\n${corpusLegacyAliases}
-<section class="example-deferred" data-example-kind="style-palette" data-example-fragment="/${styleFragment.rel}" data-example-state="idle" aria-labelledby="examples-style-palette-deferred-title">
+<section class="example-deferred" data-example-kind="style-palette" data-example-fragment="/${styleFragment.rel.replace(/\.html$/, '')}" data-example-state="idle" aria-labelledby="examples-style-palette-deferred-title">
   <h2 id="examples-style-palette-deferred-title">Style × Palette combinations</h2>
   <p>The complete rendered matrix is available on its standalone page and can also load here on request.</p>
   <p data-example-status role="status" aria-live="polite">Examples are not loaded yet.</p>
   <div class="example-deferred-actions"><button type="button" data-example-load hidden>Load examples</button><a href="/examples/style-palette/">Open complete Style × Palette page</a></div>
   <div data-example-content></div>
 </section>
-<section class="example-deferred" data-example-kind="corpus" data-example-fragment="/${corpusFragment.rel}" data-example-state="idle" aria-labelledby="examples-corpus-deferred-title">
+<section class="example-deferred" data-example-kind="corpus" data-example-fragment="/${corpusFragment.rel.replace(/\.html$/, '')}" data-example-state="idle" aria-labelledby="examples-corpus-deferred-title">
   <h2 id="examples-corpus-deferred-title">Rich shared example gallery</h2>
   <p>The full project corpus remains searchable and linkable on a stable standalone page.</p>
   <p data-example-status role="status" aria-live="polite">Examples are not loaded yet.</p>

--- a/website/source/assets/examples.js
+++ b/website/source/assets/examples.js
@@ -70,7 +70,7 @@
     var fragmentUrl;
     try {
       fragmentUrl = new URL(url, location.href);
-      var expectedPath = new RegExp('^/examples/fragments/' + kind + '-[a-f0-9]{12}\\.html$');
+      var expectedPath = new RegExp('^/examples/fragments/' + kind + '-[a-f0-9]{12}$');
       if (fragmentUrl.origin !== location.origin || fragmentUrl.search || fragmentUrl.hash || !expectedPath.test(fragmentUrl.pathname)) throw new Error('invalid example fragment URL');
     } catch (error) {
       setState(section, 'failed');

--- a/website/src/worker-core.ts
+++ b/website/src/worker-core.ts
@@ -98,7 +98,7 @@ const IMMUTABLE_CACHE = 'public, max-age=31536000, immutable'
 type ImmutableAssetRule = Readonly<{ path: RegExp, contentTypes: readonly string[] }>
 const IMMUTABLE_ASSET_RULES: readonly ImmutableAssetRule[] = Object.freeze([
   Object.freeze({ path: /^\/(?:editor\/editor-(?:(?:app|renderer)-)?[a-f0-9]{12}|vendor\/mermaid-[a-f0-9]{12}\.min)\.js$/i, contentTypes: ['text/javascript', 'application/javascript'] }),
-  Object.freeze({ path: /^\/examples\/fragments\/(?:style-palette|corpus)-[a-f0-9]{12}\.html$/i, contentTypes: ['text/html'] }),
+  Object.freeze({ path: /^\/examples\/fragments\/(?:style-palette|corpus)-[a-f0-9]{12}$/i, contentTypes: ['text/html'] }),
   Object.freeze({ path: /^\/(?:examples|generated\/inline)-[a-f0-9]{12}\.js$/i, contentTypes: ['text/javascript', 'application/javascript'] }),
   Object.freeze({ path: /^\/examples-[a-f0-9]{12}\.css$/i, contentTypes: ['text/css'] }),
   Object.freeze({ path: /^\/fonts\/Inter-(?:Regular|Medium|SemiBold|Bold)\.subset-[a-f0-9]{12}\.woff2$/i, contentTypes: ['font/woff2'] }),
@@ -150,7 +150,7 @@ function withHeaders(response: Response, pathname: string, method: string, negot
   if (typeEssence === 'text/html') headers.set('Content-Security-Policy', csp)
 
   if (/\.(json|md|txt)$/i.test(pathname)) headers.set('Access-Control-Allow-Origin', '*')
-  if (/^\/examples\/fragments\/(?:style-palette|corpus)-[a-f0-9]{12}\.html$/i.test(pathname)) {
+  if (/^\/examples\/fragments\/(?:style-palette|corpus)-[a-f0-9]{12}$/i.test(pathname)) {
     headers.set('X-Robots-Tag', 'noindex, nofollow')
   }
   headers.set('Cache-Control', classifyWebsiteAssetCache({


### PR DESCRIPTION
Closes #214.

## What

Use Cloudflare’s canonical extensionless HTML-asset URL for content-hashed Examples fragments while retaining the emitted `.html` file in the build output. Align the loader’s closed URL admission, success-only immutable-cache rule, `X-Robots-Tag`, browser server projection, tests, live verifier, and exact payload report with that one public path.

## Why

The post-deploy probe added by #215 found a production-only mismatch. Cloudflare HTML handling redirects a requested fragment such as:

```text
/examples/fragments/corpus-5779e15f7a89.html
```

with `307` to:

```text
/examples/fragments/corpus-5779e15f7a89
```

The loader follows that redirect and still renders the fragment, but the redirect is `no-store` and the final response was only `no-cache`. That violated #214’s success-only immutable-cache acceptance criterion even though functional browser tests passed locally.

## Reproduction

Against the #215 deployment:

```bash
curl -sSI https://agentic-mermaid.dev/examples/fragments/corpus-5779e15f7a89.html \
  | grep -iE 'HTTP/|location:|cache-control:'
curl -sSI https://agentic-mermaid.dev/examples/fragments/corpus-5779e15f7a89 \
  | grep -iE 'HTTP/|content-type:|cache-control:'
```

The first request returns `307` to the extensionless path; the final successful response is not immutable. After this PR is deployed, the loader requests the extensionless URL directly and the Worker classifies only that exact successful `text/html` path as immutable. The old extensionful path remains unpromoted.

Post-deploy confirmation:

```bash
bun run website
bun run scripts/site/verify-live-examples-delivery.ts
```

The probe checks exact live/local bytes and hashes, GET/HEAD status and MIME, immutable caching, no `Set-Cookie`, fragment `X-Robots-Tag`, standalone canonicals, and nonexistent-hash rejection. Production success is intentionally not claimed before deployment.

## Tests

- `bun run test` — **6,825 pass, 48 browser-opt-in skips, 0 fail**.
- `AM_BROWSER_TESTS=1 bun test src/__tests__/website-browser-a11y.test.ts --timeout 600000` — **27 pass, 519 assertions**.
- `bun run website:payload:check` — exact report, graph, and budgets pass.
- `bun run website:check`; `bunx tsc --noEmit`; `git diff --check` — pass.
- `bash .agents/skills/good-pr/scripts/check-pr-readiness.sh main` — all checks pass.

The focused regression asserts generated loader URLs are extensionless, real Chromium fetches those URLs through the local Cloudflare projection, successful extensionless fragments are immutable, and the old `.html` public shape is not promoted.

## Payload and risk

- Examples remains 6 requests; exact totals are 380,391 raw / 66,938 gzip / 53,183 Brotli bytes.
- Homepage and blank-editor request graphs and every byte ceiling remain unchanged.
- No UI, corpus, renderer, Editor, deep-link, or no-JS behavior changes. This is a narrow production transport/cache correction discovered by the intentionally fail-closed live verifier.
