### PR TITLE
Fix brace-expansion security override

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -32,7 +32,7 @@
     },
   },
   "overrides": {
-    "brace-expansion": "5.0.7",
+    "brace-expansion": "5.0.8",
     "esbuild": "0.28.1",
     "fast-uri": "3.1.4",
     "lodash-es": "4.18.1",
@@ -446,7 +446,7 @@
 
     "body-parser": ["body-parser@2.3.0", "", { "dependencies": { "bytes": "^3.1.2", "content-type": "^2.0.0", "debug": "^4.4.3", "http-errors": "^2.0.1", "iconv-lite": "^0.7.2", "on-finished": "^2.4.1", "qs": "^6.15.2", "raw-body": "^3.0.2", "type-is": "^2.1.0" } }, "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw=="],
 
-    "brace-expansion": ["brace-expansion@5.0.7", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA=="],
+    "brace-expansion": ["brace-expansion@5.0.8", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg=="],
 
     "browserslist": ["browserslist@4.28.2", "", { "dependencies": { "baseline-browser-mapping": "^2.10.12", "caniuse-lite": "^1.0.30001782", "electron-to-chromium": "^1.5.328", "node-releases": "^2.0.36", "update-browserslist-db": "^1.2.3" }, "bin": { "browserslist": "cli.js" } }, "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg=="],
 

--- a/package.json
+++ b/package.json
@@ -190,7 +190,7 @@
     "yaml": "^2.8.3"
   },
   "overrides": {
-    "brace-expansion": "5.0.7",
+    "brace-expansion": "5.0.8",
     "esbuild": "0.28.1",
     "fast-uri": "3.1.4",
     "lodash-es": "4.18.1",


### PR DESCRIPTION
## What

Update the repository override from `brace-expansion@5.0.7` to `brace-expansion@5.0.8`.

## Why

The pinned `5.0.7` release is affected by high-severity advisory `GHSA-mh99-v99m-4gvg`, so `bun audit --audit-level=high` fails on `main`. The package enters the development graph through `@stryker-mutator/core` → `minimatch`; `minimatch@10.2.5` already accepts `brace-expansion@^5.0.5`.

## How

Change only:

- the override in `package.json`;
- the matching override, resolved version, and integrity checksum in `bun.lock`.

No dependency is added, and no production or rendering code changes.

## Reproduction and verification

At base commit `c5924e24521cc04c180d3fbd2fd2787cd4b1c81d`, `bun run audit:dependencies` reports `brace-expansion <=5.0.7`. On this branch:

```text
$ bun pm why brace-expansion
brace-expansion@5.0.8
  └─ minimatch@10.2.5 (requires ^5.0.5)
     └─ @stryker-mutator/core@9.6.1 (requires ~10.2.4)
        └─ dev agentic-mermaid
```

`bun run audit:dependencies` now exits successfully.

## Testing

- [x] `bun run test` — 6,841 passed, 56 skipped, 0 failed; 339,679 assertions across 403 files.
- [x] `bun run quality:check` — all 11 CI-parity checks passed.
- [x] Dependency audit — no high or critical advisory.
- [x] Rendered corpus — 462 diagrams, 1,848 format audits, 0 hard/soft defects, 0 render errors.
- [x] `git diff --check`.

There is no visible output change, so screenshots are not applicable.

## Risk

Low. The change updates one transitive development dependency within `minimatch`'s declared range. The frozen install, full test suite, security audit, generated-evidence checks, renderer corpus, lint, typecheck, website/Worker artifacts, hero freshness, and golden-drift check all pass.

## Checklist

- [x] Tests pass locally (`bun run test`) and the CI-parity quality suite passes (`bun run quality:check`).
- [x] Golden snapshots were not changed.
- [x] No diagram family was added.