### PR TITLE
Harden MCP scope and conformance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,12 +124,37 @@ jobs:
         # focused regressions and the canonical corpus gate actually bite.
         run: bun run sabotage:routes
 
+  mcp-conformance:
+    name: MCP conformance
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.13
+          no-cache: true
+
+      - name: Setup Node for the official conformance CLI
+        uses: actions/setup-node@v7
+        with:
+          node-version: 24
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Run pinned official MCP conformance scenarios
+        run: bun run eval:mcp-conformance
+
   # Preserve the existing required check name while the work behind it runs in
   # parallel. always() turns a failed or cancelled prerequisite into a failed
   # aggregate gate instead of a misleading skipped check.
   test:
     runs-on: ubuntu-latest
-    needs: [unit, quality, route-sabotage]
+    needs: [unit, quality, route-sabotage, mcp-conformance]
     if: ${{ always() }}
 
     steps:
@@ -169,9 +194,10 @@ jobs:
           UNIT_RESULT: ${{ needs.unit.result }}
           QUALITY_RESULT: ${{ needs.quality.result }}
           SABOTAGE_RESULT: ${{ needs['route-sabotage'].result }}
+          MCP_CONFORMANCE_RESULT: ${{ needs['mcp-conformance'].result }}
         run: |
-          if [[ "$UNIT_RESULT" != "success" || "$QUALITY_RESULT" != "success" || "$SABOTAGE_RESULT" != "success" ]]; then
-            echo "unit=$UNIT_RESULT quality=$QUALITY_RESULT route-sabotage=$SABOTAGE_RESULT"
+          if [[ "$UNIT_RESULT" != "success" || "$QUALITY_RESULT" != "success" || "$SABOTAGE_RESULT" != "success" || "$MCP_CONFORMANCE_RESULT" != "success" ]]; then
+            echo "unit=$UNIT_RESULT quality=$QUALITY_RESULT route-sabotage=$SABOTAGE_RESULT mcp-conformance=$MCP_CONFORMANCE_RESULT"
             exit 1
           fi
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ This changelog tracks user-facing changes for **Agentic Mermaid**, a fork of `lu
 
 ## Unreleased
 
+### Added
+- Added a pinned official MCP conformance CI lane for the current `2025-11-25` initialize path and the applicable `2026-07-28` release-candidate discovery, tool-list, HTTP-header, caching, and stateless scenarios. Its strict expected-failure baseline contains only probes that require unadvertised optional methods or harness-only diagnostic tools; new failures and stale baseline entries both fail CI.
+- Added a committed MCP protocol-input matrix covering required per-request metadata, header mirrors, request-id correlation, version/transport boundaries, batch rules, notification silence, and unadvertised methods. The response corpus now records those negative wire contracts explicitly.
+- Expanded the skill benchmark from 31 to 39 cases, including direct hosted tool selection, schema-error recovery, hosted-size fallback, underspecified quality goals, and a repository-grounded MCP scope audit. Every case now carries domain, difficulty, trigger-type, and success-goal taxonomy, and the manifest audit reports no prompt/assertion leakage.
+
+### Changed
+- MCP discovery and initialization now advertise a tools-only capability surface. The server no longer claims empty prompt or resource namespaces, and unadvertised `prompts/list`, `resources/list`, and `resources/templates/list` calls return Method Not Found instead of synthetic empty results.
+- Protocol revision claims are now transport-exact: hosted Streamable HTTP serves `2025-03-26`, `2025-06-18`, `2025-11-25`, and the `2026-07-28` release candidate; local stdio omits batch-mandatory `2025-03-26`; and local HTTP+SSE remains `2024-11-05` only. `server/discover` and unsupported-version errors report the same exact list.
+- Layout comparison reports both example-weighted and family-balanced adverse rates, so a large flowchart sample cannot hide a regression in a small family. The Mermaid documentation corpus now records its exact upstream commit, sample counts, and legacy 12-family scope instead of implying complete registry coverage.
+
+### Fixed
+- Unsupported protocol-version errors are now emitted after the bounded request parse so they preserve a valid JSON-RPC request id and include the retryable supported-version list. Modern requests with missing required `_meta` fields use `-32602`; only actual header/body disagreements use `-32020`.
+- Modern caching hints are emitted only for implemented cacheable list methods (`server/discover` and `tools/list`), keeping discovery, handlers, and cache metadata consistent.
+- Replaced a CLI TTY-guard test that could block on the aggregate runner's inherited stdin with a bounded end-to-end subprocess using an explicitly closed pipe.
+
 ## 0.3.3 — 2026-07-28
 
 ### Changed

--- a/docs/contributing/lessons-learned.md
+++ b/docs/contributing/lessons-learned.md
@@ -8,6 +8,54 @@ date; do not delete old ones — supersede them in place.
 > long-form fork narrative and major-PR retrospectives, see
 > [`../project/lessons-learned.md`](../project/lessons-learned.md).
 
+## 2026-07 — MCP scope honesty and conformance
+
+**Protocol compliance belongs to a surface and transport, not to a shared
+dispatcher.** The dispatcher understood five revisions, but the local stdio
+transport could not receive the batches required by `2025-03-26`, and the
+hosted POST-only endpoint could not honestly claim the `2024-11-05` HTTP+SSE
+transport. Rule: advertise the intersection of message semantics, transport
+obligations, and implemented handlers. Test each transport's advertised version
+list independently; shared code is not evidence that every caller serves the
+same protocol.
+
+**An empty optional namespace is still a capability claim.** Returning empty
+`prompts/list` and `resources/list` results while advertising both capabilities
+made clients and conformance probes reasonably treat those methods as product
+surface. Rule: omit optional capabilities that the product does not implement,
+and return Method Not Found for their methods. Do not add fake empty handlers or
+diagnostic tools merely to make a generic harness look greener.
+
+**A protocol error that answers a parsed request must preserve its id.** The
+hosted endpoint rejected an unsupported protocol header before reading the body,
+so it returned `id: null` even when the request carried a valid id. Rule: keep
+transport refusals before parsing, but perform request-level version admission
+after a bounded body read. Invalid modern metadata is `-32602`; a real
+header/body mirror disagreement is `-32020`; an unsupported revision is
+`-32022` with the correlated request id and retryable supported-version list.
+
+**Official conformance needs a strict applicability boundary.** The upstream
+caching scenario probes prompts and resources even when discovery omits them,
+and several stateless checks require specially named diagnostic tools. Rule:
+commit a narrow expected-failure baseline only for demonstrably inapplicable
+fixtures, fail on every unlisted failure, and also fail when a baseline entry
+unexpectedly passes. Product discovery must remain more honest than the test
+fixture.
+
+**Eval volume, provenance, and answer leakage are separate quality axes.** A
+271-example documentation corpus was dominated by flowcharts, aggregate layout
+rates could hide a one-example family regression, and literal prompt phrases
+appeared in output assertions. Rule: publish family-macro and example-micro
+rates together, pin corpus commit/count provenance, state known family skew, tag
+every agent case for slice reporting, and replace answer-shaped keyword checks
+with structural or artifact assertions.
+
+**A test must not inherit an input that its own comment says may hang.** The
+TTY guard's positive-control case called `readFileSync(0)` inside the aggregate
+runner and could wait forever on the runner's open stdin. Rule: give blocking
+input paths a real bounded subprocess pipe and close it explicitly; a timeout
+comment is not an oracle.
+
 ## 2026-07 — hosted MCP production rollout (#228, #233–#236)
 
 **Treat production promotion as a transaction.** The first workflow could report

--- a/eval/agent-usage/README.md
+++ b/eval/agent-usage/README.md
@@ -153,14 +153,14 @@ The no-docs baseline fails canonical serialization every time; every
 doc-bearing surface fixes it. At equal outcome the homepage/start.md surface was
 the cheapest doc-bearing surface. Single-model harness, n=3: direction, not magnitudes.
 
-Known blind spots of the stored case set: it measures task success and
-response shape on fully specified tasks. It does not yet measure discovery
-cost (turns/tokens spent before the first productive call), underspecified-task
-handling (does the agent ask instead of guessing when placeholders are left
-unreplaced), or repo-grounding honesty (are architecture claims traceable to
-inspected source). A variant comparison cannot detect regressions on an axis
-with no cases — add adversarial cases for those axes before trusting a
-comparison on them.
+Known blind spots of this stored Code Mode case set: it measures task success
+and response shape on fully specified tasks, but still does not measure
+discovery cost (turns/tokens spent before the first productive call). The
+companion `skill-evals/shared-benchmark.json` now carries adversarial
+underspecified-task and repository-grounded MCP scope cases, so those axes can
+be measured in multi-turn coding-agent runs rather than forced into this
+single-response JavaScript harness. A variant comparison cannot support a
+discovery-cost claim until its runner records that pre-productive-call metric.
 
 Run deterministic layers: `bun run eval/agent-usage/harness.ts`
 Run stored Code Mode eval: `bun run eval/agent-usage/run.ts`

--- a/eval/layout-compare/run.ts
+++ b/eval/layout-compare/run.ts
@@ -102,6 +102,22 @@ export interface Comparison {
   after: SampleResult | undefined
 }
 
+export interface FamilyComparisonSummary {
+  family: string
+  samples: number
+  adverse: number
+  adverseRate: number
+  counts: Record<Verdict, number>
+}
+
+export interface FamilyBalancedSummary {
+  families: FamilyComparisonSummary[]
+  /** Every family contributes equally, regardless of corpus size. */
+  macroAdverseRate: number
+  /** Every sample contributes equally; retained to expose corpus skew. */
+  microAdverseRate: number
+}
+
 const LEGIBILITY_EPS = 0.01
 
 export function compareSample(before: SampleResult | undefined, after: SampleResult | undefined): Comparison {
@@ -167,11 +183,39 @@ export function compareSnapshots(before: Snapshot, after: Snapshot): Comparison[
   return [...ids].map(id => compareSample(byId.get(id), afterById.get(id)))
 }
 
+/** Report both sample-weighted and family-weighted outcomes. The docs corpus is
+ * intentionally source-faithful rather than balanced (flowchart has far more
+ * examples than journey/pie), so raw totals alone can conceal a complete
+ * regression in a small family. */
+export function summarizeComparisonsByFamily(comparisons: readonly Comparison[]): FamilyBalancedSummary {
+  const byFamily = new Map<string, Comparison[]>()
+  for (const comparison of comparisons) {
+    const rows = byFamily.get(comparison.family) ?? []
+    rows.push(comparison)
+    byFamily.set(comparison.family, rows)
+  }
+  const verdicts: readonly Verdict[] = ['status-changed', 'regression', 'improvement', 'changed', 'unchanged']
+  const families = [...byFamily.entries()]
+    .sort(([a], [b]) => compareCodePointStrings(a, b))
+    .map(([family, rows]) => {
+      const counts = Object.fromEntries(verdicts.map(verdict => [verdict, rows.filter(row => row.verdict === verdict).length])) as Record<Verdict, number>
+      const adverse = counts['status-changed'] + counts.regression
+      return { family, samples: rows.length, adverse, adverseRate: adverse / rows.length, counts }
+    })
+  const totalAdverse = families.reduce((sum, family) => sum + family.adverse, 0)
+  return {
+    families,
+    macroAdverseRate: families.length === 0 ? 0 : families.reduce((sum, family) => sum + family.adverseRate, 0) / families.length,
+    microAdverseRate: comparisons.length === 0 ? 0 : totalAdverse / comparisons.length,
+  }
+}
+
 const VERDICT_ORDER: Record<Verdict, number> = { 'status-changed': 0, regression: 1, improvement: 2, changed: 3, unchanged: 4 }
 
 export function buildReportHtml(before: Snapshot, after: Snapshot): string {
   const comparisons = compareSnapshots(before, after).sort((a, b) =>
     VERDICT_ORDER[a.verdict] - VERDICT_ORDER[b.verdict] || compareCodePointStrings(a.id, b.id))
+  const balanced = summarizeComparisonsByFamily(comparisons)
   const counts = new Map<Verdict, number>()
   for (const c of comparisons) counts.set(c.verdict, (counts.get(c.verdict) ?? 0) + 1)
 
@@ -200,6 +244,13 @@ export function buildReportHtml(before: Snapshot, after: Snapshot): string {
   const summary = (['status-changed', 'regression', 'improvement', 'changed', 'unchanged'] as Verdict[])
     .map(v => `<li><strong>${counts.get(v) ?? 0}</strong> ${v}</li>`).join('')
 
+  const familyRows = balanced.families.map(family => `<tr>
+    <td>${esc(family.family)}</td><td>${family.samples}</td>
+    <td>${family.counts['status-changed']}</td><td>${family.counts.regression}</td>
+    <td>${family.counts.improvement}</td><td>${family.counts.changed}</td><td>${family.counts.unchanged}</td>
+    <td>${(family.adverseRate * 100).toFixed(1)}%</td>
+  </tr>`).join('')
+
   return `<!doctype html>
 <html><head><meta charset="utf-8"><title>Layout comparison: ${esc(before.label)} → ${esc(after.label)}</title>
 <style>
