### PR TITLE
fix(ci): resolve uploaded Worker versions correctly

### DIFF
--- a/.github/workflows/deploy-cloudflare.yml
+++ b/.github/workflows/deploy-cloudflare.yml
@@ -233,8 +233,10 @@ jobs:
             --strict \
             --tag "$EXPECTED_SHA" \
             --message "GitHub Actions run $GITHUB_RUN_ID for $EXPECTED_SHA"
-          candidate_id="$(jq -er --arg tag "$EXPECTED_SHA" \
-            'select(.type == "version-upload" and .worker_tag == $tag) | .version_id' "$output" | tail -n 1)"
+          # Wrangler's `worker_tag` output field is Cloudflare's opaque Worker
+          # identifier, not the annotation supplied by `--tag`.
+          candidate_id="$(bun run ../scripts/ci/resolve-wrangler-version-upload.ts \
+            "$output" agentic-mermaid-website)"
           versions="$(../node_modules/.bin/wrangler versions list --json)"
           jq -e --arg id "$candidate_id" --arg tag "$EXPECTED_SHA" \
             'any(.[]; .id == $id and .annotations["workers/tag"] == $tag)' <<<"$versions" >/dev/null

--- a/scripts/ci/resolve-wrangler-version-upload.ts
+++ b/scripts/ci/resolve-wrangler-version-upload.ts
@@ -1,0 +1,44 @@
+import { readFileSync } from 'node:fs'
+
+type WranglerOutputEntry = Record<string, unknown>
+
+function parseEntry(line: string, index: number): WranglerOutputEntry {
+  let value: unknown
+  try {
+    value = JSON.parse(line)
+  } catch (error) {
+    throw new Error(`Wrangler output line ${index + 1} is not valid JSON`, { cause: error })
+  }
+
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error(`Wrangler output line ${index + 1} is not a JSON object`)
+  }
+  return value as WranglerOutputEntry
+}
+
+export function resolveWranglerVersionUpload(ndjson: string, expectedWorkerName: string): string {
+  const entries = ndjson
+    .split(/\r?\n/)
+    .filter(line => line.trim() !== '')
+    .map(parseEntry)
+
+  const uploads = entries.filter(entry => entry.type === 'version-upload' && entry.version === 1 && entry.worker_name === expectedWorkerName)
+
+  if (uploads.length !== 1) {
+    throw new Error(`Expected exactly one Wrangler version-upload event for ${expectedWorkerName}; found ${uploads.length}`)
+  }
+
+  const versionId = uploads[0]!.version_id
+  if (typeof versionId !== 'string' || versionId.length === 0) {
+    throw new Error(`Wrangler version-upload event for ${expectedWorkerName} has no version_id`)
+  }
+  return versionId
+}
+
+if (import.meta.main) {
+  const [outputPath, expectedWorkerName] = process.argv.slice(2)
+  if (!outputPath || !expectedWorkerName) {
+    throw new Error('Usage: bun run scripts/ci/resolve-wrangler-version-upload.ts <output.ndjson> <worker-name>')
+  }
+  process.stdout.write(resolveWranglerVersionUpload(readFileSync(outputPath, 'utf8'), expectedWorkerName))
+}

--- a/src/__tests__/wrangler-version-upload.test.ts
+++ b/src/__tests__/wrangler-version-upload.test.ts
@@ -1,8 +1,11 @@
 import { describe, expect, test } from 'bun:test'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
 import { resolveWranglerVersionUpload } from '../../scripts/ci/resolve-wrangler-version-upload'
 
 const WORKER = 'agentic-mermaid-website'
 const VERSION_ID = '556b9e5c-895c-4b19-958b-964a90322a1d'
