### PR TITLE
Upgrade Ruff to 0.16.0

### DIFF
--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -1,0 +1,16 @@
+name: Ruff
+
+on:
+  pull_request:
+  push:
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: astral-sh/setup-uv@v9.0.0
+      - run: uvx ruff@0.16.0 check scripts/interop/probe-python.py scripts/site/subset-website-inter-fonts.py

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,4 @@
+required-version = "==0.16.0"
+
+[lint]
+ignore = ["EXE001", "SIM117"]

--- a/scripts/interop/probe-python.py
+++ b/scripts/interop/probe-python.py
@@ -14,10 +14,10 @@ import sys
 from importlib.metadata import version
 from pathlib import Path
 
-import mcp
-from mcp import ClientSession, StdioServerParameters
 from mcp.client.stdio import stdio_client
 from mcp.client.streamable_http import streamablehttp_client
+
+from mcp import ClientSession, StdioServerParameters
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 FLOW = "flowchart LR\n  A --> B"


### PR DESCRIPTION
## Summary

- Pin Ruff to exactly 0.16.0 with required-version.
- Apply the expanded Ruff defaults to the two Python interoperability and font-subsetting scripts.
- Fix the safe findings and document narrow compatibility exceptions.
- Add a dedicated GitHub Actions lint gate using setup-uv v9.

## Why

Ruff 0.16 enables 413 rules by default, up from 59. Pinning prevents surprise toolchain drift while adopting those stronger checks intentionally.

## Testing

- uvx ruff@0.16.0 check on both Python scripts
- Python compilation
- PR readiness check against main

## Risk

Low. Changes are lint-driven cleanups plus CI and configuration. Repository-specific exceptions are explicit in ruff.toml, and no runtime behaviour change is intended.