@@ -219,12 +270,20 @@ export function buildReportHtml(before: Snapshot, after: Snapshot): string {
   .improvement .badge { background: #e3f7ef; }
   .family { font-size: 12px; color: #777; }
   .notes { color: #444; font-size: 13px; }
+  table { border-collapse: collapse; background: #fff; }
+  th, td { border: 1px solid #ddd; padding: 5px 8px; text-align: right; }
+  th:first-child, td:first-child { text-align: left; }
 </style></head>
 <body>
 <h1>Layout comparison</h1>
 <p><strong>${esc(before.label)}</strong> (${esc(before.rev)}, ${esc(before.createdAt)}) →
    <strong>${esc(after.label)}</strong> (${esc(after.rev)}, ${esc(after.createdAt)})</p>
 <ul>${summary}</ul>
+<p><strong>Family-balanced adverse rate:</strong> ${(balanced.macroAdverseRate * 100).toFixed(1)}%
+   (sample-weighted: ${(balanced.microAdverseRate * 100).toFixed(1)}%).</p>
+<details open><summary>Per-family outcomes</summary>
+<table><thead><tr><th>family</th><th>samples</th><th>status</th><th>regressions</th><th>improvements</th><th>changed</th><th>unchanged</th><th>adverse</th></tr></thead>
+<tbody>${familyRows}</tbody></table></details>
 <p>Unchanged samples are hidden. Verdicts: metric deltas use measureQuality
 (edge crossings, label legibility) plus node/edge-count faithfulness;
 "changed" means bytes differ with no metric movement.</p>

--- a/eval/mcp-conformance/README.md
+++ b/eval/mcp-conformance/README.md
@@ -1,0 +1,30 @@
+# MCP conformance gate
+
+This gate runs the official `@modelcontextprotocol/conformance` package at the
+exact version declared in `scripts/ci/mcp-conformance.ts`. It exercises the
+hosted handler on loopback, not the public deployment, so rate limiting or a CDN
+cannot hide a protocol regression.
+
+The selected scenarios cover the two real eras and the advertised product
+surface:
+
+- `server-initialize` at `2025-11-25` for the stable handshake path;
+- `tools-list` for the tools-only surface;
+- `http-header-validation`, `caching`, and `server-stateless` at `2026-07-28`.
+
+`expected-failures.yml` contains only checks the upstream harness cannot apply
+to this server. Three caching checks probe optional methods even when discovery
+does not advertise them. Four stateless checks require specially named
+diagnostic tools that are not product capabilities. Adding fake prompt,
+resource, streaming, logging, or capability tools merely to satisfy those
+fixtures would make discovery less honest.
+
+The baseline is strict: an unlisted failure fails CI, and an expected failure
+that unexpectedly passes is treated as stale baseline drift. Re-run with:
+
+```sh
+bun run eval:mcp-conformance
+```
+
+The production endpoint should remain a separate, paced smoke test. It is not a
+replacement for this deterministic protocol gate.

--- a/eval/mcp-conformance/expected-failures.yml
+++ b/eval/mcp-conformance/expected-failures.yml
@@ -1,0 +1,18 @@
+# The official harness exposes these checks through diagnostic fixtures that
+# are intentionally not part of agentic-mermaid's product surface. Entries are
+# scenario-qualified so any additional failure remains fatal, and an upstream
+# harness improvement that skips inapplicable checks turns into a stale-baseline
+# failure that must be reviewed.
+server:
+  # This tools-only server does not implement optional prompts/resources RPCs.
+  - caching:sep-2549-prompts-list-caching-hints
+  - caching:sep-2549-resources-list-caching-hints
+  - caching:sep-2549-resources-templates-list-caching-hints
+
+  # These checks require conformance-only tools named test_missing_capability,
+  # test_streaming_elicitation, and test_logging_tool. Shipping those fixtures
+  # would expand and misrepresent the public tool surface.
+  - server-stateless:sep-2575-server-rejects-undeclared-capability
+  - server-stateless:sep-2575-missing-capability-http-400
+  - server-stateless:sep-2575-http-server-no-independent-requests-on-stream
+  - server-stateless:sep-2575-server-no-log-without-loglevel

--- a/eval/mcp-protocol/README.md
+++ b/eval/mcp-protocol/README.md
@@ -1,0 +1,16 @@
+# MCP protocol input matrix
+
+`cases.json` is a committed set of transport and envelope mutations derived
+from the specification and the official conformance scenarios. It deliberately
+stores inputs and expected wire outcomes as data rather than generating them
+from the server implementation.
+
+The matrix emphasizes one-field failures: required `_meta` members, version and
+method header mirrors, request-id correlation, batching, notification silence,
+and optional-method scope. A legacy positive control prevents an over-strict
+modern validator from making every case pass by rejecting everything.
+
+When the protocol or official suite changes, update the provenance and each
+affected expectation explicitly. The consuming unit test validates unique case
+names and requires both success and failure cases so the input set cannot
+quietly collapse into a one-sided rejection suite.

--- a/eval/mcp-protocol/cases.json
+++ b/eval/mcp-protocol/cases.json
@@ -1,0 +1,104 @@
+{
+  "schemaVersion": 1,
+  "provenance": {
+    "protocolRevision": "2026-07-28",
+    "source": "MCP specification plus @modelcontextprotocol/conformance@0.2.0-alpha.10 server-stateless and http-header-validation scenarios",
+    "design": "Each negative case changes one protocol field or transport mirror from a conforming request. Expected outcomes are committed independently of the implementation."
+  },
+  "cases": [
+    {
+      "name": "missing-meta",
+      "mutation": "Remove params._meta",
+      "headers": { "mcp-protocol-version": "2026-07-28", "mcp-method": "tools/list" },
+      "body": { "jsonrpc": "2.0", "id": 101, "method": "tools/list", "params": {} },
+      "expected": { "status": 400, "id": 101, "errorCode": -32602 }
+    },
+    {
+      "name": "missing-protocol-version",
+      "mutation": "Remove io.modelcontextprotocol/protocolVersion from _meta",
+      "headers": { "mcp-protocol-version": "2026-07-28", "mcp-method": "tools/list" },
+      "body": { "jsonrpc": "2.0", "id": 102, "method": "tools/list", "params": { "_meta": { "io.modelcontextprotocol/clientCapabilities": {} } } },
+      "expected": { "status": 400, "id": 102, "errorCode": -32602 }
+    },
+    {
+      "name": "missing-client-capabilities",
+      "mutation": "Remove io.modelcontextprotocol/clientCapabilities from _meta",
+      "headers": { "mcp-protocol-version": "2026-07-28", "mcp-method": "tools/list" },
+      "body": { "jsonrpc": "2.0", "id": 103, "method": "tools/list", "params": { "_meta": { "io.modelcontextprotocol/protocolVersion": "2026-07-28" } } },
+      "expected": { "status": 400, "id": 103, "errorCode": -32602 }
+    },
+    {
+      "name": "mismatched-protocol-header",
+      "mutation": "Change MCP-Protocol-Version without changing _meta",
+      "headers": { "mcp-protocol-version": "2025-11-25", "mcp-method": "tools/list" },
+      "body": { "jsonrpc": "2.0", "id": 104, "method": "tools/list", "params": { "_meta": { "io.modelcontextprotocol/protocolVersion": "2026-07-28", "io.modelcontextprotocol/clientCapabilities": {} } } },
+      "expected": { "status": 400, "id": 104, "errorCode": -32020 }
+    },
+    {
+      "name": "missing-protocol-header",
+      "mutation": "Remove MCP-Protocol-Version from a modern request",
+      "headers": { "mcp-method": "tools/list" },
+      "body": { "jsonrpc": "2.0", "id": 105, "method": "tools/list", "params": { "_meta": { "io.modelcontextprotocol/protocolVersion": "2026-07-28", "io.modelcontextprotocol/clientCapabilities": {} } } },
+      "expected": { "status": 400, "id": 105, "errorCode": -32020 }
+    },
+    {
+      "name": "missing-method-header",
+      "mutation": "Remove Mcp-Method from a modern request",
+      "headers": { "mcp-protocol-version": "2026-07-28" },
+      "body": { "jsonrpc": "2.0", "id": 106, "method": "tools/list", "params": { "_meta": { "io.modelcontextprotocol/protocolVersion": "2026-07-28", "io.modelcontextprotocol/clientCapabilities": {} } } },
+      "expected": { "status": 400, "id": 106, "errorCode": -32020 }
+    },
+    {
+      "name": "missing-name-header",
+      "mutation": "Remove Mcp-Name from tools/call",
+      "headers": { "mcp-protocol-version": "2026-07-28", "mcp-method": "tools/call" },
+      "body": { "jsonrpc": "2.0", "id": 107, "method": "tools/call", "params": { "name": "verify", "arguments": { "source": "flowchart TD\n  A --> B" }, "_meta": { "io.modelcontextprotocol/protocolVersion": "2026-07-28", "io.modelcontextprotocol/clientCapabilities": {} } } },
+      "expected": { "status": 400, "id": 107, "errorCode": -32020 }
+    },
+    {
+      "name": "unsupported-version-correlates-id",
+      "mutation": "Replace MCP-Protocol-Version with an unsupported revision",
+      "headers": { "mcp-protocol-version": "2099-01-01", "mcp-method": "tools/list" },
+      "body": { "jsonrpc": "2.0", "id": 108, "method": "tools/list", "params": { "_meta": { "io.modelcontextprotocol/protocolVersion": "2026-07-28", "io.modelcontextprotocol/clientCapabilities": {} } } },
+      "expected": { "status": 400, "id": 108, "errorCode": -32022, "errorData": { "supported": ["2025-03-26", "2025-06-18", "2025-11-25", "2026-07-28"], "requested": "2099-01-01" } }
+    },
+    {
+      "name": "hosted-rejects-pre-streamable-http-revision",
+      "mutation": "Use the 2024-11-05 HTTP+SSE revision on the hosted Streamable HTTP endpoint",
+      "headers": { "mcp-protocol-version": "2024-11-05" },
+      "body": { "jsonrpc": "2.0", "id": 113, "method": "tools/list" },
+      "expected": { "status": 400, "id": 113, "errorCode": -32022, "errorData": { "supported": ["2025-03-26", "2025-06-18", "2025-11-25", "2026-07-28"], "requested": "2024-11-05" } }
+    },
+    {
+      "name": "modern-batch-rejected",
+      "mutation": "Wrap two conforming requests in a JSON-RPC batch",
+      "headers": { "mcp-protocol-version": "2026-07-28" },
+      "body": [
+        { "jsonrpc": "2.0", "id": 109, "method": "tools/list", "params": { "_meta": { "io.modelcontextprotocol/protocolVersion": "2026-07-28", "io.modelcontextprotocol/clientCapabilities": {} } } },
+        { "jsonrpc": "2.0", "id": 110, "method": "tools/list", "params": { "_meta": { "io.modelcontextprotocol/protocolVersion": "2026-07-28", "io.modelcontextprotocol/clientCapabilities": {} } } }
+      ],
+      "expected": { "status": 400, "id": null, "errorCode": -32600 }
+    },
+    {
+      "name": "malformed-modern-notification-is-silent",
+      "mutation": "Remove clientCapabilities and id from a modern request",
+      "headers": { "mcp-protocol-version": "2026-07-28", "mcp-method": "tools/list" },
+      "body": { "jsonrpc": "2.0", "method": "tools/list", "params": { "_meta": { "io.modelcontextprotocol/protocolVersion": "2026-07-28" } } },
+      "expected": { "status": 400, "emptyBody": true }
+    },
+    {
+      "name": "legacy-positive-control",
+      "mutation": "Use the pre-stateless request shape with no modern transport headers",
+      "headers": {},
+      "body": { "jsonrpc": "2.0", "id": 111, "method": "tools/list" },
+      "expected": { "status": 200, "id": 111, "hasResult": true }
+    },
+    {
+      "name": "unadvertised-resource-templates",
+      "mutation": "Probe an optional method omitted from discovery capabilities",
+      "headers": { "mcp-protocol-version": "2026-07-28", "mcp-method": "resources/templates/list" },
+      "body": { "jsonrpc": "2.0", "id": 112, "method": "resources/templates/list", "params": { "_meta": { "io.modelcontextprotocol/protocolVersion": "2026-07-28", "io.modelcontextprotocol/clientCapabilities": {} } } },
+      "expected": { "status": 404, "id": 112, "errorCode": -32601 }
+    }
+  ]
+}

--- a/eval/mermaid-docs-corpus/README.md
+++ b/eval/mermaid-docs-corpus/README.md
@@ -1,10 +1,17 @@
 # mermaid-docs corpus
 
-`corpus.json` is a curated set of `(family, source)` example diagrams mined
-from the mermaid-js documentation. It feeds the layout-compare harness
+`corpus.json` is the original 12-family set of `(family, source)` examples
+mined from Mermaid's syntax documentation. It feeds the layout-compare harness
 (`eval/layout-compare/run.ts`) and round-trip/verify checks. `divergences.json`
 is the executable ledger for docs examples that intentionally parse and
-round-trip while producing known verification warnings.
+round-trip while producing known verification warnings. `provenance.json`
+pins the exact upstream revision and records the family distribution.
+
+This corpus is not the complete registered-family inventory. Mindmap,
+GitGraph, and radar were enrolled later and are covered by the pinned upstream
+suite, their dedicated companion corpora/benches, and the one-per-family docs
+showcase. Keeping that boundary explicit prevents an old 12-family snapshot
+from being mistaken for exhaustive coverage.
 
 ## Regenerating
 
@@ -12,14 +19,34 @@ Regen is **networked** — it reads markdown from a local mermaid clone:
 
 ```sh
 git clone https://github.com/mermaid-js/mermaid /tmp/mermaid
+git -C /tmp/mermaid checkout a2d9686451df7c4644a3eeca20535bbd4c5776b0
 bun run eval/mermaid-docs-corpus/build-corpus.ts /tmp/mermaid
 ```
 
-The family map lives in `FILE_TO_FAMILY` in `build-corpus.ts`.
+The builder refuses an unpinned checkout. The family map lives in
+`FILE_TO_FAMILY` in `build-corpus.ts`; changing its scope requires an explicit
+corpus and provenance review.
 
 ## Refresh note
 
-The committed `corpus.json` was regenerated from `mermaid-js/mermaid` on
-2026-06-16 and now includes all currently registered renderable families,
-including pie and quadrant. Corpus entries are **never fabricated** — they only
-come from a real regen against upstream docs.
+The committed corpus contains 271 examples at the pinned revision:
+
+| Family | Examples |
+|---|---:|
+| flowchart | 111 |
+| class / sequence | 36 each |
+| er | 23 |
+| state | 20 |
+| timeline | 14 |
+| gantt | 11 |
+| xychart | 8 |
+| architecture | 6 |
+| quadrant | 3 |
+| pie | 2 |
+| journey | 1 |
+
+That imbalance mirrors upstream documentation volume. Reports derived from it
+must show per-family or macro-averaged outcomes alongside raw sample totals;
+otherwise flowcharts can drown out a total regression in journey or pie.
+Corpus entries are **never fabricated**—they come from the pinned upstream
+documents.

--- a/eval/mermaid-docs-corpus/build-corpus.ts
+++ b/eval/mermaid-docs-corpus/build-corpus.ts
@@ -1,8 +1,9 @@
-// Mine mermaid-js source docs for example diagrams across supported docs
-// families. Output: eval/mermaid-docs-corpus/corpus.json — a curated set
+// Mine mermaid-js source docs for the original twelve-family docs corpus.
+// Output: eval/mermaid-docs-corpus/corpus.json — a curated set
 // of (family, source) pairs we can run through parse → verify → round-trip.
-// The committed corpus was fully regenerated from upstream docs on
-// 2026-06-16 and includes every registered renderable built-in family.
+// Newer registered families are covered by the companion corpora named in the
+// README; claiming this historical corpus alone is exhaustive would hide its
+// large family imbalance and later enrollment boundary.
 //
 // Run with: bun run eval/mermaid-docs-corpus/build-corpus.ts <path-to-mermaid-clone>
 //
@@ -10,6 +11,10 @@
 
 import { readdirSync, readFileSync, writeFileSync, existsSync } from 'node:fs'
 import { join } from 'node:path'
+import { execFileSync } from 'node:child_process'
+
+export const UPSTREAM_REPOSITORY = 'https://github.com/mermaid-js/mermaid'
+export const UPSTREAM_REVISION = 'a2d9686451df7c4644a3eeca20535bbd4c5776b0'
 
 const FILE_TO_FAMILY: Record<string, string> = {
   'flowchart.md': 'flowchart',
@@ -35,6 +40,14 @@ export interface CorpusEntry {
   source: string
   origin: string
   index: number
+}
+
+function checkoutRevision(mermaidRepo: string): string {
+  try {
+    return execFileSync('git', ['-C', mermaidRepo, 'rev-parse', 'HEAD'], { encoding: 'utf8' }).trim()
+  } catch {
+    throw new Error(`cannot read upstream git revision from ${mermaidRepo}`)
+  }
 }
 
 export function buildCorpus(mermaidRepo: string): CorpusEntry[] {
@@ -63,11 +76,30 @@ if (import.meta.main) {
     console.error('Clone with: git clone --depth 1 https://github.com/mermaid-js/mermaid /tmp/mermaid')
     process.exit(1)
   }
+  const revision = checkoutRevision(repo)
+  if (revision !== UPSTREAM_REVISION) {
+    console.error(`wrong Mermaid revision: expected ${UPSTREAM_REVISION}, got ${revision}`)
+    console.error(`Run: git -C ${repo} checkout ${UPSTREAM_REVISION}`)
+    process.exit(1)
+  }
   const corpus = buildCorpus(repo)
   const out = join(import.meta.dir, 'corpus.json')
   writeFileSync(out, JSON.stringify(corpus, null, 2))
   const byFamily: Record<string, number> = {}
   for (const e of corpus) byFamily[e.family] = (byFamily[e.family] || 0) + 1
+  writeFileSync(join(import.meta.dir, 'provenance.json'), JSON.stringify({
+    schemaVersion: 1,
+    upstream: { repository: UPSTREAM_REPOSITORY, revision },
+    scope: 'Original twelve-family Mermaid syntax-document corpus; not the complete registered-family inventory.',
+    entries: corpus.length,
+    familyCounts: Object.fromEntries(Object.entries(byFamily).sort()),
+    companions: [
+      'eval/mermaid-upstream-suite-bench',
+      'eval/mindmap-gitgraph-content-corpus',
+      'eval/mermaid-radar-bench',
+      'eval/mermaid-doc-showcase',
+    ],
+  }, null, 2) + '\n')
   console.log(`Wrote ${corpus.length} examples to ${out}`)
   for (const [f, n] of Object.entries(byFamily).sort()) console.log(`  ${f}: ${n}`)
 }

--- a/eval/mermaid-docs-corpus/provenance.json
+++ b/eval/mermaid-docs-corpus/provenance.json
@@ -1,0 +1,29 @@
+{
+  "schemaVersion": 1,
+  "upstream": {
+    "repository": "https://github.com/mermaid-js/mermaid",
+    "revision": "a2d9686451df7c4644a3eeca20535bbd4c5776b0"
+  },
+  "scope": "Original twelve-family Mermaid syntax-document corpus; not the complete registered-family inventory.",
+  "entries": 271,
+  "familyCounts": {
+    "architecture": 6,
+    "class": 36,
+    "er": 23,
+    "flowchart": 111,
+    "gantt": 11,
+    "journey": 1,
+    "pie": 2,
+    "quadrant": 3,
+    "sequence": 36,
+    "state": 20,
+    "timeline": 14,
+    "xychart": 8
+  },
+  "companions": [
+    "eval/mermaid-upstream-suite-bench",
+    "eval/mindmap-gitgraph-content-corpus",
+    "eval/mermaid-radar-bench",
+    "eval/mermaid-doc-showcase"
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -168,6 +168,7 @@
     "lint:contracts": "bun test src/__tests__/agent-substrate-lint.test.ts src/__tests__/test-quality-lint.test.ts",
     "eval:agent-live": "bun run eval/agent-usage/live.ts",
     "eval:agent-subagent": "bun run eval/agent-usage/capture-subagent-prompt-eval.ts",
+    "eval:mcp-conformance": "bun run scripts/ci/mcp-conformance.ts",
     "eval:degenerate-routes": "bun run eval/degenerate-etn/enumerate.ts",
     "rubric:visual": "bun run eval/visual-rubric/run.ts",
     "contact:sheet": "bun run eval/visual-rubric/contact-sheet.ts",

--- a/scripts/ci/mcp-conformance.ts
+++ b/scripts/ci/mcp-conformance.ts
@@ -1,0 +1,100 @@
+#!/usr/bin/env bun
+
+// Run the official MCP conformance CLI against the real hosted handler on a
+// loopback server. CI downloads one exact pre-release package; local audits may
+// point MCP_CONFORMANCE_BIN at an already-built dist/index.js.
+
+const CONFORMANCE_PACKAGE = '@modelcontextprotocol/conformance@0.2.0-alpha.10'
+const EXPECTED_FAILURES = 'eval/mcp-conformance/expected-failures.yml'
+
+interface Scenario {
+  readonly name: string
+  readonly specVersion: string
+  readonly baseline?: boolean
+}
+
+const SCENARIOS: readonly Scenario[] = [
+  { name: 'server-initialize', specVersion: '2025-11-25' },
+  { name: 'tools-list', specVersion: '2026-07-28' },
+  { name: 'http-header-validation', specVersion: '2026-07-28' },
+  { name: 'caching', specVersion: '2026-07-28', baseline: true },
+  { name: 'server-stateless', specVersion: '2026-07-28', baseline: true },
+]
+
+async function firstLine(stream: ReadableStream<Uint8Array>): Promise<string> {
+  const reader = stream.getReader()
+  const decoder = new TextDecoder()
+  let text = ''
+  try {
+    while (!text.includes('\n')) {
+      const next = await reader.read()
+      if (next.done) break
+      text += decoder.decode(next.value, { stream: true })
+    }
+  } finally {
+    reader.releaseLock()
+  }
+  return text.split(/\r?\n/, 1)[0] ?? ''
+}
+
+function conformanceCommand(): string[] {
+  const localBin = process.env.MCP_CONFORMANCE_BIN
+  return localBin
+    ? ['node', localBin]
+    : ['npx', '--yes', CONFORMANCE_PACKAGE]
+}
+
+async function startServer() {
+  const configuredPort = process.env.MCP_CONFORMANCE_PORT
+  const ports = configuredPort ? [configuredPort] : ['0', '43189', '43190', '43191']
+  for (const port of ports) {
+    const server = Bun.spawn(['bun', 'run', 'scripts/interop/serve-hosted.ts'], {
+      cwd: process.cwd(),
+      env: { ...process.env, INTEROP_PORT: port },
+      stdin: 'ignore',
+      stdout: 'pipe',
+      stderr: 'inherit',
+    })
+    let timeout: ReturnType<typeof setTimeout> | undefined
+    const url = await Promise.race([
+      firstLine(server.stdout),
+      new Promise<string>(resolve => {
+        timeout = setTimeout(() => resolve(''), 3_000)
+      }),
+    ])
+    if (timeout !== undefined) clearTimeout(timeout)
+    if (/^http:\/\/127\.0\.0\.1:\d+\/mcp$/.test(url)) return { server, url }
+    server.kill()
+    await server.exited
+  }
+  throw new Error(`local MCP server did not start on candidate ports: ${ports.join(', ')}`)
+}
+
+const { server, url } = await startServer()
+try {
+  for (const scenario of SCENARIOS) {
+    process.stdout.write(`\n==> MCP conformance: ${scenario.name} (${scenario.specVersion})\n`)
+    const args = [
+      ...conformanceCommand(),
+      'server',
+      '--url', url,
+      '--scenario', scenario.name,
+      '--spec-version', scenario.specVersion,
+      ...(scenario.baseline ? ['--expected-failures', EXPECTED_FAILURES] : []),
+    ]
+    const result = Bun.spawnSync(args, {
+      cwd: process.cwd(),
+      stdin: 'inherit',
+      stdout: 'inherit',
+      stderr: 'inherit',
+    })
+    if (result.exitCode !== 0) {
+      throw new Error(`official MCP conformance scenario failed: ${scenario.name}`)
+    }
+  }
+} finally {
+  server.kill()
+  await server.exited
+}
+
+process.stdout.write(`\nOfficial MCP conformance scenarios passed (${SCENARIOS.length}).\n`)

--- a/skill-evals/README.md
+++ b/skill-evals/README.md
@@ -8,10 +8,20 @@ The public tune split now includes:
 
 - Diagram families: every registry-declared built-in, via the manifest's
   `family:*` tags (enforced by the doc-sync test rather than copied here).
-- Channels: library, CLI, and MCP Code Mode.
+- Channels: library, CLI, hosted MCP direct tools, and MCP Code Mode.
+- Hosted MCP routing: direct `verify`/`describe`/`mutate`/`build` cases,
+  schema-error recovery through `describe_sdk`, and local fallback for inputs
+  beyond the hosted limit. A separate repository-grounding case requires scope
+  claims to cite inspected implementation files rather than generic MCP lore.
 - Negative/no-trigger rows for unrelated work.
-- Adversarial rows for source concatenation, skipping verify, editing generated `editor.html`, and using `type` instead of `kind`.
+- Adversarial rows for source concatenation, skipping verify, editing generated
+  `editor.html`, using `type` instead of `kind`, underspecified quality goals,
+  and oversized hosted inputs.
 - Fixture-backed artifact rows under [`fixtures/`](./fixtures/) that require changed Mermaid/source plus `verifyMermaid` evidence.
+- Every case is tagged by domain, difficulty, trigger type, and success goal so
+  aggregate pass rates can be sliced instead of hiding regressions in one
+  overall mean. Output assertions avoid repeating literal prompt clues; regex
+  checks are used where a structural relationship matters.
 
 The manifest also contains private `prompt_ref` stubs for `holdout` and `holdback`. Those paths are intentionally under ignored `skill-evals/private/`; keep real hidden prompts and answer keys out of public commits.
 
@@ -20,7 +30,7 @@ The manifest also contains private `prompt_ref` stubs for `holdout` and `holdbac
 Install/run with:
 
 ```bash
-uvx --from git+https://github.com/adewale/skill-eval-harness.git@v0.1.1 skill-benchmark --help
+uvx --from git+https://github.com/adewale/skill-eval-harness.git@v0.4.0 skill-benchmark --help
 ```
 
 Validate and audit the public manifest:

--- a/skill-evals/shared-benchmark.json
+++ b/skill-evals/shared-benchmark.json
@@ -4,7 +4,7 @@
   "harness": {
     "name": "skill-eval-harness",
     "url": "https://github.com/adewale/skill-eval-harness",
-    "version": ">=0.1.1"
+    "version": ">=0.4.0"
   },
   "skill_paths": [
     "skills/agentic-mermaid-diagram-workflow",
@@ -29,6 +29,10 @@
       "id": "pos-diagram-existing-flowchart-safe-edit",
       "split": "tune",
       "kind": "positive",
+      "domain": "diagram-editing",
+      "difficulty": "core",
+      "success_goals": ["outcome","process"],
+      "trigger_type": "explicit",
       "prompt": "A coding agent must edit an existing Mermaid flowchart using Agentic Mermaid. Give the safest workflow and a tiny code sketch for adding a Cache node between API and DB. Also name the main render output formats. Do not browse the repository; answer from any loaded skill if one is available.",
       "expected_behavior": [
         "Use parse -> narrow -> mutate -> verify -> serialize for existing structured diagrams.",
@@ -88,6 +92,10 @@
       "id": "pos-live-editor-source-of-truth",
       "split": "tune",
       "kind": "positive",
+      "domain": "editor-workflow",
+      "difficulty": "extended",
+      "success_goals": ["outcome","process"],
+      "trigger_type": "explicit",
       "prompt": "A coding agent must change Agentic Mermaid's live editor export behavior. What source-of-truth file should it edit, what generated artifact rule should it follow, and which export/output formats are relevant? Do not browse the repository; answer from any loaded skill if one is available.",
       "expected_behavior": [
         "Identify scripts/site/editor.ts as the source of truth.",
@@ -127,7 +135,11 @@
       "id": "pos-family-flowchart-library-fixture",
       "split": "tune",
       "kind": "positive",
-      "prompt": "Use the attached Mermaid fixture. With the Agentic Mermaid library channel, edit the existing flowchart so Cache sits between API and DB. Produce artifact files under outputs/flowchart-cache/final.mmd and outputs/flowchart-cache/verify.json, include their contents in your final answer, and show the exact verification evidence from verifyMermaid. Do not edit by source concatenation when a typed op exists.",
+      "domain": "diagram-authoring",
+      "difficulty": "extended",
+      "success_goals": ["outcome","process"],
+      "trigger_type": "explicit",
+      "prompt": "Use the attached Mermaid fixture. With the Agentic Mermaid library channel, edit the existing flowchart so a caching tier sits between API and DB. Produce artifact files under outputs/flowchart-cache/final.mmd and outputs/flowchart-cache/verify.json, include their contents in your final answer, and show the exact evidence from the library validator. Do not edit by source concatenation when a typed op exists.",
       "files": [
         "fixtures/flowchart-cache/input.mmd"
       ],
@@ -161,12 +173,8 @@
         },
         {
           "name": "cache-path",
-          "type": "contains_all",
-          "values": [
-            "API",
-            "Cache",
-            "DB"
-          ]
+          "type": "regex",
+          "pattern": "API\\s*--[^\\n]*>\\s*Cache[\\s\\S]*Cache\\s*--[^\\n]*>\\s*DB"
         },
         {
           "name": "kind-op",
@@ -186,7 +194,11 @@
       "id": "pos-family-sequence-code-mode-fixture",
       "split": "tune",
       "kind": "positive",
-      "prompt": "Use the attached Mermaid fixture. In MCP Code Mode style, show one execute(code) payload that parses the existing sequence diagram, narrows it, adds an API retry message before the final response, verifies, and serializes. Produce outputs/sequence-retry/final.mmd and outputs/sequence-retry/verify.json, include both contents in the final answer, and include the verification result. Use typed mutation where supported.",
+      "domain": "diagram-authoring",
+      "difficulty": "extended",
+      "success_goals": ["outcome","process","efficiency"],
+      "trigger_type": "explicit",
+      "prompt": "Use the attached Mermaid fixture. In one hosted sandbox call, parse the existing sequence diagram, narrow it, add an API recovery attempt before the final response, verify, and serialize. Produce outputs/sequence-retry/final.mmd and outputs/sequence-retry/verify.json, include both contents in the final answer, and include the verification result. Use typed mutation where supported.",
       "files": [
         "fixtures/sequence-retry/input.mmd"
       ],
@@ -228,11 +240,8 @@
         },
         {
           "name": "retry",
-          "type": "contains_any",
-          "values": [
-            "Retry",
-            "retry"
-          ]
+          "type": "regex",
+          "pattern": "add_message[\\s\\S]*(?:Retry|retry)"
         }
       ],
       "tags": [
@@ -247,7 +256,11 @@
       "id": "pos-family-timeline-cli-fixture",
       "split": "tune",
       "kind": "positive",
-      "prompt": "Use the attached Mermaid fixture. Use the CLI channel to add a Ship period under the Build section with an artifact event, verify it, and render at least one text or image output. Include the exact am mutate/am render command sketch, write outputs/timeline-release/final.mmd and outputs/timeline-release/verify.json, and include their contents in your final answer.",
+      "domain": "diagram-authoring",
+      "difficulty": "extended",
+      "success_goals": ["outcome","process"],
+      "trigger_type": "explicit",
+      "prompt": "Use the attached Mermaid fixture. Use the CLI channel to add a Ship period under the Build section with an artifact event, verify it, and render at least one text or image output. Include exact command sketches for the mutation and rendering steps, write outputs/timeline-release/final.mmd and outputs/timeline-release/verify.json, and include their contents in your final answer.",
       "files": [
         "fixtures/timeline-release/input.mmd"
       ],
@@ -305,7 +318,11 @@
       "id": "pos-family-class-library-fixture",
       "split": "tune",
       "kind": "positive",
-      "prompt": "Use the attached Mermaid fixture. With the library channel, add a Receipt class and a relation from PaymentService to Receipt, then verify and serialize. Write outputs/class-payment/final.mmd and outputs/class-payment/verify.json, include both contents in the final answer, and show Result.value handling.",
+      "domain": "diagram-authoring",
+      "difficulty": "extended",
+      "success_goals": ["outcome","process"],
+      "trigger_type": "explicit",
+      "prompt": "Use the attached Mermaid fixture. With the library channel, add a billing-record class and a relation from PaymentService to it, then verify and serialize. Write outputs/class-payment/final.mmd and outputs/class-payment/verify.json, include both contents in the final answer, and show Result.value handling.",
       "files": [
         "fixtures/class-payment/input.mmd"
       ],
@@ -359,7 +376,11 @@
       "id": "pos-family-er-library-fixture",
       "split": "tune",
       "kind": "positive",
-      "prompt": "Use the attached Mermaid fixture. With the library channel, add a PRODUCT entity with id/name attributes and relate ORDER to PRODUCT. Verify and serialize. Write outputs/er-orders/final.mmd and outputs/er-orders/verify.json, include both contents, and show the exact typed ops.",
+      "domain": "diagram-authoring",
+      "difficulty": "extended",
+      "success_goals": ["outcome","process"],
+      "trigger_type": "explicit",
+      "prompt": "Use the attached Mermaid fixture. With the library channel, add a catalog-item entity with id/name attributes and relate ORDER to it. Verify and serialize. Write outputs/er-orders/final.mmd and outputs/er-orders/verify.json, include both contents, and show the exact typed ops.",
       "files": [
         "fixtures/er-orders/input.mmd"
       ],
@@ -418,7 +439,11 @@
       "id": "pos-family-journey-library-fixture",
       "split": "tune",
       "kind": "positive",
-      "prompt": "Use the attached Mermaid fixture. With the library channel, add a Review order task in the Pay section of the existing journey diagram, then verify and serialize. Write outputs/journey-checkout/final.mmd and outputs/journey-checkout/verify.json, include both contents, and show the typed Journey mutation path.",
+      "domain": "diagram-authoring",
+      "difficulty": "extended",
+      "success_goals": ["outcome","process"],
+      "trigger_type": "explicit",
+      "prompt": "Use the attached Mermaid fixture. With the library channel, add an order-check task in the Pay section of the existing journey diagram, then verify and serialize. Write outputs/journey-checkout/final.mmd and outputs/journey-checkout/verify.json, include both contents, and show the typed Journey mutation path.",
       "files": [
         "fixtures/journey-checkout/input.mmd"
       ],
@@ -466,6 +491,10 @@
       "id": "pos-family-xychart-library-fixture",
       "split": "tune",
       "kind": "positive",
+      "domain": "diagram-authoring",
+      "difficulty": "extended",
+      "success_goals": ["outcome","process"],
+      "trigger_type": "explicit",
       "prompt": "Use the attached Mermaid fixture. With the library channel, add Apr with value 90 to the existing XY chart, then verify and serialize. Write outputs/xychart-growth/final.mmd and outputs/xychart-growth/verify.json, include both contents, and show the typed XY chart mutation path.",
       "files": [
         "fixtures/xychart-growth/input.mmd"
@@ -527,7 +556,11 @@
       "id": "pos-family-architecture-library-fixture",
       "split": "tune",
       "kind": "positive",
-      "prompt": "Use the attached Mermaid fixture. With the library channel, add a Cache service between API and Database in the existing architecture diagram, then verify and serialize. Write outputs/architecture-cache/final.mmd and outputs/architecture-cache/verify.json, include both contents, and show the typed Architecture mutation path.",
+      "domain": "diagram-authoring",
+      "difficulty": "extended",
+      "success_goals": ["outcome","process"],
+      "trigger_type": "explicit",
+      "prompt": "Use the attached Mermaid fixture. With the library channel, add a caching service between API and Database in the existing architecture diagram, then verify and serialize. Write outputs/architecture-cache/final.mmd and outputs/architecture-cache/verify.json, include both contents, and show the typed Architecture mutation path.",
       "files": [
         "fixtures/architecture-cache/input.mmd"
       ],
@@ -560,8 +593,8 @@
         },
         {
           "name": "cache",
-          "type": "contains",
-          "value": "Cache"
+          "type": "regex",
+          "pattern": "(?:service\\s+Cache|Cache\\s*\\[)"
         },
         {
           "name": "formats",
@@ -585,7 +618,11 @@
       "id": "pos-family-state-library-fixture",
       "split": "tune",
       "kind": "positive",
-      "prompt": "Use the attached Mermaid fixture. With the library channel, add a Failed state and a Processing -> Failed transition labeled error, then verify and serialize. Write outputs/state-lifecycle/final.mmd and outputs/state-lifecycle/verify.json, include both contents, and show the typed State mutation path.",
+      "domain": "diagram-authoring",
+      "difficulty": "extended",
+      "success_goals": ["outcome","process"],
+      "trigger_type": "explicit",
+      "prompt": "Use the attached Mermaid fixture. With the library channel, add an unsuccessful terminal state and a Processing transition into it with a failure label, then verify and serialize. Write outputs/state-lifecycle/final.mmd and outputs/state-lifecycle/verify.json, include both contents, and show the typed State mutation path.",
       "files": [
         "fixtures/state-lifecycle/input.mmd"
       ],
@@ -637,6 +674,10 @@
       "id": "pos-family-pie-library-fixture",
       "split": "tune",
       "kind": "positive",
+      "domain": "diagram-authoring",
+      "difficulty": "core",
+      "success_goals": ["outcome","process"],
+      "trigger_type": "explicit",
       "prompt": "Use the attached Mermaid fixture. With the library channel, add a PDF slice with value 10 to the existing pie chart, then verify and serialize. Write outputs/pie-exports/final.mmd and outputs/pie-exports/verify.json, include both contents, and show the typed Pie mutation path.",
       "files": [
         "fixtures/pie-exports/input.mmd"
@@ -688,7 +729,11 @@
       "id": "pos-family-quadrant-library-fixture",
       "split": "tune",
       "kind": "positive",
-      "prompt": "Use the attached Mermaid fixture. With the library channel, move the MCP setup point to [0.70, 0.40], then verify and serialize. Write outputs/quadrant-priorities/final.mmd and outputs/quadrant-priorities/verify.json, include both contents, and show the typed Quadrant mutation path.",
+      "domain": "diagram-authoring",
+      "difficulty": "extended",
+      "success_goals": ["outcome","process"],
+      "trigger_type": "explicit",
+      "prompt": "Use the attached Mermaid fixture. With the library channel, move the protocol-integration point to [0.70, 0.40], then verify and serialize. Write outputs/quadrant-priorities/final.mmd and outputs/quadrant-priorities/verify.json, include both contents, and show the typed Quadrant mutation path.",
       "files": [
         "fixtures/quadrant-priorities/input.mmd"
       ],
@@ -740,7 +785,11 @@
       "id": "pos-family-gantt-library-fixture",
       "split": "tune",
       "kind": "positive",
-      "prompt": "Use the attached Mermaid fixture. With the library channel, add a Docs task after the build task and before release, then verify and serialize. Write outputs/gantt-release/final.mmd and outputs/gantt-release/verify.json, include both contents, and show the typed Gantt mutation path.",
+      "domain": "diagram-authoring",
+      "difficulty": "extended",
+      "success_goals": ["outcome","process"],
+      "trigger_type": "explicit",
+      "prompt": "Use the attached Mermaid fixture. With the library channel, add a documentation task after the build task and before release, then verify and serialize. Write outputs/gantt-release/final.mmd and outputs/gantt-release/verify.json, include both contents, and show the typed Gantt mutation path.",
       "files": [
         "fixtures/gantt-release/input.mmd"
       ],
@@ -788,7 +837,11 @@
       "id": "pos-family-mindmap-library-fixture",
       "split": "tune",
       "kind": "positive",
-      "prompt": "Use the attached Mindmap fixture. Add a Validation child under Research with the typed library API, verify, and serialize. Write outputs/mindmap-product/final.mmd and outputs/mindmap-product/verify.json.",
+      "domain": "diagram-authoring",
+      "difficulty": "core",
+      "success_goals": ["outcome","process"],
+      "trigger_type": "explicit",
+      "prompt": "Use the attached Mindmap fixture. Add a pre-merge checking child under Research with the typed library API, verify, and serialize. Write outputs/mindmap-product/final.mmd and outputs/mindmap-product/verify.json.",
       "files": [
         "fixtures/mindmap-product/input.mmd"
       ],
@@ -825,7 +878,11 @@
       "id": "pos-family-gitgraph-library-fixture",
       "split": "tune",
       "kind": "positive",
-      "prompt": "Use the attached GitGraph fixture. Create a docs branch, append a commit, return to main, merge it, verify, and serialize with the typed library API. Write outputs/gitgraph-release/final.mmd and outputs/gitgraph-release/verify.json.",
+      "domain": "diagram-authoring",
+      "difficulty": "extended",
+      "success_goals": ["outcome","process"],
+      "trigger_type": "explicit",
+      "prompt": "Use the attached GitGraph fixture. Create a documentation branch, append a commit, return to main, merge it, verify, and serialize with the typed library API. Write outputs/gitgraph-release/final.mmd and outputs/gitgraph-release/verify.json.",
       "files": [
         "fixtures/gitgraph-release/input.mmd"
       ],
@@ -864,7 +921,11 @@
       "id": "pos-channel-mcp-code-mode-batch",
       "split": "tune",
       "kind": "positive",
-      "prompt": "Show the MCP Code Mode approach for a multi-step Agentic Mermaid edit: parse an existing flowchart, narrow, apply two typed mutations, verify once at the commit point, then return source plus an SVG render. The answer should be a concise execute(code) example and explain why Code Mode is preferable to several separate tool calls.",
+      "domain": "mcp-tool-selection",
+      "difficulty": "extended",
+      "success_goals": ["outcome","process","efficiency"],
+      "trigger_type": "explicit",
+      "prompt": "Show the hosted sandbox approach for a multi-step Agentic Mermaid edit: parse an existing flowchart, narrow, apply two typed mutations, validate once just before publishing, then return source plus an SVG render. The answer should be one concise sandbox-call example and explain why batching the logic is preferable to several separate tool calls.",
       "expected_behavior": [
         "Uses execute(code) and mermaid.* SDK names.",
         "Batches typed mutations before one verify-before-commit.",
@@ -909,10 +970,174 @@
       ]
     },
     {
+      "id": "pos-channel-mcp-direct-verify",
+      "split": "tune",
+      "kind": "positive",
+      "domain": "mcp-tool-selection",
+      "difficulty": "core",
+      "trigger_type": "explicit",
+      "success_goals": ["outcome", "efficiency"],
+      "prompt": "Using the hosted Agentic Mermaid MCP server, validate this existing flowchart and return its detected family and warnings. No editing, rendering, or custom JavaScript is needed. Choose the cheapest direct tool and show its arguments: `flowchart TD\\n  API --> DB`.",
+      "expected_behavior": [
+        "Calls the direct verify tool with source.",
+        "Does not route a simple verification through execute/Code Mode."
+      ],
+      "assertions": [
+        { "name": "direct-verify", "type": "contains_all", "values": ["verify", "source"] },
+        { "name": "no-execute", "type": "excludes_any", "values": ["execute(code)", "mermaid.execute", "name: 'execute'", "\"name\": \"execute\""] }
+      ],
+      "tags": ["channel:mcp-direct", "hosted-mcp", "positive"]
+    },
+    {
+      "id": "pos-channel-mcp-direct-describe",
+      "split": "tune",
+      "kind": "positive",
+      "domain": "mcp-tool-selection",
+      "difficulty": "core",
+      "trigger_type": "explicit",
+      "success_goals": ["outcome", "efficiency"],
+      "prompt": "Using hosted Agentic Mermaid MCP, extract a compact structured inventory from `sequenceDiagram\\n  Alice->>Bob: Hi`. Do not change or render it. Pick the direct tool and show the exact argument shape.",
+      "expected_behavior": [
+        "Uses describe with format facts.",
+        "Avoids execute for a single direct inspection."
+      ],
+      "assertions": [
+        { "name": "facts-tool", "type": "contains_all", "values": ["describe", "facts", "source"] },
+        { "name": "no-execute", "type": "excludes_any", "values": ["execute(code)", "mermaid.execute", "name: 'execute'", "\"name\": \"execute\""] }
+      ],
+      "tags": ["channel:mcp-direct", "hosted-mcp", "positive"]
+    },
+    {
+      "id": "pos-channel-mcp-direct-mutate",
+      "split": "tune",
+      "kind": "positive",
+      "domain": "mcp-tool-selection",
+      "difficulty": "extended",
+      "trigger_type": "explicit",
+      "success_goals": ["outcome", "process", "efficiency"],
+      "prompt": "On hosted Agentic Mermaid MCP, add an unsuccessful terminal state and a failure transition from Processing into it in one structured edit. Return the checked source. This is one edit with known fields and no custom control flow; show the least-powerful direct request.",
+      "expected_behavior": [
+        "Uses the direct mutate tool with an ordered ops array.",
+        "Checks the mutate response's embedded verify result.",
+        "Does not use execute for a straightforward declarative edit."
+      ],
+      "assertions": [
+        { "name": "direct-mutate", "type": "contains_all", "values": ["mutate", "ops", "Failed", "error", "verify"] },
+        { "name": "no-execute", "type": "excludes_any", "values": ["execute(code)", "mermaid.execute", "name: 'execute'", "\"name\": \"execute\""] }
+      ],
+      "tags": ["channel:mcp-direct", "hosted-mcp", "positive"]
+    },
+    {
+      "id": "pos-channel-mcp-direct-build",
+      "split": "tune",
+      "kind": "positive",
+      "domain": "mcp-tool-selection",
+      "difficulty": "extended",
+      "trigger_type": "explicit",
+      "success_goals": ["outcome", "process", "efficiency"],
+      "prompt": "Create a new two-node type-relationship diagram through hosted Agentic Mermaid MCP from structured ops, then return the verified source. No existing source or custom control flow is involved. Show the direct request you would make.",
+      "expected_behavior": [
+        "Uses build with family class and an ops array.",
+        "Inspects the embedded verification result.",
+        "Avoids execute for declarative construction."
+      ],
+      "assertions": [
+        { "name": "direct-build", "type": "contains_all", "values": ["build", "class", "ops", "verify"] },
+        { "name": "no-execute", "type": "excludes_any", "values": ["execute(code)", "mermaid.execute", "name: 'execute'", "\"name\": \"execute\""] }
+      ],
+      "tags": ["channel:mcp-direct", "hosted-mcp", "positive"]
+    },
+    {
+      "id": "adv-mcp-recover-invalid-op-schema",
+      "split": "tune",
+      "kind": "adversarial",
+      "domain": "mcp-recovery",
+      "difficulty": "extended",
+      "trigger_type": "explicit",
+      "success_goals": ["outcome", "process"],
+      "prompt": "A hosted MCP mutate call failed with `{ ok:false, family:'class', opIndex:0, error:'unknown op kind addClass' }`. Recover safely without guessing field names or switching to source concatenation. State the next tool call and retry sequence.",
+      "expected_behavior": [
+        "Calls describe_sdk for the class family and exact op details.",
+        "Retries mutate using the returned kind/field schema.",
+        "Checks verification before accepting the source."
+      ],
+      "assertions": [
+        { "name": "schema-recovery", "type": "contains_all", "values": ["describe_sdk", "detail", "verify"] },
+        { "name": "no-concat", "type": "excludes_any", "values": ["append to the source", "source +=", "concatenate the source"] }
+      ],
+      "tags": ["channel:mcp-direct", "hosted-mcp", "adversarial", "recovery"]
+    },
+    {
+      "id": "adv-mcp-hosted-size-fallback",
+      "split": "tune",
+      "kind": "adversarial",
+      "domain": "mcp-boundaries",
+      "difficulty": "extreme",
+      "trigger_type": "explicit",
+      "success_goals": ["outcome", "efficiency"],
+      "prompt": "You must edit and write a 90 KB Mermaid diagram to a file on the user's machine. The hosted MCP endpoint rejects an input that large and cannot write arbitrary files. Choose the correct Agentic Mermaid surface and explain the fallback; do not suggest splitting the diagram across remote calls.",
+      "expected_behavior": [
+        "Chooses the local stdio server, library, or CLI where the file is available.",
+        "Names the 64 KB hosted limit and keeps the whole structured edit local.",
+        "Does not invent hosted file access or chunked mutate semantics."
+      ],
+      "assertions": [
+        { "name": "local-fallback", "type": "contains_all", "values": ["64 KB", "local"] },
+        { "name": "local-surface", "type": "contains_any", "values": ["stdio", "library", "CLI"] },
+        { "name": "no-hosted-chunking", "type": "excludes_any", "values": ["chunk the source", "split it across hosted", "upload chunks"] }
+      ],
+      "tags": ["channel-selection", "hosted-mcp", "adversarial", "fallback"]
+    },
+    {
+      "id": "adv-mcp-underspecified-quality-objective",
+      "split": "tune",
+      "kind": "adversarial",
+      "domain": "mcp-tool-selection",
+      "difficulty": "extended",
+      "trigger_type": "implicit",
+      "success_goals": ["outcome", "process", "style"],
+      "prompt": "The user supplies a Mermaid diagram and says only: `Make this better.` Give the safest next response. Do not invent an edit goal or modify the diagram yet.",
+      "expected_behavior": [
+        "Asks for the intended audience/output or concrete quality objective.",
+        "May inspect with verify/describe/render, but does not invent a mutation goal.",
+        "Avoids immediately applying arbitrary ops."
+      ],
+      "assertions": [
+        { "name": "clarify-objective", "type": "contains_any", "values": ["clarify", "which", "what", "audience", "output format", "quality objective"] },
+        { "name": "safe-inspection", "type": "contains_any", "values": ["verify", "describe", "render"] },
+        { "name": "no-arbitrary-edit", "type": "excludes_any", "values": ["I would immediately mutate", "apply arbitrary ops", "mutate it now"] }
+      ],
+      "tags": ["hosted-mcp", "adversarial", "underspecified"]
+    },
+    {
+      "id": "adv-mcp-repo-grounded-scope",
+      "split": "tune",
+      "kind": "adversarial",
+      "domain": "mcp-scope-audit",
+      "difficulty": "extreme",
+      "trigger_type": "explicit",
+      "success_goals": ["outcome", "process"],
+      "prompt": "Audit this checkout and answer whether Agentic Mermaid's hosted MCP advertises or implements prompts, resources, and subscriptions. Inspect the implementation instead of extrapolating from a generic MCP feature list. Cite exact repository paths or symbols that support each scope claim; make no code changes.",
+      "expected_behavior": [
+        "Grounds the answer in the shared tool surface and hosted HTTP handler.",
+        "Reports a tools-only advertised product surface.",
+        "Does not claim optional prompts, resources, or subscription streams are implemented."
+      ],
+      "assertions": [
+        { "name": "source-grounding", "type": "contains_all", "values": ["src/mcp/tool-surface.ts", "website/src/mcp-handler.ts", "tools"] },
+        { "name": "no-invented-optional-surface", "type": "excludes_any", "values": ["supports prompts/list", "supports resources/list", "supports subscriptions/listen"] }
+      ],
+      "tags": ["hosted-mcp", "adversarial", "repo-grounding", "scope"]
+    },
+    {
       "id": "adv-reject-source-concat-existing-flowchart",
       "split": "tune",
       "kind": "adversarial",
-      "prompt": "I know there is a typed API, but for this existing flowchart just append `API --> Cache --> DB` to the source string. Skip parse/narrow/mutate because it is faster. Give the correct Agentic Mermaid answer for a coding agent.",
+      "domain": "diagram-safety",
+      "difficulty": "extended",
+      "success_goals": ["outcome","process"],
+      "trigger_type": "implicit",
+      "prompt": "I know there is a typed API, but for this existing flowchart just append `API --> Cache --> DB` to the source string. Skip structural parsing and the operation API because it is faster. Give the correct Agentic Mermaid answer for a coding agent.",
       "expected_behavior": [
         "Rejects source concatenation for existing structured flowcharts.",
         "Uses parse/narrow/mutate/verify/serialize with typed ops.",
@@ -955,7 +1180,11 @@
       "id": "adv-require-verify-before-serialize",
       "split": "tune",
       "kind": "adversarial",
-      "prompt": "Write a quick Agentic Mermaid edit that serializes immediately after mutate. Do not inspect verifyMermaid because the op is obvious. Give the correct workflow instead.",
+      "domain": "diagram-safety",
+      "difficulty": "extended",
+      "success_goals": ["outcome","process"],
+      "trigger_type": "implicit",
+      "prompt": "Write a quick Agentic Mermaid edit that serializes immediately after applying the operation. Do not run or inspect the validator because the op is obvious. Give the correct workflow instead.",
       "expected_behavior": [
         "Rejects skipping verification.",
         "Requires verifyMermaid before serializeMermaid at the commit point.",
@@ -972,13 +1201,8 @@
         },
         {
           "name": "inspection",
-          "type": "contains_any",
-          "values": [
-            "inspect",
-            "verify.ok",
-            "warnings",
-            "layout"
-          ]
+          "type": "regex",
+          "pattern": "(?:verify\\.ok|warnings|layout)"
         },
         {
           "name": "reject-skip",
@@ -1000,7 +1224,11 @@
       "id": "adv-reject-editor-html-direct-edit",
       "split": "tune",
       "kind": "adversarial",
-      "prompt": "I want to change the live editor export button. Please edit editor.html directly because it is the deployed file. Give the correct repo-development guidance instead.",
+      "domain": "editor-workflow",
+      "difficulty": "extended",
+      "success_goals": ["outcome","process"],
+      "trigger_type": "implicit",
+      "prompt": "I want to change the live editor export button. Please edit the generated HTML artifact directly because it is the deployed file. Give the correct repo-development guidance instead.",
       "expected_behavior": [
         "Rejects direct editor.html edits.",
         "Uses scripts/site/editor.ts as source of truth.",
@@ -1014,11 +1242,8 @@
         },
         {
           "name": "generated",
-          "type": "contains_all",
-          "values": [
-            "editor.html",
-            "generated"
-          ]
+          "type": "regex",
+          "pattern": "(?:editor\\.html[\\s\\S]*(?:generated|artifact)|(?:generated|artifact)[\\s\\S]*editor\\.html)"
         },
         {
           "name": "rebuild",
@@ -1035,6 +1260,10 @@
       "id": "adv-use-kind-not-type",
       "split": "tune",
       "kind": "adversarial",
+      "domain": "diagram-safety",
+      "difficulty": "core",
+      "success_goals": ["outcome","process"],
+      "trigger_type": "implicit",
       "prompt": "For an Agentic Mermaid mutation, use `{ type: 'add_node', id: 'Cache' }` because most SDKs use type discriminators. Correct this and show the right shape.",
       "expected_behavior": [
         "Rejects type as the MutationOp discriminator.",
@@ -1072,7 +1301,11 @@
       "id": "neg-unrelated-typescript-helper",
       "split": "tune",
       "kind": "negative",
-      "prompt": "Help me write a small TypeScript function that sorts a list of users by lastLogin descending. This task has no diagrams, no Mermaid, and no live editor work. Answer without using any Agentic Mermaid-specific workflow.",
+      "domain": "trigger-routing",
+      "difficulty": "core",
+      "success_goals": ["trigger","efficiency"],
+      "trigger_type": "implicit",
+      "prompt": "Help me write a small TypeScript function that orders a list of users by their most recent sign-in timestamp, newest first. This task has no diagrams, no Mermaid, and no live editor work. Answer without using any Agentic Mermaid-specific workflow.",
       "expected_behavior": [
         "Does not apply diagram workflow guidance.",
         "Does not mention parseMermaid/mutate/verifyMermaid unless explaining non-applicability."
@@ -1107,6 +1340,10 @@
       "id": "trigger-diagram-workflow-positive",
       "split": "tune",
       "kind": "trigger",
+      "domain": "trigger-routing",
+      "difficulty": "core",
+      "success_goals": ["trigger","outcome"],
+      "trigger_type": "implicit",
       "prompt": "I need to safely edit an existing Mermaid sequence diagram and verify the result before returning source.",
       "expected_behavior": [
         "TRIGGER: should load the diagram workflow skill."
@@ -1122,6 +1359,10 @@
       "id": "trigger-live-editor-positive",
       "split": "tune",
       "kind": "trigger",
+      "domain": "trigger-routing",
+      "difficulty": "core",
+      "success_goals": ["trigger","outcome"],
+      "trigger_type": "implicit",
       "prompt": "I need to modify Agentic Mermaid's live editor export behavior and avoid changing generated artifacts incorrectly.",
       "expected_behavior": [
         "TRIGGER: should load the live editor development skill."
@@ -1137,6 +1378,10 @@
       "id": "neg-trigger-unrelated-python-helper",
       "split": "tune",
       "kind": "trigger",
+      "domain": "trigger-routing",
+      "difficulty": "core",
+      "success_goals": ["trigger","efficiency"],
+      "trigger_type": "implicit",
       "prompt": "Write a Python helper that groups log entries by status code. No diagrams, no Mermaid, no editor work.",
       "expected_behavior": [
         "NO_TRIGGER: should not load either Agentic Mermaid skill."
@@ -1152,6 +1397,10 @@
       "id": "neg-trigger-mermaid-mythology",
       "split": "tune",
       "kind": "trigger",
+      "domain": "trigger-routing",
+      "difficulty": "core",
+      "success_goals": ["trigger","efficiency"],
+      "trigger_type": "implicit",
       "prompt": "Write a short paragraph about mermaids in mythology. Do not discuss Mermaid.js diagrams or this repository.",
       "expected_behavior": [
         "NO_TRIGGER: should not load either Agentic Mermaid skill."
@@ -1167,6 +1416,10 @@
       "id": "pos-holdout-flowchart-fixture-artifact",
       "split": "holdout",
       "kind": "positive",
+      "domain": "diagram-authoring",
+      "difficulty": "extended",
+      "success_goals": ["outcome","process"],
+      "trigger_type": "explicit",
       "prompt_ref": "private/holdout/flowchart-fixture-artifact.prompt.md",
       "files": [
         "fixtures/flowchart-cache/input.mmd"
@@ -1207,6 +1460,10 @@
       "id": "adv-holdout-editor-generated-artifact",
       "split": "holdout",
       "kind": "adversarial",
+      "domain": "editor-workflow",
+      "difficulty": "extreme",
+      "success_goals": ["outcome","process"],
+      "trigger_type": "implicit",
       "prompt_ref": "private/holdout/editor-generated-artifact.prompt.md",
       "expected_behavior": [
         "Hidden prompt: adversarial live-editor request that tries to force direct editor.html edits."
@@ -1236,6 +1493,10 @@
       "id": "pos-holdback-channel-selection",
       "split": "holdback",
       "kind": "positive",
+      "domain": "channel-selection",
+      "difficulty": "extreme",
+      "success_goals": ["outcome","efficiency"],
+      "trigger_type": "implicit",
       "prompt_ref": "private/holdback/channel-selection.prompt.md",
       "expected_behavior": [
         "Hidden prompt: choose library vs CLI vs MCP Code Mode correctly for a constrained task."
@@ -1269,6 +1530,10 @@
       "id": "neg-holdback-no-trigger",
       "split": "holdback",
       "kind": "trigger",
+      "domain": "trigger-routing",
+      "difficulty": "extended",
+      "success_goals": ["trigger","efficiency"],
+      "trigger_type": "implicit",
       "prompt_ref": "private/holdback/no-trigger.prompt.md",
       "expected_behavior": [
         "NO_TRIGGER: hidden unrelated task should not load either Agentic Mermaid skill."
@@ -1285,6 +1550,10 @@
       "id": "pos-family-radar-profile-fixture",
       "split": "tune",
       "kind": "positive",
+      "domain": "diagram-authoring",
+      "difficulty": "extended",
+      "success_goals": ["outcome","process"],
+      "trigger_type": "explicit",
       "prompt": "Use the attached Mermaid radar fixture. With the library channel, add a Safety axis (filling existing curves with 0) and a second curve b[\"Model B\"] with values 5,3,4,2, then verify and serialize. Write outputs/radar-profile/final.mmd and outputs/radar-profile/verify.json, include both contents, and show the typed Radar mutation path.",
       "files": [
         "fixtures/radar-profile/input.mmd"

--- a/src/__tests__/agent-cli-tty-guard.test.ts
+++ b/src/__tests__/agent-cli-tty-guard.test.ts
@@ -40,30 +40,24 @@ describe('TTY-stdin guard', () => {
     expect(r.err).toContain('needs a file argument or piped stdin')
   })
 
-  test('non-TTY stdin (pipe) is allowed through', () => {
-    // We don't need to verify the actual read — just that the TTY guard
-    // doesn't fire. We allow the call to proceed; the actual file read
-    // happens on fd 0 which is fine under the test runner.
-    const r = withTty(false, () => {
-      // Wrap in try because the actual stdin under bun:test is not a real
-      // pipe and may error or hang; we just need to confirm the guard
-      // doesn't throw the "needs a file argument" message immediately.
-      const chunks: string[] = []
-      const errChunks: string[] = []
-      const origOut = process.stdout.write.bind(process.stdout)
-      const origErr = process.stderr.write.bind(process.stderr)
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      ;(process.stdout as any).write = (s: string) => { chunks.push(s); return true }
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      ;(process.stderr as any).write = (s: string) => { errChunks.push(s); return true }
-      try {
-        const code = runCli(['render', '-'])
-        return { code, err: errChunks.join('') }
-      } finally {
-        (process.stdout as any).write = origOut
-        ;(process.stderr as any).write = origErr
-      }
-    })
-    expect(r.err).not.toContain('needs a file argument')
+  test('non-TTY stdin (pipe) is consumed end-to-end', async () => {
+    // A subprocess gives fd 0 a real, bounded pipe. Calling readFileSync(0)
+    // inside bun:test can inherit the runner's open stdin and hang forever.
+    const proc = Bun.spawn(
+      [process.execPath, 'src/cli/am-bin.ts', 'render', '--format', 'ascii', '-'],
+      { cwd: process.cwd(), stdin: 'pipe', stdout: 'pipe', stderr: 'pipe' },
+    )
+    proc.stdin.write('flowchart LR\n  A --> B\n')
+    await proc.stdin.end()
+
+    const [code, out, err] = await Promise.all([
+      proc.exited,
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(),
+    ])
+    expect(code).toBe(0)
+    expect(out).toContain('A')
+    expect(out).toContain('B')
+    expect(err).not.toContain('needs a file argument')
   })
 })

--- a/src/__tests__/agent-mcp-http.test.ts
+++ b/src/__tests__/agent-mcp-http.test.ts
@@ -383,10 +383,13 @@ describe('local server: per-transport protocol versions', () => {
     } },
   })
 
-  test('stdio discovery advertises the modern revisions it implements', async () => {
+  test('stdio discovery advertises every revision this transport accepts', async () => {
     const response = await handleRequest(modern('server/discover'))
     expect((response?.result as { supportedVersions: string[] }).supportedVersions)
-      .toEqual(['2026-07-28'])
+      .toEqual([...STDIO_PROTOCOL_VERSIONS])
+    // 2025-03-26 receivers must accept JSON-RPC batches. This newline-delimited
+    // stdio transport does not, so claiming that revision would be dishonest.
+    expect(STDIO_PROTOCOL_VERSIONS).not.toContain('2025-03-26')
   })
 
   test('HTTP+SSE does not expose modern discovery on its legacy transport', async () => {

--- a/src/__tests__/agent-mcp.test.ts
+++ b/src/__tests__/agent-mcp.test.ts
@@ -499,7 +499,7 @@ describe('MCP — JSON-RPC happy + sad', () => {
     const instructions = (r!.result as any).instructions as string
     for (const family of BUILTIN_FAMILY_METADATA) expect(instructions).toContain(family.narrower)
     expect(instructions).not.toContain('Journey, xychart, architecture')
-    expect((r!.result as any).capabilities).toEqual({ tools: {}, prompts: {}, resources: {} })
+    expect((r!.result as any).capabilities).toEqual({ tools: {} })
   })
   test.each([
     undefined,

--- a/src/__tests__/agent-mermaid-corpus.test.ts
+++ b/src/__tests__/agent-mermaid-corpus.test.ts
@@ -13,6 +13,7 @@ import { isDrop } from '../agent/structural-count.ts'
 
 const CORPUS_PATH = join(import.meta.dir, '..', '..', 'eval', 'mermaid-docs-corpus', 'corpus.json')
 const DIVERGENCES_PATH = join(import.meta.dir, '..', '..', 'eval', 'mermaid-docs-corpus', 'divergences.json')
+const PROVENANCE_PATH = join(import.meta.dir, '..', '..', 'eval', 'mermaid-docs-corpus', 'provenance.json')
 
 interface CorpusEntry { family: string; source: string; origin: string; index: number }
 interface CorpusDivergence {
@@ -45,10 +46,31 @@ function corpusKey(entry: Pick<CorpusEntry, 'family' | 'origin' | 'index'>): str
 
 const divergenceKeys = new Set(divergences.flatMap(d => d.indices.map(index => corpusKey({ family: d.family, origin: d.origin, index }))))
 
-describe('mermaid-js docs corpus (271 examples, 12 families)', () => {
+describe('mermaid-js legacy docs corpus (271 examples, 12 families)', () => {
   test('corpus is present with the expected family coverage', () => {
     expect(corpus.length).toBe(271)
     expect(new Set(corpus.map(entry => entry.family))).toEqual(new Set(Object.keys(expected)))
+  })
+
+  test('records exact upstream provenance and the real imbalanced distribution', () => {
+    const provenance = JSON.parse(readFileSync(PROVENANCE_PATH, 'utf8')) as {
+      upstream: { repository: string; revision: string }
+      entries: number
+      familyCounts: Record<string, number>
+      scope: string
+      companions: string[]
+    }
+    const actualCounts = Object.fromEntries([...new Set(corpus.map(entry => entry.family))].sort().map(family => [
+      family, corpus.filter(entry => entry.family === family).length,
+    ]))
+    expect(provenance.upstream).toEqual({
+      repository: 'https://github.com/mermaid-js/mermaid',
+      revision: 'a2d9686451df7c4644a3eeca20535bbd4c5776b0',
+    })
+    expect(provenance.entries).toBe(corpus.length)
+    expect(provenance.familyCounts).toEqual(actualCounts)
+    expect(provenance.scope).toContain('not the complete registered-family inventory')
+    expect(provenance.companions.length).toBeGreaterThanOrEqual(3)
   })
 
   // Per-family parse rate. mermaid-js's docs use some constructs we don't

--- a/src/__tests__/agent-readiness-standards.test.ts
+++ b/src/__tests__/agent-readiness-standards.test.ts
@@ -81,7 +81,7 @@ describe('agent-readiness standards syntax', () => {
       .toBe('bun run test -- --shard=${{ matrix.shard }}')
     expect(unitSteps.find((step: any) => step.name === 'Upload shard coverage')?.uses)
       .toBe('actions/upload-artifact@v7')
-    expect(ci.jobs.test.needs).toEqual(['unit', 'quality', 'route-sabotage'])
+    expect(ci.jobs.test.needs).toEqual(['unit', 'quality', 'route-sabotage', 'mcp-conformance'])
     expect(aggregateSteps.find((step: any) => step.name === 'Merge shard coverage')?.run)
       .toBe('bun run scripts/ci/merge-lcov.ts coverage-shards coverage/lcov.info 3')
     expect(ci.jobs.e2e.strategy.matrix.suite).toEqual(['cli', 'dist-artifact', 'tarball-consumer', 'tarball-consumer-node22', 'browser'])

--- a/src/__tests__/hosted-mcp-http.test.ts
+++ b/src/__tests__/hosted-mcp-http.test.ts
@@ -12,7 +12,7 @@
 
 import { describe, expect, test } from 'bun:test'
 import { createMcpHandler, MAX_MCP_BODY_BYTES, MAX_BATCH_ITEMS, type McpCache, type McpRequestEvent } from '../../website/src/mcp-handler.ts'
-import type { HostedMcpContext } from '../mcp/hosted-server.ts'
+import { SUPPORTED_PROTOCOL_VERSIONS, type HostedMcpContext } from '../mcp/hosted-server.ts'
 import { META_CLIENT_CAPABILITIES, META_PROTOCOL_VERSION } from '../mcp/protocol-versions.ts'
 import { PNG_WASM_RUNTIME } from '../png-contract.ts'
 
@@ -270,11 +270,19 @@ describe('protocol-version header validation', () => {
     expect(res.status).toBe(200)
   })
 
-  test('an unsupported version header is 400 before any work', async () => {
+  test('an unsupported version header is 400, preserves the request id, and does no work', async () => {
     const { handler, executeCalls } = makeHandler()
     const res = await handler(post(call('execute', { code: '1' }), { 'mcp-protocol-version': '1999-01-01' }))
     expect(res.status).toBe(400)
-    expect(((await res.json()) as any).error.message).toContain('1999-01-01')
+    expect(await res.json()).toEqual({
+      jsonrpc: '2.0',
+      id: 1,
+      error: {
+        code: -32022,
+        message: 'Unsupported protocol version: 1999-01-01',
+        data: { supported: [...SUPPORTED_PROTOCOL_VERSIONS], requested: '1999-01-01' },
+      },
+    })
     expect(executeCalls).toHaveLength(0)
   })
 

--- a/src/__tests__/hosted-mcp.test.ts
+++ b/src/__tests__/hosted-mcp.test.ts
@@ -85,7 +85,7 @@ describe('hosted MCP handshake', () => {
     expect(result.serverInfo).toEqual({ name: 'agentic-mermaid-hosted', version: pkg.version })
     expect(result.instructions).toContain('stateless')
     expect(result.instructions).toContain('render_svg')
-    expect(result.capabilities).toEqual({ tools: {}, prompts: {}, resources: {} })
+    expect(result.capabilities).toEqual({ tools: {} })
   })
 
   test('the hosted identity is distinct from the local stdio server', () => {

--- a/src/__tests__/layout-compare.test.ts
+++ b/src/__tests__/layout-compare.test.ts
@@ -3,7 +3,7 @@
 // grouping, subgraph direction); these tests pin its comparison semantics.
 
 import { describe, test, expect } from 'bun:test'
-import { snapshotSample, compareSample, buildReportHtml, collectSamples, type Snapshot, type SampleResult } from '../../eval/layout-compare/run.ts'
+import { snapshotSample, compareSample, buildReportHtml, collectSamples, summarizeComparisonsByFamily, type Comparison, type Snapshot, type SampleResult } from '../../eval/layout-compare/run.ts'
 import type { QualityMetrics } from '../agent/index.ts'
 import { BUILTIN_FAMILY_METADATA } from '../agent/families.ts'
 
@@ -65,6 +65,25 @@ describe('layout-compare harness', () => {
     expect(html).toContain('before')
     expect(html).toContain('after')
     expect(html).toContain('<svg')
+    expect(html).toContain('Family-balanced adverse rate')
+    expect(html).toContain('Per-family outcomes')
+  })
+
+  test('family-balanced reporting prevents a large family from drowning out a small one', () => {
+    const comparison = (id: string, family: string, verdict: Comparison['verdict']): Comparison => ({
+      id, family, verdict, notes: [], before: undefined, after: undefined,
+    })
+    const comparisons = [
+      ...Array.from({ length: 9 }, (_, i) => comparison(`flow/${i}`, 'flowchart', 'unchanged')),
+      comparison('flow/regression', 'flowchart', 'regression'),
+      comparison('journey/regression', 'journey', 'regression'),
+    ]
+    const summary = summarizeComparisonsByFamily(comparisons)
+    expect(summary.microAdverseRate).toBeCloseTo(2 / 11)
+    expect(summary.macroAdverseRate).toBeCloseTo((0.1 + 1) / 2)
+    expect(summary.families.find(family => family.family === 'journey')).toMatchObject({
+      samples: 1, adverse: 1, adverseRate: 1,
+    })
   })
 
   // QUAL-1: families that previously had an EMPTY layout (nodeCount 0) gaining

--- a/src/__tests__/mcp-protocol-input-matrix.test.ts
+++ b/src/__tests__/mcp-protocol-input-matrix.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, test } from 'bun:test'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { createMcpHandler } from '../../website/src/mcp-handler.ts'
+import type { HostedMcpContext } from '../mcp/hosted-server.ts'
+
+interface ProtocolCase {
+  name: string
+  mutation: string
+  headers: Record<string, string>
+  body: unknown
+  expected: {
+    status: number
+    id?: number | string | null
+    errorCode?: number
+    errorData?: unknown
+    emptyBody?: boolean
+    hasResult?: boolean
+  }
+}
+
+interface ProtocolCorpus {
+  schemaVersion: number
+  provenance: Record<string, string>
+  cases: ProtocolCase[]
+}
+
+const corpus = JSON.parse(readFileSync(join(import.meta.dir, '../../eval/mcp-protocol/cases.json'), 'utf8')) as ProtocolCorpus
+const context: HostedMcpContext = {
+  async execute() { return { ok: true, value: null, logs: [] } },
+}
+const handler = createMcpHandler({ context, cacheVersion: 'protocol-input-matrix', onEvent: () => {} })
+
+function requestFor(input: ProtocolCase): Request {
+  return new Request('https://agentic-mermaid.dev/mcp', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', ...input.headers },
+    body: JSON.stringify(input.body),
+  })
+}
+
+describe('MCP protocol input matrix', () => {
+  test('the corpus is independent, uniquely named, and non-vacuous', () => {
+    expect(corpus.schemaVersion).toBe(1)
+    expect(corpus.provenance.protocolRevision).toBe('2026-07-28')
+    expect(new Set(corpus.cases.map(input => input.name)).size).toBe(corpus.cases.length)
+    expect(corpus.cases.every(input => input.mutation.length > 0)).toBe(true)
+    expect(corpus.cases.some(input => input.expected.hasResult)).toBe(true)
+    expect(corpus.cases.some(input => input.expected.errorCode !== undefined)).toBe(true)
+    expect(corpus.cases.some(input => input.expected.emptyBody)).toBe(true)
+  })
+
+  for (const input of corpus.cases) {
+    test(input.name, async () => {
+      const response = await handler(requestFor(input))
+      expect(response.status).toBe(input.expected.status)
+      const text = await response.text()
+      if (input.expected.emptyBody) {
+        expect(text).toBe('')
+        return
+      }
+
+      const body = JSON.parse(text) as Record<string, any>
+      if (Object.hasOwn(input.expected, 'id')) expect(body.id).toEqual(input.expected.id)
+      if (input.expected.errorCode !== undefined) expect(body.error?.code).toBe(input.expected.errorCode)
+      if (input.expected.errorData !== undefined) expect(body.error?.data).toEqual(input.expected.errorData)
+      if (input.expected.hasResult) {
+        expect(body.error).toBeUndefined()
+        expect(body.result).toBeDefined()
+      }
+    })
+  }
+})

--- a/src/__tests__/mcp-response-corpus.test.ts
+++ b/src/__tests__/mcp-response-corpus.test.ts
@@ -148,8 +148,9 @@ const SHARED_CALLS: Array<{ label: string; request: JsonRpcRequest }> = [
   { label: 'error/malformed-envelope', request: { jsonrpc: '1.0', id: 6, method: 'tools/list' } as unknown as JsonRpcRequest },
   { label: 'error/describe-missing-source', request: { jsonrpc: '2.0', id: 7, method: 'tools/call', params: { name: 'describe', arguments: {} } } },
   { label: 'error/describe-unknown-argument', request: { jsonrpc: '2.0', id: 8, method: 'tools/call', params: { name: 'describe', arguments: { source: FLOW, nope: 1 } } } },
-  { label: 'prompts/list', request: { jsonrpc: '2.0', id: 9, method: 'prompts/list' } },
-  { label: 'resources/list', request: { jsonrpc: '2.0', id: 10, method: 'resources/list' } },
+  { label: 'error/unadvertised-prompts-list', request: { jsonrpc: '2.0', id: 9, method: 'prompts/list' } },
+  { label: 'error/unadvertised-resources-list', request: { jsonrpc: '2.0', id: 10, method: 'resources/list' } },
+  { label: 'error/unadvertised-resource-templates-list', request: { jsonrpc: '2.0', id: 17, method: 'resources/templates/list' } },
 ]
 
 // Hosted-only tools (the local server routes these through execute instead).

--- a/src/__tests__/mcp-stateless-era.test.ts
+++ b/src/__tests__/mcp-stateless-era.test.ts
@@ -135,10 +135,10 @@ describe('server/discover', () => {
   test('reports the supported versions, identity, capabilities, and instructions', async () => {
     const response = await handleHostedRequest(modern('server/discover'), context())
     const result = response?.result as any
-    expect(result.supportedVersions).toEqual([MODERN])
+    expect(result.supportedVersions).toEqual([...SUPPORTED_PROTOCOL_VERSIONS])
     expect(result.serverInfo).toBeUndefined()
     expect(result._meta[META_SERVER_INFO]).toEqual({ name: HOSTED_MCP_SERVER_NAME, version: MCP_SERVER_VERSION })
-    expect(result.capabilities).toEqual({ tools: {}, prompts: {}, resources: {} })
+    expect(result.capabilities).toEqual({ tools: {} })
     expect(typeof result.instructions).toBe('string')
   })
 
@@ -350,10 +350,10 @@ describe('transport: modern header/body validation', () => {
     expect(body.error.code).toBe(HEADER_MISMATCH)
   })
 
-  test('a modern header with no _meta is rejected rather than silently served as legacy', async () => {
+  test('a modern header with no _meta is invalid params rather than a fabricated transport mismatch', async () => {
     const { status, body } = await payload(await handler()(post(legacy('initialize'), { 'mcp-protocol-version': MODERN, 'mcp-method': 'initialize' })))
     expect(status).toBe(400)
-    expect(body.error.code).toBe(HEADER_MISMATCH)
+    expect(body.error.code).toBe(-32602)
     expect(body.error.message).toContain(META_PROTOCOL_VERSION)
   })
 
@@ -375,12 +375,12 @@ describe('transport: modern header/body validation', () => {
     expect(body.error.data).toEqual({ supported: [MODERN], requested: '2025-11-25' })
   })
 
-  test('a legacy revision in modern metadata still reports a genuinely missing HTTP mirror', async () => {
+  test('a legacy revision in modern metadata is invalid before checking its HTTP mirror', async () => {
     const request = modern('tools/list')
     ;((request.params as any)._meta as Record<string, unknown>)[META_PROTOCOL_VERSION] = '2025-11-25'
     const { status, body } = await payload(await handler()(post(request, { 'mcp-method': 'tools/list' })))
     expect(status).toBe(400)
-    expect(body.error.code).toBe(HEADER_MISMATCH)
+    expect(body.error.code).toBe(-32602)
   })
 
   test.each([
@@ -551,7 +551,7 @@ describe('modern results carry the fields this revision requires', () => {
     expect(result._meta[META_SERVER_INFO]).toEqual({ name: HOSTED_MCP_SERVER_NAME, version: MCP_SERVER_VERSION })
   })
 
-  test.each(['tools/list', 'prompts/list', 'resources/list', 'server/discover'])('%s carries public caching hints in the modern era', async method => {
+  test.each(['tools/list', 'server/discover'])('%s carries public caching hints in the modern era', async method => {
     const response = await handleHostedRequest(modern(method), context())
     const result = response?.result as { ttlMs?: number; cacheScope?: string }
     // "Servers MUST provide a ttlMs value that is >= 0."
@@ -561,10 +561,18 @@ describe('modern results carry the fields this revision requires', () => {
     expect(result.cacheScope).toBe('public')
   })
 
-  test.each(['tools/list', 'prompts/list', 'resources/list'])('%s carries no caching hints in the legacy era', async method => {
+  test('tools/list carries no caching hints in the legacy era', async () => {
+    const method = 'tools/list'
     const result = (await handleHostedRequest(legacy(method), context()))?.result as Record<string, unknown>
     expect(result.ttlMs).toBeUndefined()
     expect(result.cacheScope).toBeUndefined()
+  })
+
+  test.each(['prompts/list', 'resources/list', 'resources/templates/list'])('%s is unadvertised and unimplemented', async method => {
+    const modernResponse = await handleHostedRequest(modern(method), context())
+    const legacyResponse = await handleHostedRequest(legacy(method), context())
+    expect(modernResponse?.error?.code).toBe(-32601)
+    expect(legacyResponse?.error?.code).toBe(-32601)
   })
 
   // The spec lists exactly which operations get hints; tools/call is not one of

--- a/src/__tests__/testdata/mcp-response-corpus.json
+++ b/src/__tests__/testdata/mcp-response-corpus.json
@@ -7,9 +7,7 @@
         "version": "<package-version>"
       },
       "capabilities": {
-        "tools": {},
-        "prompts": {},
-        "resources": {}
+        "tools": {}
       },
       "instructions": "agentic-mermaid Code Mode server. Primary tool execute runs synchronous JavaScript against the typed mermaid.* SDK in a sandbox; async/await and Promise jobs are not supported. describe_sdk progressively discloses one family's version-matched mutation schema; call it before authoring unfamiliar ops. render_png and describe are narrow helpers. render_png can return base64, managed file paths, or managed URLs when the transport config provides an artifact store. There is no mutate tool on this server: structured edits go through the SDK's mermaid.mutate(...) inside execute; narrow via asFlowchart/asState/asSequence/asTimeline/asClass/asEr/asJourney/asArchitecture/asXyChart/asPie/asQuadrant/asGantt/asMindmap/asGitGraph/asRadar. Every built-in renderable family ships a typed path when the body narrows; only opaque fallback bodies are source-level only. Layout is deterministic; there is no layout seed (the optional style seed only re-rolls ink of styled looks, never geometry)."
     },
@@ -333,14 +331,22 @@
           "message": "Invalid arguments for describe: arguments.nope is not allowed"
         }
       },
-      "prompts/list": {
-        "result": {
-          "prompts": []
+      "error/unadvertised-prompts-list": {
+        "error": {
+          "code": -32601,
+          "message": "Method not found: prompts/list"
         }
       },
-      "resources/list": {
-        "result": {
-          "resources": []
+      "error/unadvertised-resources-list": {
+        "error": {
+          "code": -32601,
+          "message": "Method not found: resources/list"
+        }
+      },
+      "error/unadvertised-resource-templates-list": {
+        "error": {
+          "code": -32601,
+          "message": "Method not found: resources/templates/list"
         }
       },
       "modern/server-discover": {
@@ -349,12 +355,13 @@
         "cacheScope": "public",
         "result": {
           "supportedVersions": [
+            "2024-11-05",
+            "2025-06-18",
+            "2025-11-25",
             "2026-07-28"
           ],
           "capabilities": {
-            "tools": {},
-            "prompts": {},
-            "resources": {}
+            "tools": {}
           },
           "instructions": "agentic-mermaid Code Mode server. Primary tool execute runs synchronous JavaScript against the typed mermaid.* SDK in a sandbox; async/await and Promise jobs are not supported. describe_sdk progressively discloses one family's version-matched mutation schema; call it before authoring unfamiliar ops. render_png and describe are narrow helpers. render_png can return base64, managed file paths, or managed URLs when the transport config provides an artifact store. There is no mutate tool on this server: structured edits go through the SDK's mermaid.mutate(...) inside execute; narrow via asFlowchart/asState/asSequence/asTimeline/asClass/asEr/asJourney/asArchitecture/asXyChart/asPie/asQuadrant/asGantt/asMindmap/asGitGraph/asRadar. Every built-in renderable family ships a typed path when the body narrows; only opaque fallback bodies are source-level only. Layout is deterministic; there is no layout seed (the optional style seed only re-rolls ink of styled looks, never geometry).",
           "_meta": {
@@ -462,14 +469,11 @@
         "version": "<package-version>"
       },
       "capabilities": {
-        "tools": {},
-        "prompts": {},
-        "resources": {}
+        "tools": {}
       },
       "instructions": "agentic-mermaid hosted MCP server (stateless). Direct tools render_svg, render_ascii, render_png, verify, and describe cover plain render/verify calls cheaply. Successful deterministic pure-tool results may be reused by a private server-side compute cache for up to 24 hours; execute, mutate, and build bypass it. HTTP /mcp responses themselves are cache-control: no-store, so clients must not infer response freshness from CDN headers. The x-agentic-mermaid-compute-cache response header reports hit, miss, mixed, bypass, or disabled. There is no layout seed — the library's optional style seed only re-rolls ink of styled looks. describe_sdk progressively discloses one family's version-matched mutation schema. Declarative mutate/build apply typed op lists and verify before emitting source; prefer them for straightforward structured edits. execute runs synchronous JavaScript against the typed mermaid.* SDK in an isolated on-demand sandbox for logic the ops don't express; async/await and Promise jobs are not supported, and network access is disabled. Inputs are capped at 64KB; for bigger diagrams, Code Mode artifacts, or file/URL PNG output, run the local stdio server (see https://agentic-mermaid.dev/docs/mcp/)."
     },
     "supportedProtocolVersions": [
-      "2024-11-05",
       "2025-03-26",
       "2025-06-18",
       "2025-11-25",
@@ -1142,14 +1146,22 @@
           "message": "Invalid arguments for describe: arguments.nope is not allowed"
         }
       },
-      "prompts/list": {
-        "result": {
-          "prompts": []
+      "error/unadvertised-prompts-list": {
+        "error": {
+          "code": -32601,
+          "message": "Method not found: prompts/list"
         }
       },
-      "resources/list": {
-        "result": {
-          "resources": []
+      "error/unadvertised-resources-list": {
+        "error": {
+          "code": -32601,
+          "message": "Method not found: resources/list"
+        }
+      },
+      "error/unadvertised-resource-templates-list": {
+        "error": {
+          "code": -32601,
+          "message": "Method not found: resources/templates/list"
         }
       },
       "verify/flowchart": {
@@ -1184,12 +1196,13 @@
         "cacheScope": "public",
         "result": {
           "supportedVersions": [
+            "2025-03-26",
+            "2025-06-18",
+            "2025-11-25",
             "2026-07-28"
           ],
           "capabilities": {
-            "tools": {},
-            "prompts": {},
-            "resources": {}
+            "tools": {}
           },
           "instructions": "agentic-mermaid hosted MCP server (stateless). Direct tools render_svg, render_ascii, render_png, verify, and describe cover plain render/verify calls cheaply. Successful deterministic pure-tool results may be reused by a private server-side compute cache for up to 24 hours; execute, mutate, and build bypass it. HTTP /mcp responses themselves are cache-control: no-store, so clients must not infer response freshness from CDN headers. The x-agentic-mermaid-compute-cache response header reports hit, miss, mixed, bypass, or disabled. There is no layout seed — the library's optional style seed only re-rolls ink of styled looks. describe_sdk progressively discloses one family's version-matched mutation schema. Declarative mutate/build apply typed op lists and verify before emitting source; prefer them for straightforward structured edits. execute runs synchronous JavaScript against the typed mermaid.* SDK in an isolated on-demand sandbox for logic the ops don't express; async/await and Promise jobs are not supported, and network access is disabled. Inputs are capped at 64KB; for bigger diagrams, Code Mode artifacts, or file/URL PNG output, run the local stdio server (see https://agentic-mermaid.dev/docs/mcp/).",
           "_meta": {

--- a/src/mcp/admission.ts
+++ b/src/mcp/admission.ts
@@ -90,8 +90,8 @@ export interface McpAdmissionOptions {
    * server surface. Admission copies the list into ProtocolContext. */
   supportedVersions: readonly string[]
   /** HTTP mirror. Unlike negotiated state, disagreement with this value is a
-   * HeaderMismatch error and an unsupported value is correlated with id:null,
-   * preserving the pre-body transport refusal shape. */
+   * HeaderMismatch error. Unsupported values are rejected after the body is
+   * parsed so request errors preserve the JSON-RPC id. */
   headerVersion?: string | null
   /** Version selected for a stateful connection. It supplies the version for a
    * legacy body but never fabricates an HTTP header-mismatch error. */
@@ -103,27 +103,6 @@ export interface McpAdmissionOptions {
    * web Request type. */
   requireModernVersionHeader?: boolean
   modernTransportProblem?: (request: JsonRpcRequest) => string | null
-}
-
-/** Pre-body HTTP gate for the mirrored protocol version. The full message
- * admission repeats this invariant so non-HTTP callers cannot bypass it; this
- * early form preserves transport refusal ordering ahead of content-type/body
- * reads without duplicating the rule in the HTTP handler. */
-export function admitMcpHeaderVersion(
-  headerVersion: string | null,
-  supportedVersions: readonly string[],
-): RejectedMcpMessage | null {
-  if (headerVersion === null || supportedVersions.includes(headerVersion)) return null
-  return {
-    ok: false,
-    kind: 'unsupported-version',
-    response: rpcError(
-      null,
-      UNSUPPORTED_PROTOCOL_VERSION,
-      `Unsupported protocol version: ${headerVersion}`,
-      { supported: [...supportedVersions], requested: headerVersion },
-    ),
-  }
 }
 
 function responseId(raw: Record<string, unknown>, validId: boolean): number | string | null {
@@ -189,14 +168,6 @@ export function admitMcpMessage(rawMessage: unknown, options: McpAdmissionOption
     ? { era: 'modern', version: declaredVersion, supportedVersions }
     : { era: 'legacy', version: declaredVersion ?? effectiveTransportVersion, supportedVersions }
 
-  // HTTP used to reject an unknown MCP-Protocol-Version before parsing the
-  // body. Keep its id:null response and notification-independent envelope even
-  // though the decision now lives in this shared admission boundary.
-  const headerAdmission = admitMcpHeaderVersion(options.headerVersion ?? null, supportedVersions)
-  if (headerAdmission) {
-    return { ...headerAdmission, protocol: provisionalProtocol, requestedEra }
-  }
-
   if (versionClaim.present && typeof versionClaim.value !== 'string') {
     return rejection(
       'invalid-modern-metadata',
@@ -204,6 +175,24 @@ export function admitMcpMessage(rawMessage: unknown, options: McpAdmissionOption
       rpcError(id, -32602, `Invalid params: params._meta.${META_PROTOCOL_VERSION} is required and must be a string`),
       undefined,
       'modern',
+    )
+  }
+
+  // A protocol error answers this parsed request, so it MUST preserve the
+  // request id. The HTTP transport deliberately waits until after its bounded
+  // body parse before reaching this shared gate.
+  if (options.headerVersion != null && !supportedVersions.includes(options.headerVersion)) {
+    return rejection(
+      'unsupported-version',
+      notification,
+      rpcError(
+        id,
+        UNSUPPORTED_PROTOCOL_VERSION,
+        `Unsupported protocol version: ${options.headerVersion}`,
+        { supported: [...supportedVersions], requested: options.headerVersion },
+      ),
+      provisionalProtocol,
+      requestedEra,
     )
   }
 
@@ -298,18 +287,28 @@ export function admitMcpMessage(rawMessage: unknown, options: McpAdmissionOption
 
   if (era === 'modern') {
     // A modern ProtocolContext is constructible only from the body declaration;
-    // a modern header with no matching body reaches the mirror error below.
+    // a modern header cannot manufacture the required per-request metadata.
     if (!isModernProtocolVersion(declaredVersion)) {
       const problem = `params._meta.${META_PROTOCOL_VERSION} is required and must match the MCP-Protocol-Version header (${options.headerVersion})`
       return rejection(
-        'header-mismatch',
+        'invalid-modern-metadata',
         notification,
-        rpcError(id, HEADER_MISMATCH, `Header mismatch: ${problem}`),
+        rpcError(id, -32602, `Invalid params: ${problem}`),
         provisionalProtocol,
         requestedEra,
       )
     }
     const protocol: ModernProtocolContext = { era: 'modern', version: declaredVersion, supportedVersions }
+    const metaProblems = modernRequestMetaProblems(request)
+    if (metaProblems.length > 0) {
+      return rejection(
+        'invalid-modern-metadata',
+        notification,
+        rpcError(id, -32602, `Invalid params: ${metaProblems.join('; ')}`),
+        protocol,
+        requestedEra,
+      )
+    }
     if (options.requireModernVersionHeader && options.headerVersion == null) {
       return rejection(
         'header-mismatch',
@@ -329,16 +328,6 @@ export function admitMcpMessage(rawMessage: unknown, options: McpAdmissionOption
         'header-mismatch',
         notification,
         rpcError(id, HEADER_MISMATCH, `Header mismatch: ${transportProblem}`),
-        protocol,
-        requestedEra,
-      )
-    }
-    const metaProblems = modernRequestMetaProblems(request)
-    if (metaProblems.length > 0) {
-      return rejection(
-        'invalid-modern-metadata',
-        notification,
-        rpcError(id, -32602, `Invalid params: ${metaProblems.join('; ')}`),
         protocol,
         requestedEra,
       )

--- a/src/mcp/hosted-server.ts
+++ b/src/mcp/hosted-server.ts
@@ -75,8 +75,10 @@ export interface HostedMcpContext {
   renderPng?(source: string, opts: RenderOptions & import('../png-contract.ts').PortablePngOutputOptions): Promise<PngRasterResult>
 }
 
-// Streamable HTTP clients negotiate 2025-03-26+; the node transports pin
-// 2024-11-05. Echo whichever supported version the client offers.
+// Streamable HTTP begins at 2025-03-26. The 2024-11-05 revision belongs to the
+// separate local HTTP+SSE transport and must not be advertised by this hosted
+// POST-only endpoint. Echo whichever supported Streamable revision the client
+// offers.
 //
 // Dual-era: 2026-07-28 is the stateless revision (no initialize, no ping,
 // server/discover mandatory); everything before it is handshake-based. We serve
@@ -86,7 +88,7 @@ export interface HostedMcpContext {
 //
 // This constant is the SINGLE authority for the accepted set. The published
 // discovery document (website/build.ts) derives from it; nothing restates it.
-export const SUPPORTED_PROTOCOL_VERSIONS = ['2024-11-05', '2025-03-26', '2025-06-18', '2025-11-25', '2026-07-28']
+export const SUPPORTED_PROTOCOL_VERSIONS = ['2025-03-26', '2025-06-18', '2025-11-25', '2026-07-28']
 
 // Hosted server identity, distinct from the local stdio server's
 // MCP_SERVER_NAME: registries and clients cache tool lists by server identity,

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -77,14 +77,12 @@ const PROTOCOL_VERSION = '2024-11-05'
  * from 2025-11-25, and the 2026-07-28 stateless era (server/discover,
  * per-request `_meta`, resultType, caching hints).
  *
- * One honest caveat, pre-existing and unchanged: this server has never
- * implemented JSON-RPC batching — every transport parses a single object, so an
- * array body is refused with -32600 on every revision. That is exactly what
- * 2025-06-18 and later require, and a deviation for the two older revisions
- * that permit it. The previous 2024-11-05-only pin was, on that axis, the least
- * accurate claim this server could have made.
+ * This stdio transport is newline-delimited and intentionally does not accept
+ * JSON-RPC batch arrays. It therefore omits 2025-03-26, whose receivers MUST
+ * accept batches, while serving the revisions whose wire contract is compatible
+ * with one-message-per-line operation.
  */
-export const STDIO_PROTOCOL_VERSIONS = ['2024-11-05', '2025-03-26', '2025-06-18', '2025-11-25', '2026-07-28'] as const
+export const STDIO_PROTOCOL_VERSIONS = ['2024-11-05', '2025-06-18', '2025-11-25', '2026-07-28'] as const
 
 /**
  * What the HTTP+SSE transport serves — and it is literally the 2024-11-05 one:

--- a/src/mcp/tool-surface.ts
+++ b/src/mcp/tool-surface.ts
@@ -89,7 +89,10 @@ export const MCP_SERVER_NAME = 'agentic-mermaid-mcp'
 // The release identity gate keeps this runtime-safe constant synchronized with
 // package.json so every MCP handshake reports the published package version.
 export const MCP_SERVER_VERSION = PACKAGE_VERSION
-const SERVER_CAPABILITIES = { tools: {}, prompts: {}, resources: {} } as const
+// The product surface is tools-only. Advertising an empty prompt/resource
+// namespace makes clients probe methods we do not implement and overstates the
+// server's scope; optional MCP features must be claimed only when complete.
+const SERVER_CAPABILITIES = { tools: {} } as const
 export const PURE_COMPUTE_ANNOTATIONS = {
   readOnlyHint: true,
   destructiveHint: false,
@@ -379,11 +382,11 @@ export function surfaceSupportedVersions<Context>(surface: McpServerSurface<Cont
 }
 
 /** server/discover is the modern replacement for initialize. Its version list
- * is deliberately modern-only: legacy revisions are negotiated by initialize
- * and do not belong in this method's stateless contract. */
+ * reports every revision this exact surface/transport accepts, including
+ * legacy revisions a dual-era client may select for its next request. */
 function discoverResult<Context>(surface: McpServerSurface<Context>, supportedVersions: readonly string[]) {
   return {
-    supportedVersions: supportedVersions.filter(isModernProtocolVersion),
+    supportedVersions: [...supportedVersions],
     capabilities: SERVER_CAPABILITIES,
     instructions: surface.instructions,
   }
@@ -485,8 +488,6 @@ export async function dispatchAdmittedMcpRequest<Context>(message: AdmittedMcpMe
       response = await surface.handleToolCall(id, { ...req.params, arguments: args }, context)
       break
     }
-    case 'prompts/list': response = reply(id, { prompts: [] }); break
-    case 'resources/list': response = reply(id, { resources: [] }); break
     default: response = unknownMethod(id, req.method)
   }
   return notification ? null : decorateMcpResult(response, req.method, era, surface.serverName ?? MCP_SERVER_NAME)
@@ -502,7 +503,7 @@ export async function dispatchAdmittedMcpRequest<Context>(message: AdmittedMcpMe
 export const LIST_RESULT_TTL_MS = 300_000
 
 /** The operations the spec requires caching hints on, intersected with ours. */
-const CACHEABLE_METHODS = new Set(['server/discover', 'tools/list', 'prompts/list', 'resources/list'])
+const CACHEABLE_METHODS = new Set(['server/discover', 'tools/list'])
 
 /**
  * Result fields this revision requires, applied on the MODERN path only.

--- a/website/src/mcp-handler.ts
+++ b/website/src/mcp-handler.ts
@@ -16,7 +16,6 @@
 import { admitHostedRequest, handleAdmittedHostedRequest, cacheKeyFor, HOSTED_MCP_SERVER_NAME, LOCAL_FALLBACK_HINT, SUPPORTED_PROTOCOL_VERSIONS, type HostedMcpContext } from '../../src/mcp/hosted-server.ts'
 import { isJsonContentType, preserveExactJsonRpcIds, reply, rpcError, stringifyJsonRpc, type ExactJsonRpcId, type JsonRpcRequest, type JsonRpcResponse } from '../../src/mcp/protocol.ts'
 import {
-  admitMcpHeaderVersion,
   isAdmittedMcpRequest,
   type AdmittedMcpMessage,
   type AdmittedMcpRequest,
@@ -407,17 +406,10 @@ export function createMcpHandler(options: McpHandlerOptions): (request: Request)
     if (request.method !== 'POST') {
       return transportError(405, 'use POST with a JSON-RPC body; this MCP endpoint is stateless and offers no server-initiated stream', cors, { Allow: 'POST, OPTIONS' })
     }
-    // MCP-Protocol-Version validation: an explicit unsupported version is 400
-    // (a missing header stays permitted for pre-2025-06-18 clients that never
-    // send one). Used below to enforce that revision's single-message rule.
-    //
-    // The error is UnsupportedProtocolVersionError (-32022) carrying the
-    // supported list, not a bare message: that `data.supported` array is what
-    // lets a client pick a mutually supported version and retry instead of
-    // failing. The negotiation flow depends on it.
+    // A missing header stays permitted for pre-2025-06-18 clients. Explicit
+    // unsupported versions are rejected by message admission after the bounded
+    // body parse so a request error can echo its JSON-RPC id.
     const protocolVersion = request.headers.get('mcp-protocol-version')
-    const headerAdmission = admitMcpHeaderVersion(protocolVersion, SUPPORTED_PROTOCOL_VERSIONS)
-    if (headerAdmission) return json(400, headerAdmission.response, cors)
     if (!isJsonContentType(request.headers.get('content-type'))) {
       return transportError(415, 'content-type must be application/json', cors)
     }
@@ -450,11 +442,18 @@ export function createMcpHandler(options: McpHandlerOptions): (request: Request)
     if (Array.isArray(parsed)) {
       event.method = 'batch'
       event.batch_size = parsed.length
+      // A batch has no single request id to correlate. Reject an unsupported
+      // transport pin before applying the revision-specific batch rule.
+      if (protocolVersion !== null && !SUPPORTED_PROTOCOL_VERSIONS.includes(protocolVersion)) {
+        return json(400, rpcError(null, -32022, `Unsupported protocol version: ${protocolVersion}`, {
+          supported: [...SUPPORTED_PROTOCOL_VERSIONS], requested: protocolVersion,
+        }), cors, exact.ids)
+      }
       // 2025-06-18 removed JSON-RPC batching, and every later revision keeps it
       // removed — 2026-07-28 requires the POST body to be a SINGLE request or
       // notification. Compared lexically, which is chronological for ISO dates,
       // so a new revision inherits the rule instead of needing a new branch.
-      // Older negotiated versions (2024-11-05 / 2025-03-26, or no header) may
+      // The original Streamable HTTP revision (2025-03-26, or no header) may
       // still batch.
       if (protocolVersion !== null && protocolVersion >= '2025-06-18') {
         return json(400, { jsonrpc: '2.0', id: null, error: { code: -32600, message: `JSON-RPC batching was removed in MCP 2025-06-18; send a single message (negotiated ${protocolVersion})` } }, cors, exact.ids)


### PR DESCRIPTION
## What

Make each Agentic Mermaid MCP surface advertise only the protocol revisions and capabilities its transport actually implements, correct modern request admission and error correlation, and add stronger conformance and eval gates.

## Why

The compliance review found four related trust gaps:

- hosted and local surfaces advertised capability/version combinations that their transports did not fully serve;
- unsupported-version responses could lose a valid JSON-RPC request id;
- empty prompt/resource handlers overstated the product surface;
- the eval portfolio lacked an official conformance lane, protocol-input negatives, family-balanced layout reporting, and complete corpus/eval provenance.

This follows a direct repository compliance audit; there is no separate issue.

## How

- Advertise a tools-only MCP capability surface and return Method Not Found for unadvertised prompt/resource methods.
- Derive exact supported-version lists per hosted Streamable HTTP, local stdio, and local HTTP+SSE transport.
- Parse bounded request bodies before request-level protocol rejection so `-32602`, `-32020`, and `-32022` errors retain the correct meaning and request id.
- Emit modern cache hints only for implemented cacheable list methods.
- Add a pinned official MCP conformance CI lane with a strict, applicability-only expected-failure baseline plus a committed 13-case protocol-input matrix.
- Add family-balanced layout summaries, pinned Mermaid corpus provenance, and eight new skill-eval cases with full slice taxonomy and leakage-safe assertions.
- Record the durable lessons and user-facing changes in Lessons Learned and the changelog.

Alternatives considered:

- Synthetic empty optional methods were rejected because an empty namespace is still a capability claim.
- Harness-only diagnostic tools were rejected because test fixtures should not expand the production tool surface.
- Shared dispatcher support was rejected as proof of transport compliance; the advertised list now reflects the actual surface/transport intersection.

## Testing

- `bun test src/__tests__/ --timeout 30000 --only-failures` — 7,080 passed, 57 skipped, 0 failed across 7,137 tests on the rebased tree.
- `bun run typecheck` — passed.
- `bun run lint` — passed, including 78 contract-lint tests.
- `bun run eval:mcp-conformance` — all five official scenarios passed; caching and stateless expected failures matched the strict applicability baseline exactly.
- `skill-benchmark validate skill-evals/shared-benchmark.json` — 39 cases and 4 ablations validated.
- `skill-benchmark audit-manifest skill-evals/shared-benchmark.json --format markdown` — no findings or recommendations.
- The protocol-input matrix and response corpus directly assert the former failure shapes: overclaimed methods, incorrect transport version lists, missing request-id correlation, and incorrect modern error codes.

The optional `--strict-holdback` skill validation cannot run in this checkout because its two gitignored private prompt fixtures are intentionally absent; the public manifest and leakage audit are green.

## Risk

Moderate. The patch changes shared admission and discovery behavior, so a client that depended on an overclaimed optional method or transport revision will now receive an explicit refusal. The risk is bounded by transport-specific dual-era tests, the full repository suite, the official conformance lane, and exact negative wire-contract fixtures.

Rollback is a single commit revert. There are no data migrations, deployment-state changes, dependency upgrades, or rendered-pixel changes.
