### PR TITLE
fix: tolerate static cache during promotion

### DIFF
--- a/.github/workflows/deploy-cloudflare.yml
+++ b/.github/workflows/deploy-cloudflare.yml
@@ -422,8 +422,10 @@ jobs:
       - name: Smoke-test the promoted production website
         id: production-site-verify
         if: steps.cloudflare-secrets.outputs.available == 'true' && steps.npm-version.outputs.available == 'true'
-        env:
-          SITE_SMOKE_EXPECTED_SHA: ${{ env.EXPECTED_SHA }}
+        # The immutable candidate smoke above proves the static site was built
+        # from EXPECTED_SHA, while the preceding /mcp check proves that Worker
+        # version is serving production traffic. Do not require cached static
+        # machine resources to change SHA atomically at promotion time.
         run: |
           bun run scripts/site/smoke-live-site.ts
           echo "verified=true" >> "$GITHUB_OUTPUT"

--- a/src/__tests__/production-site-smoke.test.ts
+++ b/src/__tests__/production-site-smoke.test.ts
@@ -140,6 +140,7 @@ describe('production website smoke deployment wiring', () => {
       workflow.indexOf('- name: Roll back any unverified deployment'),
     )
     expect(promoted).toContain('id: production-site-verify')
+    expect(promoted).not.toContain('SITE_SMOKE_EXPECTED_SHA')
     expect(promoted).toContain('echo "verified=true" >> "$GITHUB_OUTPUT"')
   })
 

--- a/website/README.md
+++ b/website/README.md
@@ -86,6 +86,9 @@ stale main commit or a browser bundle that differs from the exact npm package,
 attaches the uploaded Worker version at 0%, probes that immutable candidate
 through the production domain, smoke-tests the website routes and hosted MCP,
 then either promotes it to 100% and repeats both checks or restores the previous
-version.
+version. The candidate website smoke requires the exact target git SHA. The
+post-promotion website smoke checks semantic health without requiring cached
+static machine resources to switch SHAs atomically; the adjacent `/mcp`
+attestation proves the promoted Worker SHA.
 
 The site still exposes no REST render API: `/mcp` speaks MCP JSON-RPC only. Code Mode `execute` runs agent JavaScript exclusively inside per-code dynamic-worker isolates with no bindings and no network.


### PR DESCRIPTION
## Summary

- keep the exact git SHA assertion on the immutable zero-traffic website candidate
- let the post-promotion website gate validate semantic route health while the adjacent MCP attestation proves the promoted Worker SHA
- document and regression-test the Cloudflare static-cache transition contract

## Why

The first protected deployment correctly rolled back after the promoted website smoke observed the prior cached machine-resource SHA immediately after promotion. The candidate website and promoted MCP checks had already proved the target build and Worker version. Static machine resources do not switch cache entries atomically with Worker traffic.

## Validation

- bun test src/__tests__/production-site-smoke.test.ts src/__tests__/mcp-deploy-rate-budget.test.ts
- npm run lint
- bun run scripts/site/smoke-live-site.ts (73 live production checks)