### PR TITLE
fix: unify MCP deployment probe cadence

### DIFF
--- a/.github/workflows/deploy-cloudflare.yml
+++ b/.github/workflows/deploy-cloudflare.yml
@@ -55,6 +55,9 @@ jobs:
     env:
       WRANGLER_SEND_METRICS: 'false'
       EXPECTED_SHA: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || github.sha }}
+      # One shared cadence covers smoke, exhaustive, and post-promotion probes.
+      # 10 requests/minute leaves substantial rolling-window WAF headroom.
+      MCP_REQUEST_INTERVAL_SECONDS: '6'
     steps:
       - name: Check Cloudflare deployment secrets
         id: cloudflare-secrets
@@ -288,6 +291,7 @@ jobs:
         # part of this contract. The full-surface probe runs in the next step,
         # which depends on the SHA gate here having absorbed propagation lag.
         run: |
+          source scripts/ci/mcp-paced-curl.sh
           MCP='https://agentic-mermaid.dev/mcp'
           CARD='https://agentic-mermaid.dev/.well-known/mcp/server-card.json'
           OVERRIDE="Cloudflare-Workers-Version-Overrides: agentic-mermaid-website=\"${CANDIDATE_ID}\""
@@ -295,7 +299,7 @@ jobs:
             local attempt
             for attempt in 1 2 3 4 5; do
               local got served
-              got="$(curl -sS --max-time 30 -H "$OVERRIDE" -H 'cache-control: no-cache' "${CARD}?deploy=${EXPECTED_SHA}&attempt=${attempt}" || true)"
+              got="$(mcp_curl -sS --max-time 30 -H "$OVERRIDE" -H 'cache-control: no-cache' "${CARD}?deploy=${EXPECTED_SHA}&attempt=${attempt}" || true)"
               served="$(jq -r '.generatedFrom.gitSha // empty' <<<"$got" 2>/dev/null || true)"
               if [[ "$served" == "$EXPECTED_SHA" ]]; then
                 echo "ok   deployed build SHA is $EXPECTED_SHA"
@@ -311,7 +315,7 @@ jobs:
             local attempt
             for attempt in 1 2 3 4 5; do
               local got
-              got="$(curl -sS --max-time 30 -X POST "$MCP" -H "$OVERRIDE" -H 'content-type: application/json' -d "$2" || true)"
+              got="$(mcp_curl -sS --max-time 30 -X POST "$MCP" -H "$OVERRIDE" -H 'content-type: application/json' -d "$2" || true)"
               if [[ "$got" == *"$3"* ]]; then
                 echo "ok   $1"
                 return 0
@@ -335,11 +339,10 @@ jobs:
         env:
           MCP_WORKER_NAME: agentic-mermaid-website
           MCP_WORKER_VERSION_ID: ${{ steps.candidate.outputs.candidate_id }}
-          MCP_REQUEST_INTERVAL_SECONDS: '2'
         # The exact gitSha poll above gates propagation. This no-retry probe then
         # asserts every tool, modern routing rule, and raw F3 transport body.
-        # Every request is paced to at most 30/minute: half the documented WAF
-        # budget, leaving rolling-window headroom for the preceding smoke test.
+        # The job-wide shared cadence keeps every production-domain request at
+        # most 10/minute across phase boundaries, without a WAF bypass.
         run: bash website/e2e-mcp.sh https://agentic-mermaid.dev/mcp
 
       - name: Require target still current before promotion
@@ -374,13 +377,14 @@ jobs:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           CANDIDATE_ID: ${{ steps.candidate.outputs.candidate_id }}
         run: |
+          source scripts/ci/mcp-paced-curl.sh
           MCP='https://agentic-mermaid.dev/mcp'
           CARD='https://agentic-mermaid.dev/.well-known/mcp/server-card.json'
           for attempt in 1 2 3 4 5; do
-            card="$(curl -sS --max-time 30 -H 'cache-control: no-cache' "${CARD}?deploy=${EXPECTED_SHA}&promotion=${attempt}" || true)"
+            card="$(mcp_curl -sS --max-time 30 -H 'cache-control: no-cache' "${CARD}?deploy=${EXPECTED_SHA}&promotion=${attempt}" || true)"
             served="$(jq -r '.generatedFrom.gitSha // empty' <<<"$card" 2>/dev/null || true)"
