### PR TITLE
fix: pace production MCP deployment probe

### DIFF
--- a/.github/workflows/deploy-cloudflare.yml
+++ b/.github/workflows/deploy-cloudflare.yml
@@ -335,8 +335,11 @@ jobs:
         env:
           MCP_WORKER_NAME: agentic-mermaid-website
           MCP_WORKER_VERSION_ID: ${{ steps.candidate.outputs.candidate_id }}
+          MCP_REQUEST_INTERVAL_SECONDS: '2'
         # The exact gitSha poll above gates propagation. This no-retry probe then
         # asserts every tool, modern routing rule, and raw F3 transport body.
+        # Every request is paced to at most 30/minute: half the documented WAF
+        # budget, leaving rolling-window headroom for the preceding smoke test.
         run: bash website/e2e-mcp.sh https://agentic-mermaid.dev/mcp
 
       - name: Require target still current before promotion

--- a/src/__tests__/mcp-deploy-rate-budget.test.ts
+++ b/src/__tests__/mcp-deploy-rate-budget.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, test } from 'bun:test'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+const ROOT = join(import.meta.dir, '..', '..')
+const DEPLOY_WORKFLOW = readFileSync(join(ROOT, '.github', 'workflows', 'deploy-cloudflare.yml'), 'utf8')
+const E2E_PROBE = readFileSync(join(ROOT, 'website', 'e2e-mcp.sh'), 'utf8')
+
+describe('production MCP deployment probe rate budget', () => {
+  test('paces every request at no more than half the documented WAF budget', () => {
+    const interval = DEPLOY_WORKFLOW.match(/MCP_REQUEST_INTERVAL_SECONDS:\s*['"]?([\d.]+)['"]?/)?.[1]
+    expect(interval).toBeDefined()
+    expect(Number(interval)).toBe(2)
+    expect(60 / Number(interval)).toBeLessThanOrEqual(30)
+
+    const mcurl = E2E_PROBE.match(/mcurl\(\) \{([\s\S]*?)\n\}/)?.[1]
+    expect(mcurl).toContain('pace_request')
+    expect(E2E_PROBE).toContain('sleep "$MCP_REQUEST_INTERVAL_SECONDS"')
+  })
+})

--- a/website/README.md
+++ b/website/README.md
@@ -39,6 +39,8 @@ bun run website          # rebuild website/public + src/generated from website/s
 bun run website:check    # verify clean in-memory website + Worker artifact contracts
 bun run website:dev      # Wrangler dev server on port 9095
 bash website/e2e-mcp.sh  # end-to-end probe of /mcp against a running server
+# Against production, stay below the public WAF budget:
+MCP_REQUEST_INTERVAL_SECONDS=2 bash website/e2e-mcp.sh https://agentic-mermaid.dev/mcp
 ```
 
 Unit coverage: `src/__tests__/hosted-mcp.test.ts` (tool surface), `hosted-mcp-http.test.ts` (transport + caching), `hosted-execute-differential.test.ts` (hosted execute semantics pinned against the local vm sandbox).

--- a/website/e2e-mcp.sh
+++ b/website/e2e-mcp.sh
@@ -19,7 +19,18 @@ set -euo pipefail
 MCP="${1:-http://127.0.0.1:9095/mcp}"
 pass=0
 
+pace_request() {
+  # Production enables this fixed cadence so the exhaustive probe remains a
+  # legitimate client of the public WAF policy. Sleeping before the first
+  # request also leaves headroom for the smoke checks that immediately precede
+  # this script in the deployment workflow.
+  if [[ -n "${MCP_REQUEST_INTERVAL_SECONDS:-}" ]]; then
+    sleep "$MCP_REQUEST_INTERVAL_SECONDS"
+  fi
+}
+
 mcurl() {
+  pace_request
   if [[ -n "${MCP_WORKER_VERSION_ID:-}" ]]; then
     local worker_name="${MCP_WORKER_NAME:-agentic-mermaid-website}"
     curl -H "Cloudflare-Workers-Version-Overrides: ${worker_name}=\"${MCP_WORKER_VERSION_ID}\"" "$@"


### PR DESCRIPTION
## Problem

The guarded deployment from main successfully uploaded and attached its zero-traffic candidate, then the exhaustive MCP probe was blocked by the production WAF with Cloudflare error 1015. The failure happened after the preceding smoke probes and the first twelve exhaustive requests, so the workflow safely rolled back before promotion.

Failed deployment evidence: https://github.com/adewale/agentic-mermaid/actions/runs/30314915050

## Change

- funnel every exhaustive probe request through an optional fixed cadence
- configure production deployment probes at one request every two seconds, or at most 30 requests/minute
- sleep before the first exhaustive request so the preceding smoke probes have rolling-window headroom
- keep the probe no-retry and use no WAF bypass, so an actual policy refusal still blocks promotion
- document the production-safe manual command
- add a regression test coupling the workflow budget to the shared request funnel

Local development remains unpaced unless MCP_REQUEST_INTERVAL_SECONDS is set.

## Validation

- bun test src/__tests__/mcp-deploy-rate-budget.test.ts
- bash -n website/e2e-mcp.sh
- workflow YAML parse
- bun run lint:biome
- bun run lint:contracts
- git diff --check

## Deployment and compatibility

This changes only CI deployment orchestration, its probe, documentation, and tests. It does not change the package or public MCP behavior, so no package version bump is needed. The existing zero-traffic candidate, smoke gate, target-current gate, promotion, verification, and rollback steps remain intact.