### PR TITLE
fix(release): publish the verified local tarball

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -176,7 +176,7 @@ jobs:
         # runs after OIDC becomes available. A retry after an ambiguous remote
         # success accepts only the byte-identical immutable registry version.
         env:
-          TARBALL: release-artifact/package.tgz
+          TARBALL: ./release-artifact/package.tgz
         run: |
           package_json="$(tar --extract --gzip --file "$TARBALL" --to-stdout package/package.json)"
           package_name="$(printf '%s' "$package_json" | jq -er '.name | select(. == "agentic-mermaid")')"

--- a/src/__tests__/agent-readiness-standards.test.ts
+++ b/src/__tests__/agent-readiness-standards.test.ts
@@ -154,7 +154,7 @@ describe('agent-readiness standards syntax', () => {
     expect(verifyStep?.run).toContain(".filename' release-artifact/package-manifest.json)\" = package.tgz")
     expect(verifyStep?.run).toContain("printf '%s  package.tgz\\n' \"$manifest_sha\" | cmp --silent")
     const npmPublishStep = publishSteps.find((step: any) => step.name === 'Publish or recover the exact npm tarball (OIDC trusted publishing)')
-    expect(npmPublishStep?.env?.TARBALL).toBe('release-artifact/package.tgz')
+    expect(npmPublishStep?.env?.TARBALL).toBe('./release-artifact/package.tgz')
     expect(npmPublishStep?.run).toContain('npm publish "$TARBALL" --ignore-scripts --access public')
     expect(npmPublishStep?.run).toContain('npm view "$package_name@$package_version" dist.integrity --json')
     expect(npmPublishStep?.run).toContain('registry_integrity" = "$local_integrity')


### PR DESCRIPTION
Closes #223.

## What

Make the credentialed npm publication step pass an explicitly local tarball path:

```diff
- TARBALL: release-artifact/package.tgz
+ TARBALL: ./release-artifact/package.tgz
```

The workflow-shape contract now pins that exact value.

## Why

The first `v0.2.0` publication run ([30054299723](https://github.com/adewale/agentic-mermaid/actions/runs/30054299723)) passed exact release identity, canonical-CI attestation, macOS/Windows smoke, package construction, the closed 116-file manifest, artifact transfer, SHA-256, and SHA-512 verification. npm then interpreted the bare relative argument as GitHub shorthand and attempted:

```text
git ls-remote ssh://git@github.com/release-artifact/package.tgz.git
```

Publication therefore failed before upload; npm `0.2.0` remains absent and MCP publication was correctly skipped. The GitHub Release was returned to draft.

The leading `./` makes npm select its local-tarball path grammar without changing any verified bytes, OIDC permission, artifact boundary, or retry behavior.

## Reproduction

The failed workflow log records exit 128 and the `git ls-remote` command above. The corrected shape succeeds locally without contacting the registry:

```bash
npm publish ./am-pr199-pack-final/package.tgz \
  --dry-run --ignore-scripts --json
```

Result: `agentic-mermaid@0.2.0`, exactly 116 files.

## Tests

- Red: after changing only the expectation, the focused workflow contract failed with expected `./release-artifact/package.tgz`, received `release-artifact/package.tgz`.
- Green: `bun test src/__tests__/agent-readiness-standards.test.ts --timeout 120000 -t 'local and CI own source gates'` — 1 passed.
- `bun run test` — 6,849 passed, 48 browser-opt-in skips, 0 failed.
- npm local-tarball dry run — 116 files, version `0.2.0`.
- Good PR readiness and `git diff --check` — pass.

## Risk

This is a two-line workflow/test correction. It does not alter package contents, lifecycle-script policy, job-scoped OIDC, registry recovery, MCP publication, product code, or rendered output. No visual evidence is applicable.

After merge-ref CI passes, the draft `v0.2.0` release will be retargeted to the fixed merge commit and republished. npm vacancy will be reconfirmed first.