-            verify="$(curl -sS --max-time 30 -X POST "$MCP" -H 'content-type: application/json' -d '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"verify","arguments":{"source":"flowchart TD\n  A --> B"}}}' || true)"
-            execute="$(curl -sS --max-time 30 -X POST "$MCP" -H 'content-type: application/json' -d '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"execute","arguments":{"code":"1 + 41"}}}' || true)"
+            verify="$(mcp_curl -sS --max-time 30 -X POST "$MCP" -H 'content-type: application/json' -d '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"verify","arguments":{"source":"flowchart TD\n  A --> B"}}}' || true)"
+            execute="$(mcp_curl -sS --max-time 30 -X POST "$MCP" -H 'content-type: application/json' -d '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"execute","arguments":{"code":"1 + 41"}}}' || true)"
             if [[ "$served" == "$EXPECTED_SHA" && "$verify" == *'"ok":true'* && "$execute" == *'"value":42'* ]]; then
               deployments="$(node_modules/.bin/wrangler --cwd website deployments list --json)"
               jq -e --arg candidate "$CANDIDATE_ID" '
@@ -393,7 +397,7 @@ jobs:
               echo "ok   $EXPECTED_SHA is verified at 100% production traffic"
               exit 0
             fi
-            echo "retry $attempt/5 promoted production verification (served: ${served:-unreadable})"
+            echo "retry $attempt/5 promoted production verification (served: ${served:-unreadable}; verify: ${verify:0:120}; execute: ${execute:0:120})"
             sleep $((attempt * 15))
           done
           echo "::error title=Promoted production verification failed::Rolling back from $EXPECTED_SHA."

--- a/scripts/ci/mcp-paced-curl.sh
+++ b/scripts/ci/mcp-paced-curl.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+# Shared request primitive for production-domain MCP deployment probes. Every
+# deployment phase sources this file so rolling WAF headroom survives phase
+# boundaries; sleeping before the first request prevents a new phase from
+# bursting immediately after the previous one.
+mcp_curl() {
+  if [[ -n "${MCP_REQUEST_INTERVAL_SECONDS:-}" ]]; then
+    sleep "$MCP_REQUEST_INTERVAL_SECONDS"
+  fi
+  curl "$@"
+}

--- a/src/__tests__/mcp-deploy-rate-budget.test.ts
+++ b/src/__tests__/mcp-deploy-rate-budget.test.ts
@@ -5,16 +5,35 @@ import { join } from 'node:path'
 const ROOT = join(import.meta.dir, '..', '..')
 const DEPLOY_WORKFLOW = readFileSync(join(ROOT, '.github', 'workflows', 'deploy-cloudflare.yml'), 'utf8')
 const E2E_PROBE = readFileSync(join(ROOT, 'website', 'e2e-mcp.sh'), 'utf8')
