### PR TITLE
Fix hosted PNG verifier bootstrap

### DIFF
--- a/scripts/verify-hosted-png-e2e.ts
+++ b/scripts/verify-hosted-png-e2e.ts
@@ -1,3 +1,7 @@
+// This standalone helper exercises the complete synchronous runtime. Keep the
+// graphical core registry-neutral for browser-lazy consumers and install the
+// built-in family resolver explicitly at this full-runtime entry point.
+import '../src/agent/families.ts'
 import { inspectPngColorProfile, inspectPngDimensions, OUTPUT_COLOR_PROFILE } from '../src/output-color-profile.ts'
 import { PNG_WASM_RUNTIME } from '../src/png-contract.ts'
 import { renderPortablePngGraphicalProjection } from '../src/png-graphical.ts'

--- a/src/__tests__/png-output-options-contract.test.ts
+++ b/src/__tests__/png-output-options-contract.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from 'bun:test'
+import { spawnSync } from 'node:child_process'
 import { readFileSync } from 'node:fs'
 import { join } from 'node:path'
 
@@ -13,6 +14,7 @@ import {
   PNG_OUTPUT_POLICY_VERSION,
   PNG_OUTPUT_OPTION_FIELDS,
   PNG_OUTPUT_OPTION_FIELD_DESCRIPTORS,
+  PNG_WASM_RUNTIME,
   PORTABLE_PNG_OUTPUT_OPTION_FIELDS,
   normalizePortablePngBackground,
   omitPngOutputOptions,
@@ -177,6 +179,44 @@ describe('canonical PNG output-option authority', () => {
       seed: 13,
     })
     expect(validateMcpToolArguments(createRenderPngTool('hosted'), args)).toEqual([])
+  })
+
+  test('the hosted PNG parity helper bootstraps built-in families in a fresh process', () => {
+    const source = 'flowchart LR\n  A[Start 漢] --> B[Finish]'
+    const rendered = renderMermaidPNGWithReceipt(source, {
+      style: ['watercolor', 'paper'],
+      seed: 13,
+      padding: 19,
+      security: 'strict',
+      scale: 0.75,
+      background: '#123456',
+      fitTo: { width: 96 },
+      onWarning: () => {},
+    })
+    const response = {
+      result: {
+        content: [{
+          text: JSON.stringify({
+            ok: true,
+            png_base64: Buffer.from(rendered.png).toString('base64'),
+            receipt: rendered.receipt,
+            runtime: PNG_WASM_RUNTIME,
+            warnings: [{ code: 'PNG_FONT_COVERAGE', script: 'Han' }],
+          }),
+        }],
+      },
+    }
+    const result = spawnSync('bun', [
+      'run',
+      join(import.meta.dir, '..', '..', 'scripts', 'verify-hosted-png-e2e.ts'),
+    ], {
+      cwd: join(import.meta.dir, '..', '..'),
+      encoding: 'utf8',
+      input: JSON.stringify(response),
+    })
+
+    expect(result.status, result.stderr || result.stdout).toBe(0)
+    expect(result.stdout).toContain('ok   render_png enforces portable WASM parity (96x29, sRGB, receipt, runtime, font warning)')
   })
 
   test('MCP admission enforces the canonical fit and native-font shapes', () => {


### PR DESCRIPTION
## What & why

Make the standalone hosted PNG parity verifier install the complete built-in family registry before it calls the registry-neutral graphical core.

BUILD-31 intentionally removed the eager family-registry dependency from the shared render path so the lazy browser entry can load one family at a time. `scripts/verify-hosted-png-e2e.ts` is a full-runtime consumer but still relied on that old transitive import. In a fresh process, `website/e2e-mcp.sh` therefore accepted the production `render_png` response and then failed locally with `FAMILY_DESCRIPTOR_MISMATCH`.

This PR mirrors the explicit bootstrap already used by `src/index.ts`; it does not reintroduce the full registry into lazy or shared rendering. A subprocess regression feeds a valid PNG response envelope to the helper, so aggregate test import order cannot hide missing initialization.

No rendered output or shipped bundle changes; screenshots are not applicable.

## Testing

- [x] Focused PNG contract test passes (`bun test src/__tests__/png-output-options-contract.test.ts --timeout 30000`): 14 passed, 109 assertions.
- [x] Verified the new test fails with `FAMILY_DESCRIPTOR_MISMATCH` when the bootstrap import is removed.
- [x] Full test suite passes (`bun run test`): 6,912 passed, 48 skipped, 0 failed across 406 files.
- [x] CI-parity quality suite passes (`bun run quality:check`): 12 checks, including dependency audit, generated artifacts, 462-diagram audit, lint, typecheck, and golden-drift enforcement.
- [x] No committed golden snapshots changed.

## Risk

Low. The production renderer, shared graphical core, and lazy browser graph are unchanged. The only runtime change is an explicit full-registry import in a repository-only standalone verifier; the regression executes it in a fresh Bun process.