+const DEPLOY_WORKFLOW = readFileSync(join(import.meta.dir, '..', '..', '.github', 'workflows', 'deploy-cloudflare.yml'), 'utf8')
 
 describe('Wrangler version-upload output', () => {
   test('treats worker_tag as an opaque Cloudflare identifier', () => {
@@ -29,5 +32,10 @@ describe('Wrangler version-upload output', () => {
     expect(() => resolveWranglerVersionUpload('', WORKER)).toThrow('found 0')
     expect(() => resolveWranglerVersionUpload(`${event}\n${event}`, WORKER)).toThrow('found 2')
     expect(() => resolveWranglerVersionUpload(event, 'another-worker')).toThrow('found 0')
+  })
+
+  test('the production workflow delegates candidate resolution to the tested parser', () => {
+    expect(DEPLOY_WORKFLOW).toContain('bun run ../scripts/ci/resolve-wrangler-version-upload.ts')
+    expect(DEPLOY_WORKFLOW).not.toContain('.worker_tag == $tag')
   })
 })

--- a/src/__tests__/wrangler-version-upload.test.ts
+++ b/src/__tests__/wrangler-version-upload.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, test } from 'bun:test'
+import { resolveWranglerVersionUpload } from '../../scripts/ci/resolve-wrangler-version-upload'
+
+const WORKER = 'agentic-mermaid-website'
+const VERSION_ID = '556b9e5c-895c-4b19-958b-964a90322a1d'
+
+describe('Wrangler version-upload output', () => {
+  test('treats worker_tag as an opaque Cloudflare identifier', () => {
+    const output = JSON.stringify({
+      type: 'version-upload',
+      version: 1,
+      worker_name: WORKER,
+      worker_tag: 'opaque-worker-tag-that-is-not-the-git-sha',
+      version_id: VERSION_ID,
+    })
+
+    expect(resolveWranglerVersionUpload(output, WORKER)).toBe(VERSION_ID)
+  })
+
+  test('requires one unambiguous upload event for the expected worker', () => {
+    const event = JSON.stringify({
+      type: 'version-upload',
+      version: 1,
+      worker_name: WORKER,
+      worker_tag: 'opaque-worker-tag',
+      version_id: VERSION_ID,
+    })
+
+    expect(() => resolveWranglerVersionUpload('', WORKER)).toThrow('found 0')
+    expect(() => resolveWranglerVersionUpload(`${event}\n${event}`, WORKER)).toThrow('found 2')
+    expect(() => resolveWranglerVersionUpload(event, 'another-worker')).toThrow('found 0')
+  })
+})


### PR DESCRIPTION
## What & why

Repair the Cloudflare candidate-upload gate after the successful upload in [run 30305726806](https://github.com/adewale/agentic-mermaid/actions/runs/30305726806) exited before staging traffic.

Wrangler's machine output uses `worker_tag` for Cloudflare's opaque Worker identifier. The workflow incorrectly compared that field with the Git SHA supplied through `--tag`; that SHA actually lives in the uploaded version's `workers/tag` annotation. As a result, the upload succeeded but candidate-ID extraction returned no value.

## How

- Parse the dedicated Wrangler NDJSON file with a small checked helper that requires exactly one v1 `version-upload` event for `agentic-mermaid-website`.
- Continue to verify the extracted version against `versions list --json` and require its `workers/tag` annotation to equal the expected commit SHA.
- Bind the production workflow to the tested parser so reverting the workflow fix fails the regression test.

This does not change application code, package artifacts, Worker behavior, or production traffic policy.

## Testing

- `bun test src/__tests__/wrangler-version-upload.test.ts` — 3 pass.
- Verified the integration test fails when the workflow fix is reverted, then passes when restored.
- Biome checks pass for both added TypeScript files.
- The workflow parses as YAML and `git diff --check` passes.
- Local quality gates passed lint, typechecks, generated artifacts, evidence checks, and all 1,848 rendered-format audits. The aggregate command could not complete only its external Bun advisory request and Docker/Colima font-subset reproduction; GitHub CI will rerun both in its clean environment.
- [GitHub CI run 30313385530](https://github.com/adewale/agentic-mermaid/actions/runs/30313385530) passes every lane. One existing MCP stdio test timed out under coverage on its first runner and passed on the failed-job rerun; no code change was required.

## Risk

The change touches candidate identification in the production deployment workflow. It remains fail-closed: malformed, missing, duplicate, wrong-worker, or untagged upload results stop before traffic changes. The existing independent annotation lookup still proves that the candidate belongs to the exact expected Git SHA.

There is no visible output change, so screenshots are not applicable.

## Checklist

- [x] Full unit and CI-parity suites pass in GitHub Actions.
- [x] Targeted regression tests pass locally and fail when the production fix is reverted.
- [x] No committed golden snapshots changed.
- [x] No diagram family was added or changed.