+const PACED_CURL = readFileSync(join(ROOT, 'scripts', 'ci', 'mcp-paced-curl.sh'), 'utf8')
 
 describe('production MCP deployment probe rate budget', () => {
-  test('paces every request at no more than half the documented WAF budget', () => {
+  test('paces every deployment phase through one conservative request primitive', () => {
     const interval = DEPLOY_WORKFLOW.match(/MCP_REQUEST_INTERVAL_SECONDS:\s*['"]?([\d.]+)['"]?/)?.[1]
     expect(interval).toBeDefined()
-    expect(Number(interval)).toBe(2)
-    expect(60 / Number(interval)).toBeLessThanOrEqual(30)
+    expect(Number(interval)).toBe(6)
+    expect(60 / Number(interval)).toBeLessThanOrEqual(10)
 
     const mcurl = E2E_PROBE.match(/mcurl\(\) \{([\s\S]*?)\n\}/)?.[1]
-    expect(mcurl).toContain('pace_request')
-    expect(E2E_PROBE).toContain('sleep "$MCP_REQUEST_INTERVAL_SECONDS"')
+    expect(E2E_PROBE).toContain('source "$REPO_ROOT/scripts/ci/mcp-paced-curl.sh"')
+    expect(mcurl).toContain('mcp_curl')
+    expect(PACED_CURL).toContain('sleep "$MCP_REQUEST_INTERVAL_SECONDS"')
+
+    expect(DEPLOY_WORKFLOW.match(/source scripts\/ci\/mcp-paced-curl\.sh/g)).toHaveLength(2)
+    expect(DEPLOY_WORKFLOW).toContain('got="$(mcp_curl')
+    expect(DEPLOY_WORKFLOW).toContain('card="$(mcp_curl')
+    expect(DEPLOY_WORKFLOW).toContain('verify="$(mcp_curl')
+    expect(DEPLOY_WORKFLOW).toContain('execute="$(mcp_curl')
+
+    const smoke = DEPLOY_WORKFLOW.slice(
+      DEPLOY_WORKFLOW.indexOf('- name: Smoke-test the zero-traffic candidate through production'),
+      DEPLOY_WORKFLOW.indexOf('- name: Probe the full zero-traffic /mcp candidate'),
+    )
+    const productionVerify = DEPLOY_WORKFLOW.slice(
+      DEPLOY_WORKFLOW.indexOf('- name: Verify the promoted production version'),
+      DEPLOY_WORKFLOW.indexOf('- name: Roll back any unverified deployment'),
+    )
+    expect(smoke).not.toContain('$(curl ')
+    expect(productionVerify).not.toContain('$(curl ')
   })
 })

--- a/website/README.md
+++ b/website/README.md
@@ -40,7 +40,7 @@ bun run website:check    # verify clean in-memory website + Worker artifact cont
 bun run website:dev      # Wrangler dev server on port 9095
 bash website/e2e-mcp.sh  # end-to-end probe of /mcp against a running server
 # Against production, stay below the public WAF budget:
-MCP_REQUEST_INTERVAL_SECONDS=2 bash website/e2e-mcp.sh https://agentic-mermaid.dev/mcp
+MCP_REQUEST_INTERVAL_SECONDS=6 bash website/e2e-mcp.sh https://agentic-mermaid.dev/mcp
 ```
 
 Unit coverage: `src/__tests__/hosted-mcp.test.ts` (tool surface), `hosted-mcp-http.test.ts` (transport + caching), `hosted-execute-differential.test.ts` (hosted execute semantics pinned against the local vm sandbox).

--- a/website/e2e-mcp.sh
+++ b/website/e2e-mcp.sh
@@ -16,26 +16,18 @@
 # a wall-clock backstop (execute-loader.ts).
 set -euo pipefail
 
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+source "$REPO_ROOT/scripts/ci/mcp-paced-curl.sh"
+
 MCP="${1:-http://127.0.0.1:9095/mcp}"
 pass=0
 
-pace_request() {
-  # Production enables this fixed cadence so the exhaustive probe remains a
-  # legitimate client of the public WAF policy. Sleeping before the first
-  # request also leaves headroom for the smoke checks that immediately precede
-  # this script in the deployment workflow.
-  if [[ -n "${MCP_REQUEST_INTERVAL_SECONDS:-}" ]]; then
-    sleep "$MCP_REQUEST_INTERVAL_SECONDS"
-  fi
-}
-
 mcurl() {
-  pace_request
   if [[ -n "${MCP_WORKER_VERSION_ID:-}" ]]; then
     local worker_name="${MCP_WORKER_NAME:-agentic-mermaid-website}"
-    curl -H "Cloudflare-Workers-Version-Overrides: ${worker_name}=\"${MCP_WORKER_VERSION_ID}\"" "$@"
+    mcp_curl -H "Cloudflare-Workers-Version-Overrides: ${worker_name}=\"${MCP_WORKER_VERSION_ID}\"" "$@"
   else
-    curl "$@"
+    mcp_curl "$@"
   fi
 }
 j() { mcurl -sS --max-time 30 -X POST "$MCP" -H 'content-type: application/json' -d "$1"; }


### PR DESCRIPTION
## Problem

PR #234 correctly paced the exhaustive zero-traffic MCP suite, and that suite passed in production. The following post-promotion verifier still used bare curl, however, so its verify/execute pair sat outside the same rolling WAF budget. The server card reached the promoted SHA, but those POST conditions never both passed; the workflow then rolled production back successfully.

Failed deployment evidence: https://github.com/adewale/agentic-mermaid/actions/runs/30316387252

This is a phase-boundary design error, not an MCP contract failure: upload, rollback arming, zero-traffic attachment, smoke, the complete candidate probe, target-current check, and promotion all passed.

## Change

- introduce one shared mcp_curl primitive for production-domain deployment probes
- route candidate smoke, the exhaustive suite, and post-promotion verification through it
- define one job-wide six-second cadence, limiting the deployment runner to at most 10 requests/minute continuously across phase boundaries
- sleep before each phase's first request so process boundaries cannot create a burst
- retain real WAF enforcement: no bypass credential/header and no retry in the exhaustive suite
- include bounded verify/execute response evidence in future final-verification retries
- strengthen the regression test so the smoke and final phases cannot regress to bare curl

## Validation

- bun test src/__tests__/mcp-deploy-rate-budget.test.ts
- bash -n scripts/ci/mcp-paced-curl.sh website/e2e-mcp.sh
- workflow YAML parse
- bun run lint:biome
- bun run lint:contracts
- git diff --check

## Deployment and compatibility

This changes deployment orchestration, tests, and documentation only. It does not change the npm package or the public MCP contract, so no version bump is needed. The previous deployment rolled back cleanly and production remains on 0.3.1 until this exact change passes CI and the guarded transaction succeeds.