### PR TITLE
Finalize the v0.3.1 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This changelog tracks user-facing changes for **Agentic Mermaid**, a fork of `lu
 
 ## Unreleased
 
+## 0.3.1 — 2026-07-27
+
 ### Added
 - Added the framework-neutral `agentic-mermaid/browser/lazy` ESM entry with async, per-built-in-family SVG loading, shared on-demand ELK, exact all-family parity tests, and raw/gzip/Brotli/request-count build budgets.
 


### PR DESCRIPTION
## What

Finalize the changelog entry for v0.3.1 by dating the already-reviewed BUILD-31 changes.

## Why

The package, server metadata, and documentation already identify the next release as v0.3.1 after #230, but the corresponding changelog entries still say `Unreleased`. The published release notes should match the exact version that the release workflow validates.

## How

- Add the `0.3.1 — 2026-07-27` release heading above the existing BUILD-31 entries.
- Keep an empty `Unreleased` section ready for subsequent work.

## Testing

- `bun run lint`
- `git diff --check`
- No runtime behavior changes; exact-commit CI will run again after merge before the release is tagged.

## Risk

Documentation-only. The remaining release risk is tagging the wrong commit; the release workflow mitigates that with exact-SHA CI and tag/package-version gates.

Related: #230
