### PR TITLE
Simplify the delivery plan for Mermaid fidelity gaps (#248)

### DIFF
--- a/docs/project/issue-248-fidelity-delivery-plan.md
+++ b/docs/project/issue-248-fidelity-delivery-plan.md
@@ -370,7 +370,7 @@ type FidelityStageExpectation =
 
 interface FidelityInvocation {
   invocationId: string
-  sourceRef: 'case-source'
+  sourceRef: string
   publicRoute: string
   renderOptions: Readonly<Record<string, JSONValue>>
   config?: Readonly<Record<string, JSONValue>>
@@ -380,18 +380,49 @@ interface FidelityInvocation {
   interaction?: Readonly<Record<string, JSONValue>>
 }
 
+interface FidelitySource {
+  sourceId: string
+  source: string
+  role: 'authored' | 'metamorphic-variant' | 'boundary' | 'malformed'
+  derivedFromSourceId?: string
+  transformId?: string
+}
+
+type FidelityResultRef =
+  | { kind: 'invocation'; invocationId: string; stage: FidelityStage }
+  | { kind: 'mutation'; mutationId: string }
+
 interface FidelityMutationInvocation {
   mutationId: string
-  invocationId: string
+  constructIds: readonly [string, ...string[]]
+  input: { invocationId: string; stage: FidelityStage }
   operation: FamilyMutationOperation
+  oracle: { id: string; schemaVersion: number }
+  preserveOracles: readonly [{ id: string; schemaVersion: number }, ...{
+    id: string
+    schemaVersion: number
+  }[]]
+  diagnostics: readonly FidelityDiagnosticExpectation[]
 }
 
 interface FidelityComparison {
   comparisonId: string
-  leftInvocationId: string
-  rightInvocationId: string
+  left: FidelityResultRef
+  right: FidelityResultRef
   oracle: { id: string; schemaVersion: number }
 }
+
+type FidelityMutationPlan =
+  | {
+      state: 'applicable'
+      entries: readonly [FidelityMutationInvocation, ...FidelityMutationInvocation[]]
+    }
+  | {
+      state: 'not-applicable'
+      entries: readonly []
+      reasonCode: string
+      upstreamEvidence: readonly [string, ...string[]]
+    }
 
 interface FamilyFidelityCase {
   caseId: string
@@ -399,9 +430,9 @@ interface FamilyFidelityCase {
   constructIds: readonly [string, ...string[]]
   authority: FidelityAuthorityRef
   upstreamRevision: string
-  source: string
+  sources: readonly [FidelitySource, ...FidelitySource[]]
   invocations: readonly [FidelityInvocation, ...FidelityInvocation[]]
-  mutations: readonly FidelityMutationInvocation[]
+  mutationPlan: FidelityMutationPlan
   comparisons: readonly FidelityComparison[]
   stages: readonly [FidelityStageExpectation, ...FidelityStageExpectation[]]
   divergenceId?: string
@@ -424,9 +455,12 @@ applies, native aggregation additionally requires a structured agent oracle;
 opaque preservation caps the aggregate at `source-preserved` even when
 downstream native rendering succeeds.
 
-Every expectation and diagnostic references a declared invocation, and every
-declared route has an exact stage-coverage policy. Define the stage dependency
-graph explicitly. A locally blocked downstream stage remains semantically
+Every source reference, expectation, diagnostic, result reference, and mutation
+input resolves to a declared object, and every declared route has an exact
+stage-coverage policy. A comparison names the exact invocation-stage or
+mutation result it consumes; an oracle cannot substitute a hidden source,
+stage, invocation, or mutation. Define the stage dependency graph explicitly.
+A locally blocked downstream stage remains semantically
 `applicable`, carries the blocking stage/invocation plus the required semantic
 oracle, stays in
 the claim denominator, and inherits the blocking disposition as an aggregate
@@ -435,13 +469,20 @@ irrelevance. Agent parsing does not block an independently executable native-
 render invocation. Stage-specific diagnostics must match the referenced public
 route and cannot be satisfied by a warning from another invocation.
 
-Invocations, render options, typed family mutations, interactions, and A/B
-comparisons are declarative and schema-versioned. The runner owns route
+Invocations, named authored/source-variant inputs, render options, typed family
+mutations, interactions, and A/B or metamorphic comparisons are declarative and
+schema-versioned. Source variants carry an explicit derivation and transform
+identity rather than being selected inside an oracle. The runner owns route
 adapters, diagnostic collectors, and the registry for the discriminated
 `FamilyMutationOperation` union. Oracles may normalize and assert supplied
 results, but must not secretly select inputs, routes, configuration variants,
-backends, or mutations. Every config-key and theme-variable effect case joins
-to an explicit named A/B invocation pair.
+backends, or mutations. Every mutation has its own result oracle and a non-empty
+set of preservation oracles for semantic facets unrelated to the operation.
+For every case with a structured applicable construct, the union of mutation
+`constructIds` must exactly cover those constructs; empty mutation coverage is
+valid only through a reviewed `not-applicable` reason with upstream evidence.
+Every config-key and theme-variable effect case joins to an explicit named A/B
+invocation pair.
 
 Pinned Mermaid rejecting the source is the only ordinary basis for local
 `reject`. An official fence may also be rejected when it is proven partial or
@@ -459,8 +500,9 @@ detection
   `-> native parser -> layout -> native semantic projection
                                      |-> Scene and output implication
                                      |-> canonical serialize/reparse
-                                     `-> each declared typed mutation
-  named A/B comparisons join their declared invocation results
+                                     `-> each declared typed mutation result
+  named A/B and metamorphic comparisons join their declared invocation-stage
+  or mutation results
 ```
 
 It records disposition and semantic results, not just thrown/not-thrown status.
@@ -669,8 +711,12 @@ for A4's report migration.
    rejects or emits exact runtime diagnostics for gradient/compositing and keeps
    every affected capability/report row downgraded.
 4. **C4: Sankey receipts and closure** — source-to-target gradient stops,
-   multiply overlap, contrast behavior, header consistency, and final report
-   state.
+   multiply overlap, contrast behavior, header consistency, quoted-field
+   whitespace identity, and final report state. The identity receipt must prove
+   that leading/trailing whitespace inside quoted fields follows the pinned
+   Mermaid normalization (currently trim-before-node-identity), or record an
+   exact diagnosed divergence; preserving the whitespace while claiming native
+   identity is a failure.
 
 If #192 is used as C3, it cannot merge or contribute to any programme claim
 until that PR itself passes the complete audit loop on its final tuple. If it
@@ -690,7 +736,8 @@ Create focused child issues and PRs for:
 - ER word-form aliases;
 - Timeline `%` comments and unsupported header directions;
 - XY Chart unknown-statement rejection; and
-- Sankey gradients/compositing and header claim consistency through Stack C.
+- Sankey gradients/compositing, quoted-field whitespace identity, and header
+  claim consistency through Stack C.
 
 Each family PR adds the receipt first, proves it discriminates, fixes both agent
 and native paths as applicable, and regenerates the affected claim rows.
@@ -916,6 +963,9 @@ Close #248 only when all of the following hold:
 - agent parse, verification, native render, serialization, mutation, Scene,
   applicable output, accessibility, and interaction behavior agree with the
   case policy;
+- every structured applicable construct is covered by at least one named typed
+  mutation result, every declared mutation has a discriminating oracle, and its
+  preservation oracles prove that unrelated semantic facets remain unchanged;
 - every config key and expanded theme-variable leaf path has exactly one
   executable effect disposition joined to a named A/B invocation pair;
 - capability and citizenship reports derive from passing receipts and
@@ -928,7 +978,9 @@ Close #248 only when all of the following hold:
 - every Phase 0 defect is fixed or truthfully downgraded with a discriminating
   regression receipt;
 - Sankey receipts observe endpoint stops and overlap compositing, not merely a
-  changed stroke byte;
+  changed stroke byte, and prove pinned trim-before-identity behavior for
+  leading/trailing whitespace in quoted fields or an exact diagnosed
+  divergence;
 - generated authorities have no unexplained drift;
 - the full validation ladder passes; and
 - a final cross-programme multi-agent audit of the closure head returns

--- a/docs/project/issue-248-fidelity-delivery-plan.md
+++ b/docs/project/issue-248-fidelity-delivery-plan.md
@@ -2,9 +2,12 @@
 
 Status: proposed. This document turns
 [#248](https://github.com/adewale/agentic-mermaid/issues/248) into a staged
-delivery programme. The issue remains the authority for the audited findings
-and closure criteria; this plan owns sequencing, PR boundaries, dependency
-policy, and review discipline.
+delivery programme. The issue remains the tracking and historical-evidence
+record. This repository document supplies the initial scoped family authority;
+after A1, the checked-in, versioned `FidelityScopeAuthority` is the sole
+executable closure authority. Editing the issue alone cannot change programme
+scope. This plan also owns sequencing, PR boundaries, dependency policy, and
+review discipline.
 
 ## 1. Decision
 
@@ -131,6 +134,10 @@ blocks programme closure, and may be promoted only when an exact runtime
 diagnostic or native fix lands. Divergence ledgers are inputs to aggregation,
 not parallel documentation.
 
+`uncovered` is an internal migration state, not a public capability
+disposition. It carries no behavioral claim, always projects to public
+`absent`, and cannot satisfy native, diagnosed, or final-closure coverage.
+
 ### 3.4 Every regression test must discriminate
 
 For each behavioral fix, demonstrate that the focused test or receipt is red on
@@ -156,17 +163,34 @@ must pass the following loop before it is marked ready or merged.
 1. Finish the scoped implementation.
 2. Commit the complete candidate and require a clean working tree. An
    uncommitted or dirty candidate cannot begin a formal audit round.
-3. Run the mandatory baseline and touched-authority checks from §9.
+3. Freeze the complete semantic PR title/body. Record its SHA-256 and GitHub
+   `lastEditedAt`; dynamic workflow run IDs and audit status do not belong in
+   that body.
 4. Record the candidate tuple: repository ID, PR number, target branch,
    target-tip SHA, merge-base SHA, head SHA, intended merge strategy, protected
-   governance-policy revision, and frozen semantic PR title/body digest.
-   Recompute and record the head-tree and full-diff digests as derived integrity
-   receipts rather than treating them as additional identity fields.
-5. Before dispatch, create a content-addressed round manifest that registers
+   governance-policy revision, and semantic-description digest. Recompute and
+   record the head tree and canonical delta digest as derived integrity receipts
+   rather than additional identity fields. `git-raw-tree-delta-v1` is SHA-256
+   over the exact NUL-delimited stdout of:
+
+   ```text
+   git -c core.abbrev=40 -c color.ui=false diff-tree --no-commit-id -r --raw -z --abbrev=40 --no-renames <merge-base> <head>
+   ```
+
+   Record the repository object format. Rendered patches, abbreviated object
+   IDs, textconv, external diff drivers, rename heuristics, locale, and object-
+   count-dependent abbreviation are not identity inputs; a binary patch may be
+   retained only as human-readable review evidence.
+5. Run the mandatory baseline and touched-authority checks from §9 against that
+   exact frozen state. A0 checks attest the semantic digest; during bootstrap,
+   every accepted provider run must start after `lastEditedAt`.
+6. Immediately before registration, reread the live PR metadata, target tip,
+   tuple, digests, and newest required runs. Any difference restarts preparation.
+7. Before dispatch, create a content-addressed round manifest that registers
    the three role/session/run IDs, prompt/scope hashes, candidate tuple, tree/
-   diff digest, and timestamp.
-6. Freeze implementation work while the auditors inspect that registered
-   candidate.
+   canonical-delta digest, and timestamp.
+8. Freeze implementation and semantic-description work while the auditors
+   inspect that registered candidate.
 
 ### 4.2 Run at least three independent agent audits
 
@@ -195,7 +219,7 @@ architecture/dependency feasibility, and enforceability/adversarial review.
 
 Each auditor must return:
 
-- `APPROVE` or `CHANGES_REQUIRED`;
+- `APPROVED` or `CHANGES_REQUIRED`;
 - stable finding IDs ordered by severity;
 - exact file, contract, or upstream evidence for each finding;
 - the smallest acceptable correction; and
@@ -217,7 +241,10 @@ the complete registered role set.
    acceptance criteria.
 3. Rerun focused and affected wider checks.
 4. Start a new independent audit round against the new candidate tuple.
-5. Repeat until every auditor returns `APPROVE` with no actionable findings.
+5. Repeat until every auditor returns `APPROVED` with no actionable findings.
+
+`AuditVerdict` is exactly `APPROVED | CHANGES_REQUIRED`. Manifests, prompts,
+reconciliation, readiness parsers, and examples must reject every other token.
 
 Any change to the repository/PR identity, semantic title/body digest, head SHA,
 target-tip SHA, merge-base SHA, target branch, intended merge strategy, or
@@ -225,7 +252,7 @@ protected governance-policy revision invalidates checks and approval and
 requires another round. This includes target-branch advancement, semantic PR
 description edits, retargeting, parent-PR merge, and rebasing even when the
 child head tree appears unchanged. Immediately before merge, compare the
-current tuple, tree/diff and semantic-description digests, required workflow
+current tuple, tree/canonical-delta and semantic-description digests, required workflow
 and governance-policy revisions, and newest non-superseded provider-issued
 check runs with the final audit record and fail closed on any difference. A
 newer failed or cancelled run for the same tuple supersedes an older success.
@@ -234,7 +261,8 @@ newer failed or cancelled run for the same tuple supersedes an older success.
 
 The trusted runner preserves each individual first report as a content-addressed
 immutable payload. One detached signed or protected round envelope records all
-payload hashes, roles, actor/session/run identities, candidate tuple, tree/diff
+payload hashes, roles, actor/session/run identities, candidate tuple, tree/
+canonical-delta
 and semantic-description digests, prompt/scope hashes, timestamps, commissioned-
 run reconciliation, and finding ledger. Never require a payload to contain its
 own byte hash. The PR conversation needs one machine-owned comment per round
@@ -267,18 +295,21 @@ This plan PR and the A0 governance PR necessarily precede the trusted audit
 runner. They use one explicit, temporary bootstrap protocol; no later PR may
 claim this exception:
 
-1. commit a clean candidate and record repository/PR identity, semantic
-   title/body digest, target tip, merge base, head, tree, diff digest, protected
-   policy revision, and squash strategy;
-2. run `git diff --check <merge-base>...<head>` and verify the changed-path set;
+1. commit a clean candidate, freeze its semantic title/body, and record its
+   digest and GitHub `lastEditedAt` together with repository/PR identity, target
+   tip, merge base, head, tree, canonical delta digest, protected policy
+   revision, and squash strategy;
+2. run `git diff --check <merge-base>...<head>`, verify the changed-path set,
+   and compute the canonical `git-raw-tree-delta-v1` receipt from §4.1;
 3. validate the external issue/PR links with `gh issue view 248` and
    `gh pr view 192`, and require every target-bound `gh pr checks` identity to
-   be complete and green before registration or dispatch;
+   start after the recorded `lastEditedAt` and be complete and green before
+   registration or dispatch;
 4. before dispatch, anchor a canonical round-manifest payload in an
    independently controlled append-only record that does not mutate the frozen
    candidate: a protected audit ref, signed annotated tag, or server-issued
    immutable record. A detached envelope records the manifest payload hash,
-   session IDs, prompt/scope hashes, tuple, tree/diff and semantic-description
+   session IDs, prompt/scope hashes, tuple, tree/canonical-delta and semantic-description
    digests, timestamp, and anchor object/URL. A PR comment points to that anchor
    but is not its authority;
 5. require each auditor to publish the first report through an independently
@@ -307,13 +338,17 @@ trusted runner artifacts and automation.
 
 The current syntax-feature inventory is derived largely from documentation
 headings and the upstream manifest covers families outside #248. A1 must first
-generate one `FidelityScopeAuthority` containing exactly the 16 families named
-by #248: the 15 built-ins on `main` plus Sankey. It then establishes the scoped
+generate one repository-versioned `FidelityScopeAuthority` containing exactly
+these initial family IDs: `flowchart`, `state`, `sequence`, `timeline`, `class`,
+`er`, `journey`, `architecture`, `xychart`, `pie`, `quadrant`, `gantt`,
+`mindmap`, `gitgraph`, `radar`, and `sankey`. It then establishes the scoped
 construct roster from pinned grammar/spec blocks, official fences, and config
 authority, with reviewed many-to-many mappings to documentation headings and
 manifest coordinates. Manifest rows outside this family authority remain in an
 explicit unsupported/out-of-scope envelope; they do not silently enter this
-programme or require projectors and cases.
+programme or require projectors and cases. A scope amendment requires an
+audited repository PR that changes the authority and its digest; synchronize the
+tracking issue, but do not treat it as a trust root.
 
 A2 generates a versioned public-route registry from canonical SDK declarations,
 CLI command/selector tables, MCP tool declarations, browser/editor/website
@@ -325,10 +360,10 @@ string or hand-maintained in cases.
 
 Exact-set validation must prove:
 
-- the in-scope family-ID set equals the 16-family authority unless #248 itself
-  is amended;
-- every scoped construct maps to at least one fidelity case and every case maps
-  back to scoped constructs and authorities;
+- the in-scope family-ID set equals the repository-versioned scope authority;
+- every scoped construct and manifest authority generates at least one coverage
+  obligation, every case maps back to scoped constructs and authorities, and
+  final closure requires every obligation to be discharged by executable cases;
 - every scoped manifest `syntaxFeature`, official `example`, `configKey`, and
   `themeVariable` appears in its typed index, while every unscoped row has an
   explicit out-of-scope disposition;
@@ -353,13 +388,30 @@ independent evidence. Use two exact, joined contracts instead:
 2. route-conformance cases prove every public adapter's accepted inputs,
    operation, selector, output, diagnostics, and pass-through/projection rules.
 
-An adapter may use factored conformance only when its registry declaration and
-tests prove it is family-agnostic: it delegates to the canonical core without
-branching on family or construct, and its touched-authority rule invalidates
-that classification when dispatch code changes. Any family/construct-specific
-branch is `route-specific` and requires direct family-case coverage for the
-affected constructs. A2 owns the precise TypeScript schema; this plan requires
-the following records and joins rather than freezing implementation syntax:
+Factored conformance is permitted only when an adapter proves a refinement to
+the canonical core for every generated route contract. An `opaque-transport`
+adapter must prove across its complete transitive production dependency closure
+that it cannot inspect or modify family, construct, source, options,
+diagnostics, semantic results, Scene data, or output bytes except through
+schema-checked lossless envelope serialization. Caching, normalization,
+coercion, security/option projection, diagnostic mapping, mutation/build
+handling, output conversion, truncation, and output-size policy are
+transformations, not opaque transport.
+
+A2 generates an exact-set `RouteTransformAuthority`. Every transformation has a
+stable contract ID, declared affected input and semantic-implication IDs, and a
+versioned refinement oracle. The runner records normalized source/request,
+operation, selector, output, config/theme/interaction/options, core result, and
+diagnostic identities at the adapter handoff, then proves that the public result
+equals the declared projection. Every semantic cell declares the implication
+IDs it proves. Missing, extra, dynamic, unclassified, or orphaned joins fail
+generation. Absence of family/construct branching is insufficient; a transform
+without a finite authoritative implication mapping is `route-specific` and
+requires direct affected-construct coverage. Touched-authority invalidation
+includes the adapter's transitive codecs, projectors, and dependencies.
+
+A2 owns the precise TypeScript schema; this plan requires the following records
+and joins rather than freezing implementation syntax:
 
 | Record | Required data |
 | --- | --- |
@@ -367,9 +419,16 @@ the following records and joins rather than freezing implementation syntax:
 | Source | Stable ID, exact source, authored/metamorphic/boundary/malformed role, and base/transform IDs for a derived variant |
 | Invocation | Stable ID, source/mutation/build kind, canonical core or public route ID, source or family input, and declarative options/operations |
 | Semantic cell | Stable ID, construct ID, invocation ID, stage, disposition, oracle/diagnostic requirements, or governed blocking/not-applicable evidence |
-| Public route | Generated transport, operation, entrypoint, selector, optional output, owning adapter, pass-through/route-specific mode, family/input applicability, and reachable stages |
-| Route-conformance case | Stable ID, route ID, contract IDs, fixture invocation IDs, oracle, and diagnostic expectations |
+| Public route | Generated transport, operation, entrypoint, selector, optional output, owning adapter, opaque-transport/refined-transform/route-specific mode, family/input applicability, and reachable stages |
+| Route transform | Stable contract ID, affected input/implication IDs, transitive dependency coordinates, handoff/result identity fields, and refinement oracle |
+| Route-conformance case | Stable ID, route ID, transform/contract IDs, fixture invocation IDs, core-handoff witness, refinement oracle, and diagnostic expectations |
 | Comparison | Stable ID, construct IDs, two exact invocation-stage results, and a versioned oracle |
+| Coverage obligation | Stable authority coordinate, required family/input/stage or route contract, state (`uncovered` or `discharged`), and resolving case/cell IDs when discharged |
+
+Coverage obligations are generated exhaustively from scope and route
+authorities before cases are authored. `uncovered` is permitted only during
+migration: it maps to public `absent`, cannot satisfy a claim, and fails final
+programme closure. This preserves exact-set accounting while evidence lands.
 
 `FidelityStage` covers detection, agent parse, verification, native parse,
 configuration, layout, Scene, SVG, PNG, terminal, serialization, mutation,
@@ -391,11 +450,16 @@ The route grid contains exactly one conformance result for every generated
 public route × accepted input kind × operation/selector/output contract. It
 checks real transport admission, option/config/theme/interaction pass-through,
 diagnostic envelopes, mutation atomicity, serialization, output bytes, and
-security rules as applicable. Use a small cross-family fixture set chosen by
-semantic category, not one fixture per construct. A `route-specific` adapter
-also generates direct required family-case cells for each affected construct.
-Aggregation permits a public native claim only when both its semantic cells and
-the applicable route-conformance cells pass.
+security rules as applicable. Use one discriminating case for every generated
+route-transform contract and equivalence class. A small cross-family fixture set
+provides concrete controls for declared pass-through/refinement invariants; it
+is not their sole proof. Property or metamorphic cases cover generic transforms
+and boundary policies that exact digest equality cannot establish. Cache
+conformance proves every semantic request field participates in the cache key.
+A `route-specific` adapter also generates direct required family-case cells for
+each affected construct or implicated semantic type. Aggregation permits a
+public native claim only when both its semantic cells and applicable route-
+conformance/refinement cells pass.
 
 Every invocation, cell, diagnostic, comparison, source, route case, and
 authority reference must resolve and have reverse coverage. Public mutation and
@@ -407,6 +471,23 @@ facets. A route that does not support an operation must emit an exact diagnosed
 outcome or carry governed `not-applicable` evidence; the programme does not
 require inventing a mutation API merely to satisfy a native render claim.
 
+The generator also derives exact mutation/build membership indexes without
+multiplying constructs across transports. Every structured `(case ID, construct
+ID, source ID)` membership whose family has a public mutation route participates
+in at least one canonical real-route invocation that mutates the construct or
+proves it survives an unrelated mutation. It requires a discriminating result
+oracle and preservation oracles for unrelated semantic facets. `not-applicable`
+is valid only when no generated public mutation operation can exercise or
+preserve that membership, with typed authority evidence.
+
+For build, every advertised `(family ID, construct ID, build-operation ID)`
+membership participates in at least one real-route sequence whose result oracle
+proves the requested construct and whose preservation oracles prove later
+operations retain unrelated constructs already built. Additional transports use
+route conformance; canonical memberships are not repeated per route. Missing,
+unknown, or orphaned required memberships fail generation, while multiple
+witnesses may satisfy one membership.
+
 Schema validation rejects a native applicable cell without an oracle, a
 source-preserved cell without both a preservation oracle and at least one
 expected runtime diagnostic, a diagnosed/rejected cell without at least one
@@ -415,6 +496,9 @@ cell without a typed reason and authority evidence. Silent loss is not a
 compatibility disposition. When agent parse applies, native aggregation
 additionally requires a structured agent oracle; opaque preservation caps the
 aggregate at `source-preserved` even when downstream rendering succeeds.
+Schema validation also rejects a pass-through route result without a complete
+core-handoff/refinement witness, or a projected result without a versioned
+projection oracle.
 
 Define the stage dependency graph explicitly. A locally blocked downstream
 stage remains applicable, identifies the blocking invocation/stage and required
@@ -456,14 +540,15 @@ regardless of native-render success. Opaque agent success paired with render
 failure additionally requires an exact diagnosed policy rather than
 `verify.ok === true` under an unqualified claim.
 
-A2 adds one deterministic package script, `fidelity:check`. It executes the
-complete scoped semantic and route-conformance corpus against the pinned
-upstream revision, builds raw receipts in a temporary directory, derives the
-compact capability index in the same process, and compares generated committed
-outputs. Committed or manually edited raw result files are never trusted as
-inputs. CI may retain
-the raw receipts as immutable debugging artifacts, but a freshness-only check
-cannot substitute for execution.
+A2 adds one deterministic package script, `fidelity:check`. It executes every
+registered semantic and route-conformance case against the pinned upstream
+revision, validates the complete generated coverage-obligation grids, derives
+public `absent` for every uncovered obligation, builds raw receipts in a
+temporary directory, derives the compact capability index in the same process,
+and compares generated committed outputs. Committed or manually edited raw
+result files are never trusted as inputs. CI may retain the raw receipts as
+immutable debugging artifacts, but a freshness-only check cannot substitute
+for execution.
 
 ### 5.4 Family semantic projectors
 
@@ -503,8 +588,10 @@ Use a two-tier dataflow:
    compact, versioned aggregate capability index consumed by runtime family
    descriptors, CLI discovery, and public report generators;
 3. freshness hashes bind the aggregate to case definitions, the executed result
-   summary, public-route registry and adapter versions, projector/oracle/schema
-   versions, divergence ledgers, and upstream revision;
+   summary, the scope authority's schema version, blob ID, and content digest,
+   the public-route/transform registries and transitive adapter dependency
+   versions, projector/oracle/schema versions, divergence ledgers, and upstream
+   revision;
    and
 4. build metafile, tarball, and bundle negative tests prove that Mermaid oracle
    code, case source, raw receipts, and semantic snapshots do not enter Node,
@@ -555,7 +642,8 @@ adoption PR. Only this plan and A0 may use the manual bootstrap in §4.5:
   `pull_request_target` checkout or execution of candidate bytes is forbidden;
 - extend the PR template and readiness tooling to require one immutable round
   bundle containing the three individual reports, finding ledger, newest check
-  identities, and current tuple/tree/diff/semantic-description digests;
+  identities, and current tuple/tree/canonical-delta/semantic-description
+  digests;
 - fail readiness when reports are missing, roles are reused, findings remain
   unresolved, runs are unreconciled, or approvals/checks are stale or
   superseded;
@@ -581,29 +669,37 @@ implementer-authored manual results are not substitutes after bootstrap.
    - choose the canonical Mermaid 11.16 revision;
    - make all executable artifacts name it or an explicit reviewed
      compatibility revision;
-   - generate the exact 16-family scope, explicit out-of-scope envelope,
-     construct-complete roster, and many-to-many authority joins from §5.1; and
+   - land the repository-versioned exact 16-family scope authority, explicit
+     out-of-scope envelope, construct-complete roster, and many-to-many
+     authority joins from §5.1; and
    - fail generation on unacknowledged splits or roster gaps.
 2. **A2: fidelity contract and runner skeleton**
    - add stable `caseId`, discriminated authority references, construct IDs,
-     deterministic coverage cells, exact-set indexes for scoped features/
-     examples/config keys/theme variables/public routes, route-bound source/
-     mutation/build invocations, A/B comparisons, and a small cross-family
-     exemplar set;
-   - add `fidelity:check` to execute the complete scoped corpus and
-     derive the compact index in one process;
+     generated coverage obligations, exact-set indexes for scoped features/
+     examples/config keys/theme variables/public routes/route transforms/
+     mutation-build memberships, route-bound source/mutation/build invocations,
+     A/B comparisons, and a small cross-family exemplar set;
+   - add `fidelity:check` to execute all registered cases, reject missing,
+     unknown, or orphaned obligations, permit explicit migration-only
+     `uncovered` obligations, project them as public `absent`, and derive the
+     compact index in one process;
    - keep cases, ephemeral raw receipts, snapshots, and upstream adapters behind
      an enforced test/eval-only import boundary;
    - add the deterministic compact-index generator contract and initial bundle
      exclusion tests;
    - do not change public capability claims yet.
-3. **A3: semantic projectors for the complete family roster**
+3. **A3: semantic projectors for enrolled families plus deferred Sankey**
    - A3.0 establishes the runner-owned oracle registry and normalized snapshot/
-     versioning rules, then lands enough projectors for Phase 0;
-   - A3.x family shards complete projectors for all 15 families currently on
-     `main`, with exact-set tracking; and
-   - the Sankey projector shard depends on C3 enrollment.
+     versioning rules and one vertical slice that validates A4 aggregation;
+   - independent A3.x shards add projectors for all 15 families currently on
+     `main`, with exact-set tracking;
+   - A4 depends on A3.0, not completion of every family shard. Unprojected
+     obligations remain present and project as public `absent`; and
+   - the Sankey projector shard alone depends on C3 enrollment and is required
+     for C4 and final 16-family closure.
 4. **A4: receipt-driven reports and citizenship**
+   - depend on A1, A2, and A3.0, then migrate reports before every family
+     projector is complete;
    - feed divergences and freshly executed receipts into capability aggregation;
    - generate the compact versioned runtime/report index and bind its freshness
      hash to scope, cases, executed result summary, routes, projectors/oracles/
@@ -612,7 +708,8 @@ implementer-authored manual results are not substitutes after bootstrap.
      generated-file-only check is insufficient;
    - prove raw evidence and Mermaid oracle code are absent from every shipped
      bundle and tarball;
-   - deliberately downgrade every not-yet-receipted claim during migration;
+   - deliberately downgrade every uncovered, unprojected, or not-yet-receipted
+     claim to `absent` during migration;
    - classify known defects from actual behavior: `diagnosed` only when the
      public path emits the exact asserted diagnostic, otherwise
      `source-preserved` or `absent` as applicable; and
@@ -622,19 +719,21 @@ implementer-authored manual results are not substitutes after bootstrap.
 Primary dependency graph:
 
 ```text
-A0 ───────────────────────────────> every implementation/adoption PR
-A1 -> A2 -> A3 -> A4
-          |           |-> family repairs + relevant B guardrail/projector
-          |           |-> Stack D official-example closure
-          |           `-> Stack E config-effect closure
-          |-> Stack B parser/seam work where the receipt API is required
-          `-> Stack C may start independently from main, but C4 consumes A4
+A0 ─────────────────────────────────────> every implementation/adoption PR
+A1 -> A2 -> A3.0 -> A4
+       |       |-> A3.<family> -> corresponding repair / D / E shard
+       |       `-> A3.sankey (after C3) -> C4
+       |-> Stack B parser/seam work where the receipt API is required
+       `-> generic C1/C2 may start independently from main
+
+C1 + C2 -> C3 -> A3.sankey
+A4 + A3.sankey -> C4 -> final 16-family closure
 ```
 
-Family repairs depend on A4 plus their family projector and relevant guardrail.
-Each family shard in Stacks D and E depends on that family's completed projector
-as well as the receipt schema and aggregation base. B and generic C
-infrastructure may begin earlier where they do not consume those authorities.
+Each non-Sankey family repair and D/E shard depends only on A4, its own completed
+family projector, and its relevant guardrail. No non-Sankey work depends on C3
+or the Sankey projector. B and generic C infrastructure may begin earlier where
+they do not consume those authorities.
 
 ### Stack B — parser and seam guardrails
 
@@ -832,8 +931,9 @@ description sections and include their digest in the candidate tuple:
   command, expected failure signature, observed red failure, and green result
   on the audited head, all linked to the required trusted exact-head job rather
   than supplied only as implementer-authored prose;
-- mandatory baseline and touched-authority checks, with the newest exact-head
-  provider-issued CI job identities and URLs;
+- required baseline and touched-authority check names and commands. Provider
+  run IDs, attempts, URLs, timestamps, and results belong in the pre-dispatch
+  manifest and machine-owned audit comment, not the frozen semantic body;
 - generated artifacts changed and why;
 - stack position and dependencies;
 - residual limitations.
@@ -842,9 +942,13 @@ After dispatch, the round-bundle pointer, finding ledger, round status, and
 final tuple live in machine-owned audit comments and immutable artifacts. They
 are not appended to or edited into the frozen semantic body.
 
-Visual-output PRs must include proportional before/after evidence generated from
-the same named input at immutable base/head revisions. The semantic receipt is
-the oracle; the image helps a reviewer inspect the consequence.
+Visual-output PRs use the same named input/config at immutable base and head
+revisions. When both revisions render, include proportional before/after
+evidence. When the base does not support the surface or fails before producing
+an artifact, preserve that exact error or unsupported receipt as the honest
+baseline and provide the head image; never fabricate a before render. The
+semantic receipt is the oracle, the image helps inspect the consequence, and
+the description states the evidence's material limitation.
 
 ## 9. Validation ladder
 
@@ -937,19 +1041,21 @@ and generated reports become the live authority.
 
 Close #248 only when all of the following hold:
 
-- the generated family scope equals the 16 families named by #248 unless the
-  issue is explicitly amended, and every unscoped manifest family/row has an
+- the generated family scope equals the current repository-versioned
+  `FidelityScopeAuthority`, and every unscoped manifest family/row has an
   explicit out-of-scope disposition;
 - every officially authorable scoped construct has freshly executed coverage;
 - the scoped construct, feature, example, config-key, theme-variable, source,
-  public-route, semantic-cell, route-conformance, and case indexes have exact-set
-  closure with no orphan or ambiguous ownership;
+  public-route, route-transform, semantic-cell, route-conformance,
+  mutation/build-membership, coverage-obligation, and case indexes have exact-
+  set closure with no orphan or ambiguous ownership;
 - every construct × named source × applicable core stage has a semantic
   invocation and oracle/diagnostic, and every public route × accepted input ×
   operation/selector/output contract has conformance evidence or an evidenced
-  `not-applicable` disposition; route-specific branches also have direct
-  affected-construct cases; missing, unknown, duplicate, and orphaned cells are
-  zero;
+  `not-applicable` disposition; every factored route has a passing core-handoff/
+  refinement witness, every unproved transformation is route-specific, and
+  route-specific transforms have direct affected-construct cases; uncovered,
+  missing, unknown, duplicate, and orphaned cells are zero;
 - every scoped official fence has a reviewed disposition;
 - every nonblank statement is modeled, preserved with an exact route-specific
   typed runtime diagnostic, or rejected; no silent semantic preservation can
@@ -960,10 +1066,12 @@ Close #248 only when all of the following hold:
 - agent parse, verification, native render, serialization, mutation, Scene,
   applicable output, accessibility, and interaction behavior agree with the
   case policy;
-- every applicable public mutation/build route is exercised through that real
-  route; a native cell has a discriminating result oracle and preservation
-  oracles, while unsupported operations are exactly diagnosed or evidenced
-  not-applicable;
+- the mutation/build membership indexes have exact-set closure; every required
+  structured mutation membership and advertised buildable construct/operation
+  membership has a real-route discriminating result and unrelated-facet
+  preservation oracle, while genuinely unavailable operations carry governed
+  `not-applicable` evidence; applicable public adapters separately pass route
+  conformance;
 - every applicable `(config/theme authority, family, input dialect)` semantic
   cell has exactly one executable effect disposition, with every wired effect
   joined to a named A/B comparison, and each accepting route passes its
@@ -984,7 +1092,7 @@ Close #248 only when all of the following hold:
 - generated authorities have no unexplained drift;
 - the full validation ladder passes; and
 - a final cross-programme multi-agent audit of the closure head returns
-  unanimous `APPROVE` with no actionable findings.
+  unanimous `APPROVED` with no actionable findings.
 
 ## 12. Governance risks and ownership
 

--- a/docs/project/issue-248-fidelity-delivery-plan.md
+++ b/docs/project/issue-248-fidelity-delivery-plan.md
@@ -83,7 +83,8 @@ Every receipt must identify:
 - minimal authored source;
 - a typed expectation for every pipeline stage, including whether it applies;
 - a versioned semantic oracle for every applicable native stage;
-- exact structured diagnostic expectations for every non-native stage;
+- exact structured diagnostic expectations for every public non-native
+  disposition and an explicit dependency for every blocked stage;
 - applicable serialization, mutation, layout, Scene, SVG, terminal,
   interaction, configuration, and accessibility implications; and
 - a named divergence ID when local behavior intentionally differs.
@@ -91,16 +92,20 @@ Every receipt must identify:
 ### 3.2 No silent statement loss
 
 Every nonblank, non-comment family statement must be modeled, preserved with a
-typed reason, or rejected with a named error. A parser must never return a
-visually plausible partial diagram after silently skipping an authored
-statement.
+route-specific typed runtime diagnostic, or rejected with a named error. A
+parser must never return a visually plausible partial diagram after silently
+skipping an authored statement. Lossless preservation by a serialization stage
+may be silent only when every applicable public parse, verify, and render route
+models the construct natively; preservation does not excuse a semantic gap on
+another route.
 
 ### 3.3 Fail-closed public claims
 
 Receipt aggregation uses the following policy:
 
 - `native`: every applicable receipt required by the claim passes;
-- `source-preserved`: source survives but native semantics are not established;
+- `source-preserved`: source survives, native semantics are not established,
+  and the applicable public route emits the exact typed diagnostic;
 - `diagnosed`: a named unsupported or divergent behavior is surfaced exactly;
 - `not-applicable`: the upstream behavior genuinely cannot apply to authored
   source or the output surface; and
@@ -113,9 +118,10 @@ semantic projection, and native render semantics. An opaque agent case caps
 the construct and public claim at `source-preserved` even when the native
 renderer succeeds. `diagnosed` is valid only when the actual public path
 emits the exact asserted runtime diagnostic. A divergence-ledger entry alone
-cannot manufacture diagnosed behavior. Silent loss remains `source-preserved`
-or `absent`, as applicable, until a runtime diagnostic or native fix lands.
-Divergence ledgers are inputs to aggregation, not parallel documentation.
+cannot manufacture diagnosed behavior. Silent semantic loss is `absent`,
+blocks programme closure, and may be promoted only when an exact runtime
+diagnostic or native fix lands. Divergence ledgers are inputs to aggregation,
+not parallel documentation.
 
 ### 3.4 Every regression test must discriminate
 
@@ -250,19 +256,31 @@ claim this exception:
    digest, and squash strategy;
 2. run `git diff --check <merge-base>...<head>` and verify the changed-path set;
 3. validate the external issue/PR links with `gh issue view 248` and
-   `gh pr view 192`, and require the target-bound `gh pr checks` result;
-4. pre-register the three sessions in a timestamped PR comment before dispatch;
-5. post every individual first report under a stable comment ID, record its
-   SHA-256 in the finding ledger, and verify that its GitHub `updated_at` value
-   has not changed at final readiness;
-6. reconcile every commissioned session, fix every actionable finding, and
+   `gh pr view 192`, and require every target-bound `gh pr checks` identity to
+   be complete and green before registration or dispatch;
+4. before dispatch, anchor a content-addressed round manifest in an
+   independently controlled append-only record that does not mutate the frozen
+   candidate: a protected audit ref, signed annotated tag, or server-issued
+   immutable record. It records session IDs, prompt/scope hashes, tuple, tree/
+   diff digest, timestamp, artifact hash, and anchor object/URL. A PR comment
+   points to that anchor but is not its authority;
+5. require each auditor to publish the first report through an independently
+   authenticated identity or a server-issued immutable transcript/artifact;
+   an implementer-pasted report alone is invalid;
+6. post every individual report pointer under a stable comment ID, record the
+   manifest/report artifact SHA-256 values plus comment `created_at`/
+   `updated_at` in the finding ledger, and have an independent human witness
+   compare the posted bytes with the origin artifacts and anchored manifest
+   before final readiness;
+7. reconcile every commissioned session and the committed manifest, fix every
+   actionable finding, and
    repeat against each new tuple until unanimous approval; and
-7. have a human maintainer verify the final tuple, hashes, comments, and checks
+8. have a human maintainer verify the final tuple, hashes, comments, and checks
    before merge.
 
-A0 must add a deterministic `bun run check:programme-docs` command for future
-plan/governance link and path validation and replace this bootstrap with trusted
-runner artifacts and automation.
+A0 must add a deterministic package script named `check:programme-docs` for
+future plan/governance link and path validation and replace this bootstrap with
+trusted runner artifacts and automation.
 
 ## 5. Evidence architecture
 
@@ -278,8 +296,8 @@ Exact-set validation must prove:
 
 - every pinned built-in construct maps to at least one fidelity case;
 - every case maps back to one or more stable construct IDs;
-- every manifest `syntaxFeature`, official `example`, and `configKey` appears in
-  its own typed index;
+- every manifest `syntaxFeature`, official `example`, `configKey`, and
+  `themeVariable` appears in its own typed index;
 - every construct exercised by an official fence is enumerated rather than
   treating the fence as one atomic feature;
 - multiple witnesses may exercise the same construct without inventing new
@@ -298,9 +316,11 @@ type FidelityAuthorityRef =
   | { kind: 'feature'; id: string }
   | { kind: 'example'; id: string }
   | { kind: 'config-key'; id: string }
+  | { kind: 'theme-variable'; id: string }
 
 type FidelityDiagnosticExpectation = {
   stage: FidelityStage
+  invocationId: string
   code: string
   stableFields: Readonly<Record<string, string | number | boolean>>
   cardinality: { min: number; max: number }
@@ -309,28 +329,69 @@ type FidelityDiagnosticExpectation = {
 
 type FidelityStageExpectation =
   | {
+      stage: FidelityStage
+      invocationId: string
       state: 'not-applicable'
       reasonCode: string
       upstreamEvidence: readonly [string, ...string[]]
     }
   | {
+      stage: FidelityStage
+      invocationId: string
       state: 'applicable'
       disposition: 'native'
       oracle: { id: string; schemaVersion: number }
       diagnostics: readonly FidelityDiagnosticExpectation[]
     }
   | {
+      stage: FidelityStage
+      invocationId: string
       state: 'applicable'
       disposition: 'source-preserved'
       oracle: { id: string; schemaVersion: number }
-      diagnostics: readonly FidelityDiagnosticExpectation[]
+      diagnostics: readonly [FidelityDiagnosticExpectation, ...FidelityDiagnosticExpectation[]]
     }
   | {
+      stage: FidelityStage
+      invocationId: string
       state: 'applicable'
       disposition: 'diagnosed' | 'reject'
       oracle?: { id: string; schemaVersion: number }
       diagnostics: readonly [FidelityDiagnosticExpectation, ...FidelityDiagnosticExpectation[]]
     }
+  | {
+      stage: FidelityStage
+      invocationId: string
+      state: 'applicable'
+      disposition: 'blocked'
+      blockedBy: { stage: FidelityStage; invocationId: string }
+      requiredOracle: { id: string; schemaVersion: number }
+    }
+
+interface FidelityInvocation {
+  invocationId: string
+  sourceRef: 'case-source'
+  publicRoute: string
+  renderOptions: Readonly<Record<string, JSONValue>>
+  config?: Readonly<Record<string, JSONValue>>
+  backendId?: string
+  terminalMode?: 'ascii' | 'unicode'
+  security?: Readonly<Record<string, JSONValue>>
+  interaction?: Readonly<Record<string, JSONValue>>
+}
+
+interface FidelityMutationInvocation {
+  mutationId: string
+  invocationId: string
+  operation: FamilyMutationOperation
+}
+
+interface FidelityComparison {
+  comparisonId: string
+  leftInvocationId: string
+  rightInvocationId: string
+  oracle: { id: string; schemaVersion: number }
+}
 
 interface FamilyFidelityCase {
   caseId: string
@@ -339,7 +400,10 @@ interface FamilyFidelityCase {
   authority: FidelityAuthorityRef
   upstreamRevision: string
   source: string
-  stages: Record<FidelityStage, FidelityStageExpectation>
+  invocations: readonly [FidelityInvocation, ...FidelityInvocation[]]
+  mutations: readonly FidelityMutationInvocation[]
+  comparisons: readonly FidelityComparison[]
+  stages: readonly [FidelityStageExpectation, ...FidelityStageExpectation[]]
   divergenceId?: string
 }
 ```
@@ -352,20 +416,32 @@ implication snapshots; generated JSON never embeds arbitrary executable
 callbacks.
 
 Schema validation must reject a native applicable stage without an oracle, a
-source-preserved stage without a preservation oracle, a diagnosed/rejected
-stage without an exact structured diagnostic, and any not-applicable stage
-without a typed reason and upstream evidence. Source preservation may be silent
-and therefore does not imply a public diagnostic. When agent parse applies,
-native aggregation additionally requires a structured agent oracle; opaque
-preservation caps the aggregate at `source-preserved` even when downstream
-native rendering succeeds.
+source-preserved stage without both a preservation oracle and an exact
+structured diagnostic, a diagnosed/rejected stage without an exact structured
+diagnostic, and any not-applicable stage without a typed reason and authority
+evidence. Silent loss is not a compatibility disposition. When agent parse
+applies, native aggregation additionally requires a structured agent oracle;
+opaque preservation caps the aggregate at `source-preserved` even when
+downstream native rendering succeeds.
 
-Define short-circuiting explicitly: detection or native parse rejection makes
-dependent downstream stages not applicable with a `blocked-by:<stage>` reason;
-opaque agent preservation still executes independently applicable native-render
-checks but cannot be promoted to an agent-native claim. Stage-specific
-diagnostics must identify the public route that emitted them and cannot be
-satisfied by a warning from another surface.
+Every expectation and diagnostic references a declared invocation, and every
+declared route has an exact stage-coverage policy. Define the stage dependency
+graph explicitly. A locally blocked downstream stage remains semantically
+`applicable`, carries the blocking stage/invocation plus the required semantic
+oracle, stays in
+the claim denominator, and inherits the blocking disposition as an aggregate
+cap. Reserve `not-applicable` for genuine upstream or governed local-surface
+irrelevance. Agent parsing does not block an independently executable native-
+render invocation. Stage-specific diagnostics must match the referenced public
+route and cannot be satisfied by a warning from another invocation.
+
+Invocations, render options, typed family mutations, interactions, and A/B
+comparisons are declarative and schema-versioned. The runner owns route
+adapters, diagnostic collectors, and the registry for the discriminated
+`FamilyMutationOperation` union. Oracles may normalize and assert supplied
+results, but must not secretly select inputs, routes, configuration variants,
+backends, or mutations. Every config-key and theme-variable effect case joins
+to an explicit named A/B invocation pair.
 
 Pinned Mermaid rejecting the source is the only ordinary basis for local
 `reject`. An official fence may also be rejected when it is proven partial or
@@ -374,24 +450,25 @@ be an executable named diagnosed compatibility divergence.
 
 ### 5.3 Receipt runner
 
-The runner executes the same source through:
+The runner executes every named declarative invocation over the case source
+through the applicable dependency graph:
 
 ```text
 detection
-  -> agent parse/body
-  -> verification
-  -> native parser and layout
-  -> normalized family semantic projection
-  -> Scene and output implication
-  -> canonical serialize/reparse
-  -> declared mutation round trip
+  |-> agent parse/body -> verification -> agent semantic projection
+  `-> native parser -> layout -> native semantic projection
+                                     |-> Scene and output implication
+                                     |-> canonical serialize/reparse
+                                     `-> each declared typed mutation
+  named A/B comparisons join their declared invocation results
 ```
 
 It records disposition and semantic results, not just thrown/not-thrown status.
 Every opaque agent outcome caps the applicable construct/public claim at
-`source-preserved`, regardless of native-render success. Opaque agent success
-paired with render failure additionally requires an exact diagnosed policy
-rather than `verify.ok === true` under an unqualified claim.
+`source-preserved` and requires its exact route-specific typed diagnostic,
+regardless of native-render success. Opaque agent success paired with render
+failure additionally requires an exact diagnosed policy rather than
+`verify.ok === true` under an unqualified claim.
 
 ### 5.4 Family semantic projectors
 
@@ -474,10 +551,15 @@ adoption PR. Only this plan and A0 may use the manual bootstrap in §4.5:
 - fail readiness when reports are missing, roles are reused, findings remain
   unresolved, runs are unreconciled, or approvals/checks are stale or
   superseded;
+- own a versioned path/dependency-to-authority map, derive the complete affected
+  authority set from the full diff, fail closed on unknown or ambiguous paths,
+  and require the newest trusted/provider-issued result for every derived check
+  identity; an exception is valid only as an immutable auditor-approved ledger
+  entry;
 - from the first behavioral repair, run a trusted exact-head red/green job in a
   detached worktree that applies the content-addressed revert/sabotage, verifies
   the expected red signature, restores the audited tree, and verifies green;
-- add `bun run check:programme-docs`; and
+- add the `check:programme-docs` package script; and
 - run the final readiness/tuple comparison from §4.3 after the final audit.
 
 The existing CI workflow runs pull requests targeting `main`; without A0, a
@@ -497,7 +579,8 @@ implementer-authored manual results are not substitutes after bootstrap.
 2. **A2: fidelity contract and runner skeleton**
    - add stable `caseId`, discriminated authority references, construct IDs,
      deterministic receipt schema, exact-set indexes for features/examples/
-     config keys, and a small cross-family exemplar set;
+     config keys/theme variables, named route invocations, typed mutations, A/B
+     comparisons, and a small cross-family exemplar set;
    - keep cases, raw receipts, snapshots, and upstream adapters behind an
      enforced test/eval-only import boundary;
    - add the deterministic compact-index generator contract and initial bundle
@@ -542,8 +625,8 @@ infrastructure may begin earlier where they do not consume those authorities.
 
 ### Stack B — parser and seam guardrails
 
-1. **B1: statement-consumption contract** — consume, typed-preserve, or reject
-   every nonblank statement.
+1. **B1: statement-consumption contract** — consume, preserve with an exact
+   route-specific typed diagnostic, or reject every nonblank statement.
 2. **B2: shared comment/delimiter normalization and agent/native seam** — run
    each fidelity source through both paths and require compatible dispositions.
 3. **B3: keyword-boundary and dual-vocabulary checks** — detect prefix regexes
@@ -643,27 +726,34 @@ Follow with focused work for:
 5. permit `reject` only when pinned Mermaid also rejects the source or the fence
    is proven partial/config-only; otherwise require an executable named
    diagnosed divergence;
-6. require exact-set closure for construct, feature, example, and case indexes
-   so new, removed, orphaned, or multiply ambiguous entries cannot disappear;
-   and
+6. require exact-set closure for construct, feature, example, and case indexes,
+   and assert that the global config-key and theme-variable indexes remain
+   joined, so new, removed, orphaned, or multiply ambiguous entries cannot
+   disappear; and
 7. keep selected galleries as visual reviewer evidence, not native proof.
 
 Classification may discover new defects. File each as a child of #248 and add
 it to the appropriate severity phase; do not weaken the case expectation to
 match current behavior.
 
-### Stack E — generated config-effect matrix
+### Stack E — generated config and theme-effect matrix
 
-For every pinned built-in-family config key, generate exactly one disposition:
+For every pinned built-in-family config key and theme-variable leaf path,
+generate exactly one disposition:
 
 - `wired`, with an A/B predicate over typed semantics, geometry, paint, or
   interaction;
 - `diagnosed-noop`, with unchanged semantics and an exact warning; or
-- `unsupported`, with a named reason.
+- `unsupported`, with a named reason and exact warning or rejection on every
+  public route that accepts the configuration.
 
-Join the upstream config inventory, descriptor declarations, runtime resolver
-reads, docs, and tests. Fail on missing or multiply owned keys. Do not create a
-third hand-maintained config roster.
+Join the upstream config and `semanticInventory.themeVariables` inventories,
+descriptor declarations, runtime resolver/theme reads, docs, and tests. Expand
+object-valued or `any` authorities to reviewed leaf paths from the pinned type/
+default authority, or explicitly enumerate their nested effect cases; a shallow
+`xyChart: any` row cannot hide `dataLabelColor`. Every disposition references a
+named A/B invocation pair. Fail on missing or multiply owned paths. Do not
+create another hand-maintained config or theme roster.
 
 ### Stack F — depth and adversarial quality
 
@@ -717,8 +807,8 @@ Every implementation PR must state:
   command, expected failure signature, observed red failure, and green result
   on the audited head, all linked to the required trusted exact-head job rather
   than supplied only as implementer-authored prose;
-- mandatory baseline and touched-authority checks, with exact-head CI job URLs
-  or command/result records;
+- mandatory baseline and touched-authority checks, with the newest exact-head
+  provider-issued CI job identities and URLs;
 - generated artifacts changed and why;
 - stack position and dependencies;
 - individual audit reports, finding ledger, rounds, and final audited tuple; and
@@ -754,16 +844,19 @@ Add deterministic checks by touched authority:
 | Scene, backend, security, output | Backend conformance, External Scene compatibility, renderer security, affected output/browser checks, `build` |
 | Browser family/catalog | `check:browser-families`, browser-lazy checks, affected browser contracts |
 | Website/package/transport | Website freshness/payload checks, package build, affected CLI/MCP/transport contracts |
-| Official fence or config matrix | Exact-set corpus/config generator check and every affected semantic A/B case |
+| Official fence, config, or theme matrix | Exact-set corpus/config/theme generator check and every affected named semantic A/B case |
 
 The audited tuple must have canonical CI or the A0 equivalent against its exact
 target base; a green run against `main` cannot substitute for a stacked PR whose
 target is a parent branch. A0 defines the required check identities; readiness
 accepts only the newest non-superseded provider-issued run for each identity,
-bound to the tested merge tree and required workflow revision. From the first
-behavioral repair onward, the trusted red/green job is a required check and must
-run the content-addressed revert or sabotage in a detached worktree against the
-exact audited head. A manual command transcript cannot satisfy either gate.
+including every identity derived from the versioned touched-authority map,
+bound to the tested merge tree and required workflow revision. Unknown or
+ambiguous paths fail closed; any exception must be an immutable auditor-approved
+ledger entry. From the first behavioral repair onward, the trusted red/green
+job is a required check and must run the content-addressed revert or sabotage
+in a detached worktree against the exact audited head. A manual command
+transcript cannot satisfy either gate.
 
 The final programme closure run includes at least:
 
@@ -798,7 +891,7 @@ Maintain a checklist on #248 grouped by:
 - Phase 0 silent-corruption fixes;
 - Phase 1 implication/config/interaction fixes;
 - official-fence classification;
-- config-effect closure;
+- config/theme-effect closure;
 - per-family projector and receipt closure; and
 - depth/hardening and final audit.
 
@@ -811,17 +904,20 @@ Close #248 only when all of the following hold:
 
 - every officially authorable construct for every claimed built-in family has
   an executed receipt;
-- the construct, feature, example, config-key, and case indexes have exact-set
-  closure with no orphan or ambiguous ownership;
+- the construct, feature, example, config-key, theme-variable, and case indexes
+  have exact-set closure with no orphan or ambiguous ownership;
 - every official fence has a reviewed disposition;
-- every nonblank statement is modeled, typed-preserved, or rejected;
+- every nonblank statement is modeled, preserved with an exact route-specific
+  typed runtime diagnostic, or rejected; no silent semantic preservation can
+  satisfy closure;
 - every applicable agent-native claim has a passing structured agent oracle;
   an opaque agent outcome remains capped at `source-preserved` even if native
   rendering succeeds;
 - agent parse, verification, native render, serialization, mutation, Scene,
   applicable output, accessibility, and interaction behavior agree with the
   case policy;
-- every config key has exactly one executable effect disposition;
+- every config key and expanded theme-variable leaf path has exactly one
+  executable effect disposition joined to a named A/B invocation pair;
 - capability and citizenship reports derive from passing receipts and
   downgrade divergences automatically;
 - every enrolled family has a complete, versioned semantic projector and every

--- a/docs/project/issue-248-fidelity-delivery-plan.md
+++ b/docs/project/issue-248-fidelity-delivery-plan.md
@@ -472,13 +472,18 @@ outcome or carry governed `not-applicable` evidence; the programme does not
 require inventing a mutation API merely to satisfy a native render claim.
 
 The generator also derives exact mutation/build membership indexes without
-multiplying constructs across transports. Every structured `(case ID, construct
-ID, source ID)` membership whose family has a public mutation route participates
-in at least one canonical real-route invocation that mutates the construct or
-proves it survives an unrelated mutation. It requires a discriminating result
-oracle and preservation oracles for unrelated semantic facets. `not-applicable`
-is valid only when no generated public mutation operation can exercise or
-preserve that membership, with typed authority evidence.
+multiplying constructs across transports. Direct mutation membership is the
+exact generated set of `(case ID, construct ID, source ID, applicable mutation-
+operation ID)` tuples. Every advertised operation whose governed schema can
+target that construct executes through the canonical real public route and has
+a discriminating direct-result oracle; survival under an unrelated mutation
+cannot discharge a direct membership. Each direct membership also has a
+separate preservation obligation, exercised by a governed unrelated operation
+or operation equivalence class, whose oracle proves that operation's target changed
+while unrelated semantic facets survived. `not-applicable` is typed per
+construct and mutation-operation ID and is valid only when authority proves
+that operation cannot exercise the membership. Missing, unknown, duplicate, or
+orphaned direct or preservation memberships fail generation.
 
 For build, every advertised `(family ID, construct ID, build-operation ID)`
 membership participates in at least one real-route sequence whose result oracle
@@ -1067,11 +1072,14 @@ Close #248 only when all of the following hold:
   applicable output, accessibility, and interaction behavior agree with the
   case policy;
 - the mutation/build membership indexes have exact-set closure; every required
-  structured mutation membership and advertised buildable construct/operation
-  membership has a real-route discriminating result and unrelated-facet
-  preservation oracle, while genuinely unavailable operations carry governed
-  `not-applicable` evidence; applicable public adapters separately pass route
-  conformance;
+  `(case ID, construct ID, source ID, applicable mutation-operation ID)`
+  membership executes that advertised operation through the canonical real
+  route with a discriminating direct-result oracle, plus a separately discharged
+  unrelated-operation preservation obligation; every advertised buildable
+  construct/operation membership has a real-route discriminating result and
+  unrelated-facet preservation oracle; genuinely unavailable operations carry
+  governed per-operation `not-applicable` evidence; and applicable public
+  adapters separately pass route conformance;
 - every applicable `(config/theme authority, family, input dialect)` semantic
   cell has exactly one executable effect disposition, with every wired effect
   joined to a named A/B comparison, and each accepting route passes its

--- a/docs/project/issue-248-fidelity-delivery-plan.md
+++ b/docs/project/issue-248-fidelity-delivery-plan.md
@@ -19,6 +19,14 @@ The programme has two inseparable outcomes:
 2. capability and citizenship claims are generated from construct-level
    semantic receipts so the same class of overclaim cannot recur.
 
+The architecture is deliberately factored. One generated authority fixes the
+16-family scope. Family cases prove construct semantics once through the
+canonical core. Generated route-conformance cases prove that CLI, SDK, MCP,
+editor, website, and output adapters preserve or accurately diagnose those
+semantics. One executable gate joins both results into the compact public
+capability index. A0 enforces candidate identity and evidence provenance; it is
+not a mandate to build a general-purpose governance platform.
+
 Fixing only the audit's defect table does not close #248. Building only the
 evidence framework while leaving silent corruption in place does not close it
 either.
@@ -149,9 +157,11 @@ must pass the following loop before it is marked ready or merged.
 2. Commit the complete candidate and require a clean working tree. An
    uncommitted or dirty candidate cannot begin a formal audit round.
 3. Run the mandatory baseline and touched-authority checks from §9.
-4. Record the exact target branch, target-tip SHA, merge-base SHA, head SHA, and
-   intended merge strategy, plus the head tree and full diff digest. This tuple
-   and digest identify the effective candidate.
+4. Record the candidate tuple: repository ID, PR number, target branch,
+   target-tip SHA, merge-base SHA, head SHA, intended merge strategy, protected
+   governance-policy revision, and frozen semantic PR title/body digest.
+   Recompute and record the head-tree and full-diff digests as derived integrity
+   receipts rather than treating them as additional identity fields.
 5. Before dispatch, create a content-addressed round manifest that registers
    the three role/session/run IDs, prompt/scope hashes, candidate tuple, tree/
    diff digest, and timestamp.
@@ -209,23 +219,27 @@ the complete registered role set.
 4. Start a new independent audit round against the new candidate tuple.
 5. Repeat until every auditor returns `APPROVE` with no actionable findings.
 
-Any change to the head SHA, target-tip SHA, merge-base SHA, target branch, or
-intended merge strategy invalidates checks and approval and requires another
-round. This includes target-branch advancement, retargeting, parent-PR merge,
-and rebasing even when the child head tree appears unchanged. Immediately
-before merge, compare the current tuple, tree/diff digest, required workflow
-revision, and newest non-superseded provider-issued check runs with the final
-audit record and fail closed on any difference. A newer failed or cancelled run
-for the same tuple supersedes an older success.
+Any change to the repository/PR identity, semantic title/body digest, head SHA,
+target-tip SHA, merge-base SHA, target branch, intended merge strategy, or
+protected governance-policy revision invalidates checks and approval and
+requires another round. This includes target-branch advancement, semantic PR
+description edits, retargeting, parent-PR merge, and rebasing even when the
+child head tree appears unchanged. Immediately before merge, compare the
+current tuple, tree/diff and semantic-description digests, required workflow
+and governance-policy revisions, and newest non-superseded provider-issued
+check runs with the final audit record and fail closed on any difference. A
+newer failed or cancelled run for the same tuple supersedes an older success.
 
 ### 4.4 Preserve audit evidence in the PR
 
-The trusted runner must preserve each individual first report as a
-content-addressed immutable artifact. Each artifact records role, actor/session/
-run identity, candidate tuple, tree/diff digest, prompt/scope hash, timestamp,
-verbatim report, and artifact hash. The PR conversation contains immutable
-pointers and hashes; mutable pasted comments are not the sole evidence. It must
-also contain an audit table with:
+The trusted runner preserves each individual first report as a content-addressed
+immutable payload. One detached signed or protected round envelope records all
+payload hashes, roles, actor/session/run identities, candidate tuple, tree/diff
+and semantic-description digests, prompt/scope hashes, timestamps, commissioned-
+run reconciliation, and finding ledger. Never require a payload to contain its
+own byte hash. The PR conversation needs one machine-owned comment per round
+pointing to this bundle; it does not duplicate each report as a separate pasted
+comment. The bundle contains an audit table with:
 
 | Round | Target | Target tip | Merge base | Head | Strategy | Individual reports | Result |
 | --- | --- | --- | --- | --- | --- | --- | --- |
@@ -235,15 +249,16 @@ Maintain a persistent finding ledger with:
 | Finding ID | Originating auditor | Severity | Disposition | Correction commit or rejection rationale | Validating round |
 | --- | --- | --- | --- | --- | --- |
 
-Post one consolidated audit comment per round in addition to the individual
-reports. The final row must identify the audited tuple and show approval from
-every role with no unresolved finding. Reviewers must be able to trace a
-finding to its correction without accessing an ephemeral agent transcript.
-Readiness automation added by A0 must reject a missing report, reused role,
-unreconciled commissioned run, unresolved finding, invalid artifact hash, or
-approval bound to a stale tuple/digest; implementer-authored summary text alone
-is not audit evidence. The final readiness job runs after the final audit and
-accepts only the newest required provider-issued check for each declared check
+The final row must identify the audited tuple and show approval from every role
+with no unresolved finding. Reviewers must be able to trace a finding to its
+correction without accessing an ephemeral agent transcript. Audit results and
+the finding ledger live in the immutable round bundle, referenced by its
+machine-owned comment, not in mutable semantic PR-body sections. Readiness
+automation added by A0 must reject a missing report, reused role, unreconciled
+commissioned run, unresolved finding, invalid payload/envelope hash, or approval
+bound to a stale tuple/digest; implementer-authored summary text alone is not
+audit evidence. The final readiness job runs after the final audit and accepts
+only the newest required provider-issued check for each declared check
 identity.
 
 ### 4.5 Manual bootstrap for this plan and A0
@@ -252,25 +267,29 @@ This plan PR and the A0 governance PR necessarily precede the trusted audit
 runner. They use one explicit, temporary bootstrap protocol; no later PR may
 claim this exception:
 
-1. commit a clean candidate and record target tip, merge base, head, tree, diff
-   digest, and squash strategy;
+1. commit a clean candidate and record repository/PR identity, semantic
+   title/body digest, target tip, merge base, head, tree, diff digest, protected
+   policy revision, and squash strategy;
 2. run `git diff --check <merge-base>...<head>` and verify the changed-path set;
 3. validate the external issue/PR links with `gh issue view 248` and
    `gh pr view 192`, and require every target-bound `gh pr checks` identity to
    be complete and green before registration or dispatch;
-4. before dispatch, anchor a content-addressed round manifest in an
+4. before dispatch, anchor a canonical round-manifest payload in an
    independently controlled append-only record that does not mutate the frozen
    candidate: a protected audit ref, signed annotated tag, or server-issued
-   immutable record. It records session IDs, prompt/scope hashes, tuple, tree/
-   diff digest, timestamp, artifact hash, and anchor object/URL. A PR comment
-   points to that anchor but is not its authority;
+   immutable record. A detached envelope records the manifest payload hash,
+   session IDs, prompt/scope hashes, tuple, tree/diff and semantic-description
+   digests, timestamp, and anchor object/URL. A PR comment points to that anchor
+   but is not its authority;
 5. require each auditor to publish the first report through an independently
    authenticated identity or a server-issued immutable transcript/artifact;
-   an implementer-pasted report alone is invalid;
-6. post every individual report pointer under a stable comment ID, record the
-   manifest/report artifact SHA-256 values plus comment `created_at`/
-   `updated_at` in the finding ledger, and have an independent human witness
-   compare the posted bytes with the origin artifacts and anchored manifest
+   record the provider artifact/transcript ID, immutable URL, actor/run identity,
+   origin timestamp, and payload hash before accepting an implementer-preserved
+   copy; an implementer-pasted report alone is invalid;
+6. post the round-bundle pointer under one stable comment ID, record the
+   manifest/report payload and envelope SHA-256 values plus comment
+   `created_at`/`updated_at` in the bundle, and have an independent human witness
+   compare the preserved bytes with the origin artifacts and anchored manifest
    before final readiness;
 7. reconcile every commissioned session and the committed manifest, fix every
    actionable finding, and
@@ -284,264 +303,141 @@ trusted runner artifacts and automation.
 
 ## 5. Evidence architecture
 
-### 5.1 Construct and public-route authority with exact-set joins
+### 5.1 Scoped family, construct, and public-route authorities
 
 The current syntax-feature inventory is derived largely from documentation
-headings; it is not by itself a construct-complete grammar authority. A1 must
-establish a stable construct roster from the pinned grammar/spec blocks,
-official fences, and config authority, with reviewed many-to-many mappings to
-documentation headings and existing manifest coordinates.
+headings and the upstream manifest covers families outside #248. A1 must first
+generate one `FidelityScopeAuthority` containing exactly the 16 families named
+by #248: the 15 built-ins on `main` plus Sankey. It then establishes the scoped
+construct roster from pinned grammar/spec blocks, official fences, and config
+authority, with reviewed many-to-many mappings to documentation headings and
+manifest coordinates. Manifest rows outside this family authority remain in an
+explicit unsupported/out-of-scope envelope; they do not silently enter this
+programme or require projectors and cases.
 
-A2 must also generate a versioned public-route registry from the canonical
-SDK, CLI, MCP, hosted, browser/editor, and output adapter declarations. A route
-ID represents one executable public entry path and records its family/input
-applicability, accepted config/theme surfaces, reachable stages, and owning
-adapter. It is not a hand-maintained list inside the cases. Adding, removing, or
-renaming a public entry point or route adapter without regenerating this
-authority must fail.
+A2 generates a versioned public-route registry from canonical SDK declarations,
+CLI command/selector tables, MCP tool declarations, browser/editor/website
+entrypoints, and `RENDER_TRANSPORT_SURFACES` × `RENDER_OUTPUTS`. A route records
+independent transport, operation, entrypoint, selector, and optional output
+dimensions plus its owning adapter. One adapter may own many routes; every route
+has exactly one owner. No semantic dimension is hidden only inside a route-ID
+string or hand-maintained in cases.
 
 Exact-set validation must prove:
 
-- every pinned built-in construct maps to at least one fidelity case;
-- every case maps back to one or more stable construct IDs;
-- every manifest `syntaxFeature`, official `example`, `configKey`, and
-  `themeVariable` appears in its own typed index;
-- every generated public-route ID maps to exactly one owning adapter and every
-  public adapter maps back to one route ID;
-- every case and config/theme effect has one coverage entry for every registry
-  route that can accept the relevant family/input, either an applicable named
-  invocation or an evidenced `not-applicable` disposition;
+- the in-scope family-ID set equals the 16-family authority unless #248 itself
+  is amended;
+- every scoped construct maps to at least one fidelity case and every case maps
+  back to scoped constructs and authorities;
+- every scoped manifest `syntaxFeature`, official `example`, `configKey`, and
+  `themeVariable` appears in its typed index, while every unscoped row has an
+  explicit out-of-scope disposition;
+- every generated route maps to one owner, every public entrypoint/selector/
+  output cell maps back to a route, and an adapter may map to multiple routes;
 - every construct exercised by an official fence is enumerated rather than
   treating the fence as one atomic feature;
 - multiple witnesses may exercise the same construct without inventing new
-  feature IDs;
-- orphan constructs, orphan cases, stale authorities, and ambiguous ownership
-  fail generation; and
-- missing, unknown, duplicate, or orphaned route IDs and route-coverage entries
-  fail generation.
+  feature IDs; and
+- orphan constructs, cases, sources, invocations, authorities, routes, and
+  ambiguous ownership fail generation.
 
-### 5.2 `FamilyFidelityContract`
+### 5.2 Factored semantic and route contracts
 
-Add a typed registry beside the built-in family descriptors, projected from the
-construct authority and existing upstream manifest rather than maintained as a
-second roster. The conceptual core is:
+Do not materialize a construct × source × public-route × stage Cartesian
+product. Most public adapters are transport projections over the same semantic
+core, so repeating every construct through every transport adds cost without
+independent evidence. Use two exact, joined contracts instead:
 
-```ts
-type FidelityAuthorityRef =
-  | { kind: 'feature'; id: string }
-  | { kind: 'example'; id: string }
-  | { kind: 'config-key'; id: string }
-  | { kind: 'theme-variable'; id: string }
+1. family cases prove construct/source semantics through the canonical agent and
+   native core routes; and
+2. route-conformance cases prove every public adapter's accepted inputs,
+   operation, selector, output, diagnostics, and pass-through/projection rules.
 
-type FidelityDiagnosticExpectation = {
-  stage: FidelityStage
-  invocationId: string
-  code: string
-  stableFields: Readonly<Record<string, string | number | boolean>>
-  cardinality: { min: number; max: number }
-  order: 'exact' | 'any'
-}
+An adapter may use factored conformance only when its registry declaration and
+tests prove it is family-agnostic: it delegates to the canonical core without
+branching on family or construct, and its touched-authority rule invalidates
+that classification when dispatch code changes. Any family/construct-specific
+branch is `route-specific` and requires direct family-case coverage for the
+affected constructs. A2 owns the precise TypeScript schema; this plan requires
+the following records and joins rather than freezing implementation syntax:
 
-type FidelityStageExpectation =
-  | {
-      stage: FidelityStage
-      invocationId: string
-      state: 'not-applicable'
-      reasonCode: string
-      upstreamEvidence: readonly [string, ...string[]]
-    }
-  | {
-      stage: FidelityStage
-      invocationId: string
-      state: 'applicable'
-      disposition: 'native'
-      oracle: { id: string; schemaVersion: number }
-      diagnostics: readonly FidelityDiagnosticExpectation[]
-    }
-  | {
-      stage: FidelityStage
-      invocationId: string
-      state: 'applicable'
-      disposition: 'source-preserved'
-      oracle: { id: string; schemaVersion: number }
-      diagnostics: readonly [FidelityDiagnosticExpectation, ...FidelityDiagnosticExpectation[]]
-    }
-  | {
-      stage: FidelityStage
-      invocationId: string
-      state: 'applicable'
-      disposition: 'diagnosed' | 'reject'
-      oracle?: { id: string; schemaVersion: number }
-      diagnostics: readonly [FidelityDiagnosticExpectation, ...FidelityDiagnosticExpectation[]]
-    }
-  | {
-      stage: FidelityStage
-      invocationId: string
-      state: 'applicable'
-      disposition: 'blocked'
-      blockedBy: { stage: FidelityStage; invocationId: string }
-      requiredOracle: { id: string; schemaVersion: number }
-    }
-
-interface FidelityInvocation {
-  invocationId: string
-  sourceRef: string
-  publicRoute: PublicRouteId
-  renderOptions: Readonly<Record<string, JSONValue>>
-  config?: Readonly<Record<string, JSONValue>>
-  backendId?: string
-  terminalMode?: 'ascii' | 'unicode'
-  security?: Readonly<Record<string, JSONValue>>
-  interaction?: Readonly<Record<string, JSONValue>>
-}
-
-type PublicRouteId = string & { readonly __publicRouteId: unique symbol }
-
-interface FidelityPublicRoute {
-  routeId: PublicRouteId
-  schemaVersion: number
-  surface: 'sdk' | 'cli' | 'mcp' | 'hosted' | 'browser' | 'editor' | 'output'
-  adapterId: string
-  familyIds: readonly [string, ...string[]]
-  acceptedInputs: readonly [
-    'source' | 'config' | 'theme' | 'interaction',
-    ...('source' | 'config' | 'theme' | 'interaction')[],
-  ]
-  stages: readonly [FidelityStage, ...FidelityStage[]]
-}
-
-type FidelityRouteCoverage =
-  | {
-      routeId: PublicRouteId
-      state: 'applicable'
-      invocationIds: readonly [string, ...string[]]
-    }
-  | {
-      routeId: PublicRouteId
-      state: 'not-applicable'
-      invocationIds: readonly []
-      reasonCode: string
-      authorityEvidence: readonly [string, ...string[]]
-    }
-
-interface FidelitySource {
-  sourceId: string
-  source: string
-  role: 'authored' | 'metamorphic-variant' | 'boundary' | 'malformed'
-  derivedFromSourceId?: string
-  transformId?: string
-}
-
-type FidelityResultRef =
-  | { kind: 'invocation'; invocationId: string; stage: FidelityStage }
-  | { kind: 'mutation'; mutationId: string }
-
-interface FidelityMutationInvocation {
-  mutationId: string
-  constructIds: readonly [string, ...string[]]
-  input: { invocationId: string; stage: FidelityStage }
-  operation: FamilyMutationOperation
-  oracle: { id: string; schemaVersion: number }
-  preserveOracles: readonly [{ id: string; schemaVersion: number }, ...{
-    id: string
-    schemaVersion: number
-  }[]]
-  diagnostics: readonly FidelityDiagnosticExpectation[]
-}
-
-interface FidelityComparison {
-  comparisonId: string
-  left: FidelityResultRef
-  right: FidelityResultRef
-  oracle: { id: string; schemaVersion: number }
-}
-
-type FidelityMutationPlan =
-  | {
-      state: 'applicable'
-      entries: readonly [FidelityMutationInvocation, ...FidelityMutationInvocation[]]
-    }
-  | {
-      state: 'not-applicable'
-      entries: readonly []
-      reasonCode: string
-      upstreamEvidence: readonly [string, ...string[]]
-    }
-
-interface FamilyFidelityCase {
-  caseId: string
-  familyId: string
-  constructIds: readonly [string, ...string[]]
-  authority: FidelityAuthorityRef
-  upstreamRevision: string
-  sources: readonly [FidelitySource, ...FidelitySource[]]
-  invocations: readonly [FidelityInvocation, ...FidelityInvocation[]]
-  routeCoverage: readonly [FidelityRouteCoverage, ...FidelityRouteCoverage[]]
-  mutationPlan: FidelityMutationPlan
-  comparisons: readonly FidelityComparison[]
-  stages: readonly [FidelityStageExpectation, ...FidelityStageExpectation[]]
-  divergenceId?: string
-}
-```
+| Record | Required data |
+| --- | --- |
+| Family case | Stable case/family IDs, non-empty construct and authority IDs, upstream revision, sources, canonical invocations, semantic cells, comparisons, optional divergence ID |
+| Source | Stable ID, exact source, authored/metamorphic/boundary/malformed role, and base/transform IDs for a derived variant |
+| Invocation | Stable ID, source/mutation/build kind, canonical core or public route ID, source or family input, and declarative options/operations |
+| Semantic cell | Stable ID, construct ID, invocation ID, stage, disposition, oracle/diagnostic requirements, or governed blocking/not-applicable evidence |
+| Public route | Generated transport, operation, entrypoint, selector, optional output, owning adapter, pass-through/route-specific mode, family/input applicability, and reachable stages |
+| Route-conformance case | Stable ID, route ID, contract IDs, fixture invocation IDs, oracle, and diagnostic expectations |
+| Comparison | Stable ID, construct IDs, two exact invocation-stage results, and a versioned oracle |
 
 `FidelityStage` covers detection, agent parse, verification, native parse,
 configuration, layout, Scene, SVG, PNG, terminal, serialization, mutation,
-accessibility, and interaction. Oracle IDs resolve through a runner-owned typed
-registry whose outputs are versioned, family-discriminated semantic or
-implication snapshots; generated JSON never embeds arbitrary executable
-callbacks.
+accessibility, and interaction. `FidelityInputKind` includes source, config,
+theme, interaction, mutation, and build inputs. Transport, operation, and output
+IDs are generated branded types, not handwritten unions in the cases. Oracle
+IDs resolve through a runner-owned typed registry whose outputs are versioned,
+family-discriminated semantic or implication snapshots; generated JSON never
+embeds arbitrary executable callbacks.
 
-Schema validation must reject a native applicable stage without an oracle, a
-source-preserved stage without both a preservation oracle and an exact
-structured diagnostic, a diagnosed/rejected stage without an exact structured
-diagnostic, and any not-applicable stage without a typed reason and authority
-evidence. Silent loss is not a compatibility disposition. When agent parse
-applies, native aggregation additionally requires a structured agent oracle;
-opaque preservation caps the aggregate at `source-preserved` even when
-downstream native rendering succeeds.
+The generator derives two required grids. The semantic grid contains exactly one
+cell for every construct × named source × applicable core stage. Every source
+must participate in a canonical semantic invocation; orphan sources are
+rejected. Every metamorphic source must name its derivation and participate in a
+comparison with its base. Multi-construct official fences produce separate
+construct/source cells even when one invocation exercises several constructs.
 
-Every source reference, expectation, diagnostic, result reference, and mutation
-input resolves to a declared object. For each case, the route-coverage route-ID
-set must equal the applicable generated registry set. Every applicable entry
-resolves to at least one invocation on that exact route and has the route's
-exact stage-coverage policy; every `not-applicable` entry carries governed
-authority evidence. Unknown routes, uncovered registry routes, and orphaned
-invocations fail validation. A comparison names the exact invocation-stage or
-mutation result it consumes; an oracle cannot substitute a hidden source,
-stage, invocation, or mutation. Define the stage dependency graph explicitly.
-A locally blocked downstream stage remains semantically
-`applicable`, carries the blocking stage/invocation plus the required semantic
-oracle, stays in
-the claim denominator, and inherits the blocking disposition as an aggregate
-cap. Reserve `not-applicable` for genuine upstream or governed local-surface
-irrelevance. Agent parsing does not block an independently executable native-
-render invocation. Stage-specific diagnostics must match the referenced public
-route and cannot be satisfied by a warning from another invocation.
+The route grid contains exactly one conformance result for every generated
+public route × accepted input kind × operation/selector/output contract. It
+checks real transport admission, option/config/theme/interaction pass-through,
+diagnostic envelopes, mutation atomicity, serialization, output bytes, and
+security rules as applicable. Use a small cross-family fixture set chosen by
+semantic category, not one fixture per construct. A `route-specific` adapter
+also generates direct required family-case cells for each affected construct.
+Aggregation permits a public native claim only when both its semantic cells and
+the applicable route-conformance cells pass.
 
-Invocations, named authored/source-variant inputs, render options, typed family
-mutations, interactions, and A/B or metamorphic comparisons are declarative and
-schema-versioned. Source variants carry an explicit derivation and transform
-identity rather than being selected inside an oracle. The runner owns route
-adapters, diagnostic collectors, and the registry for the discriminated
-`FamilyMutationOperation` union. Oracles may normalize and assert supplied
-results, but must not secretly select inputs, routes, configuration variants,
-backends, or mutations. Every mutation has its own result oracle and a non-empty
-set of preservation oracles for semantic facets unrelated to the operation.
-For every case with a structured applicable construct, the union of mutation
-`constructIds` must exactly cover those constructs; empty mutation coverage is
-valid only through a reviewed `not-applicable` reason with upstream evidence.
-Every config-key and theme-variable effect case joins to an explicit named A/B
-invocation pair.
+Every invocation, cell, diagnostic, comparison, source, route case, and
+authority reference must resolve and have reverse coverage. Public mutation and
+build conformance must execute the real route; runner-internal operations cannot
+stand in for CLI, MCP, SDK, or other public admission, batching, diagnostics,
+verification, and serialization behavior. A native mutation/build semantic
+cell requires a result oracle and preservation oracles for unrelated semantic
+facets. A route that does not support an operation must emit an exact diagnosed
+outcome or carry governed `not-applicable` evidence; the programme does not
+require inventing a mutation API merely to satisfy a native render claim.
 
-Pinned Mermaid rejecting the source is the only ordinary basis for local
-`reject`. An official fence may also be rejected when it is proven partial or
-config-only. If pinned Mermaid accepts a complete fence, local rejection must
-be an executable named diagnosed compatibility divergence.
+Schema validation rejects a native applicable cell without an oracle, a
+source-preserved cell without both a preservation oracle and at least one
+expected runtime diagnostic, a diagnosed/rejected cell without at least one
+expected diagnostic, invalid diagnostic cardinalities, and a not-applicable
+cell without a typed reason and authority evidence. Silent loss is not a
+compatibility disposition. When agent parse applies, native aggregation
+additionally requires a structured agent oracle; opaque preservation caps the
+aggregate at `source-preserved` even when downstream rendering succeeds.
+
+Define the stage dependency graph explicitly. A locally blocked downstream
+stage remains applicable, identifies the blocking invocation/stage and required
+oracle, stays in the claim denominator, and inherits the blocking disposition
+as an aggregate cap. Agent parsing does not block an independently executable
+native-render invocation. Diagnostics and oracles are bound to their exact
+invocation, route, construct, and stage; they cannot select hidden sources,
+routes, configuration variants, backends, mutations, or builds.
+
+Config and theme semantic effects use the same family cells. Ownership is exact
+per `(authority ID, family ID, input dialect)`, so a shared global theme path
+has one disposition for every applicable in-scope family rather than one
+arbitrary family owner. Route conformance separately proves pass-through for
+each accepting public route; a route-specific transformation requires its own
+A/B case. Every wired effect joins to an explicit named A/B comparison. Pinned
+Mermaid rejecting the source is the ordinary basis for local `reject`; if pinned
+Mermaid accepts a complete fence, local rejection requires an executable named
+diagnosed compatibility divergence.
 
 ### 5.3 Receipt runner
 
-The runner executes every named declarative invocation over the case source
-through the applicable dependency graph:
+The runner executes every named declarative invocation through its real public
+route adapter and the applicable dependency graph:
 
 ```text
 detection
@@ -549,9 +445,8 @@ detection
   `-> native parser -> layout -> native semantic projection
                                      |-> Scene and output implication
                                      |-> canonical serialize/reparse
-                                     `-> each declared typed mutation result
-  named A/B and metamorphic comparisons join their declared invocation-stage
-  or mutation results
+                                     `-> public mutation/build invocation
+  named A/B and metamorphic comparisons join declared invocation-stage results
 ```
 
 It records disposition and semantic results, not just thrown/not-thrown status.
@@ -560,6 +455,15 @@ Every opaque agent outcome caps the applicable construct/public claim at
 regardless of native-render success. Opaque agent success paired with render
 failure additionally requires an exact diagnosed policy rather than
 `verify.ok === true` under an unqualified claim.
+
+A2 adds one deterministic package script, `fidelity:check`. It executes the
+complete scoped semantic and route-conformance corpus against the pinned
+upstream revision, builds raw receipts in a temporary directory, derives the
+compact capability index in the same process, and compares generated committed
+outputs. Committed or manually edited raw result files are never trusted as
+inputs. CI may retain
+the raw receipts as immutable debugging artifacts, but a freshness-only check
+cannot substitute for execution.
 
 ### 5.4 Family semantic projectors
 
@@ -593,13 +497,13 @@ the receipt.
 Use a two-tier dataflow:
 
 1. case definitions, authored witnesses, upstream adapters, semantic
-   expectations, raw receipts, and divergence authorities live in test/eval-
-   only modules that production code cannot import;
-2. one deterministic generator validates those authorities and emits a compact,
-   versioned aggregate capability index consumed by runtime family descriptors,
-   CLI discovery, and public report generators;
-3. freshness hashes bind the aggregate to case definitions, receipt results,
-   the public-route registry and adapter versions, projector/oracle/schema
+   expectations, ephemeral raw receipts, and divergence authorities live in
+   test/eval-only modules that production code cannot import;
+2. `fidelity:check` validates and executes those authorities, then emits a
+   compact, versioned aggregate capability index consumed by runtime family
+   descriptors, CLI discovery, and public report generators;
+3. freshness hashes bind the aggregate to case definitions, the executed result
+   summary, public-route registry and adapter versions, projector/oracle/schema
    versions, divergence ledgers, and upstream revision;
    and
 4. build metafile, tarball, and bundle negative tests prove that Mermaid oracle
@@ -612,11 +516,11 @@ shipping the evidence corpus.
 
 ### 5.6 Capability and citizenship projection
 
-Replace blanket built-in capability evidence with aggregation over passing
-receipts. Section A, the syntax capability ledger, citizenship, CLI discovery,
-and generated docs must consume the same result. A report freshness check must
-fail when behavior, a receipt, a divergence, or an upstream revision changes
-without regenerating the public claims.
+Replace blanket built-in capability evidence with aggregation over freshly
+executed passing receipts. Section A, the syntax capability ledger, citizenship,
+CLI discovery, and generated docs must consume the same result.
+`fidelity:check` must fail when behavior, a case, a divergence, an authority, or
+an upstream revision changes without a matching execution-derived public claim.
 
 ## 6. Delivery stacks and work packages
 
@@ -630,16 +534,28 @@ Land this immediately after the plan and before every implementation or
 adoption PR. Only this plan and A0 may use the manual bootstrap in §4.5:
 
 - make canonical trusted CI run for every programme pull-request target branch
-  and attest the exact target tip, merge base, head, tested merge result, and
-  workflow revision;
+  and attest the repository/PR identity, semantic-description digest, exact
+  target tip, merge base, head, tested merge result, workflow revision, and
+  governance-policy revision;
 - protect every temporary programme base with a ruleset or sole merge bot,
   disallow bypass and force-push, and enforce the declared squash strategy;
+- evaluate readiness workflows and the path/dependency-to-authority policy from
+  a protected target revision or external service, never solely from candidate
+  bytes. A governance-changing PR is checked against the union of base and
+  candidate policies, receives fixed meta-checks, and activates its new policy
+  only after merge;
 - add trusted multi-agent runner artifacts, pre-registered round manifests,
   distinct actor/session/run identities, content hashes, and reconciliation of
   failed/timed-out/abandoned runs;
-- extend the PR template and readiness tooling to require the three immutable
-  individual reports, finding ledger, newest check identities, and current
-  tuple/tree/diff digest;
+- isolate hostile candidate content from audit authority: dependency acquisition
+  uses a vetted cache stage; candidate tests and auditors run without secrets or
+  write tokens, without network after acquisition, and with the candidate
+  mounted read-only for auditors. A separate narrowly privileged publisher that
+  never executes candidate bytes emits audit artifacts/checks. Privileged
+  `pull_request_target` checkout or execution of candidate bytes is forbidden;
+- extend the PR template and readiness tooling to require one immutable round
+  bundle containing the three individual reports, finding ledger, newest check
+  identities, and current tuple/tree/diff/semantic-description digests;
 - fail readiness when reports are missing, roles are reused, findings remain
   unresolved, runs are unreconciled, or approvals/checks are stale or
   superseded;
@@ -665,17 +581,19 @@ implementer-authored manual results are not substitutes after bootstrap.
    - choose the canonical Mermaid 11.16 revision;
    - make all executable artifacts name it or an explicit reviewed
      compatibility revision;
-   - establish the construct-complete roster and many-to-many authority joins
-     from §5.1; and
+   - generate the exact 16-family scope, explicit out-of-scope envelope,
+     construct-complete roster, and many-to-many authority joins from §5.1; and
    - fail generation on unacknowledged splits or roster gaps.
 2. **A2: fidelity contract and runner skeleton**
    - add stable `caseId`, discriminated authority references, construct IDs,
-     deterministic receipt schema, exact-set indexes for features/examples/
-     config keys/theme variables/public routes, typed route applicability and
-     named invocations, typed mutations, A/B comparisons, and a small cross-
-     family exemplar set;
-   - keep cases, raw receipts, snapshots, and upstream adapters behind an
-     enforced test/eval-only import boundary;
+     deterministic coverage cells, exact-set indexes for scoped features/
+     examples/config keys/theme variables/public routes, route-bound source/
+     mutation/build invocations, A/B comparisons, and a small cross-family
+     exemplar set;
+   - add `fidelity:check` to execute the complete scoped corpus and
+     derive the compact index in one process;
+   - keep cases, ephemeral raw receipts, snapshots, and upstream adapters behind
+     an enforced test/eval-only import boundary;
    - add the deterministic compact-index generator contract and initial bundle
      exclusion tests;
    - do not change public capability claims yet.
@@ -686,10 +604,12 @@ implementer-authored manual results are not substitutes after bootstrap.
      `main`, with exact-set tracking; and
    - the Sankey projector shard depends on C3 enrollment.
 4. **A4: receipt-driven reports and citizenship**
-   - feed divergences and receipts into capability aggregation;
+   - feed divergences and freshly executed receipts into capability aggregation;
    - generate the compact versioned runtime/report index and bind its freshness
-     hash to cases, results, projectors/oracles/schemas, divergences, and upstream
-     revision;
+     hash to scope, cases, executed result summary, routes, projectors/oracles/
+     schemas, divergences, and upstream revision;
+   - make `evidence:check` invoke `fidelity:check`; a hash-only or
+     generated-file-only check is insufficient;
    - prove raw evidence and Mermaid oracle code are absent from every shipped
      bundle and tarball;
    - deliberately downgrade every not-yet-receipted claim during migration;
@@ -814,9 +734,11 @@ Follow with focused work for:
 
 ### Stack D — exhaustive official examples
 
-1. generate one case record for every harvested official fence;
-2. review all 331 audited fences as structured, opaque, reject, partial, or
-   config-only;
+1. generate one case record for every official fence projected through the
+   16-family scope authority;
+2. review the complete generated scoped set (331 in the audit baseline) as
+   structured, opaque, reject, partial, or config-only; do not use a hard-coded
+   count as the authority;
 3. enumerate every construct exercised by each fence and join it to the
    construct authority rather than treating the fence as one feature;
 4. attach one or more semantic receipts or a named diagnosed compatibility
@@ -824,10 +746,10 @@ Follow with focused work for:
 5. permit `reject` only when pinned Mermaid also rejects the source or the fence
    is proven partial/config-only; otherwise require an executable named
    diagnosed divergence;
-6. require exact-set closure for construct, feature, example, and case indexes,
-   and assert that the global config-key and theme-variable indexes remain
-   joined, so new, removed, orphaned, or multiply ambiguous entries cannot
-   disappear; and
+6. require exact-set closure for scoped family, construct, feature, example,
+   source, semantic-cell, route-conformance, and case indexes, plus explicit dispositions for
+   out-of-scope manifest rows, so new, removed, orphaned, or ambiguous entries
+   cannot disappear; and
 7. keep selected galleries as visual reviewer evidence, not native proof.
 
 Classification may discover new defects. File each as a child of #248 and add
@@ -836,7 +758,7 @@ match current behavior.
 
 ### Stack E — generated config and theme-effect matrix
 
-For every pinned built-in-family config key and theme-variable leaf path,
+For every applicable `(authority path, family ID, input dialect)` semantic cell,
 generate exactly one disposition:
 
 - `wired`, with an A/B predicate over typed semantics, geometry, paint, or
@@ -849,9 +771,13 @@ Join the upstream config and `semanticInventory.themeVariables` inventories,
 descriptor declarations, runtime resolver/theme reads, docs, and tests. Expand
 object-valued or `any` authorities to reviewed leaf paths from the pinned type/
 default authority, or explicitly enumerate their nested effect cases; a shallow
-`xyChart: any` row cannot hide `dataLabelColor`. Every disposition references a
-named A/B invocation pair. Fail on missing or multiply owned paths. Do not
-create another hand-maintained config or theme roster.
+`xyChart: any` row cannot hide `dataLabelColor`. Expand shared global paths such
+as `primaryColor` across every applicable in-scope family instead of assigning
+one arbitrary owner. Route-conformance cases prove unchanged admission and
+pass-through for every accepting route; a route-specific transformation adds a
+direct A/B case. Every wired disposition references a named A/B invocation pair.
+Fail on missing cells or duplicate ownership of the same tuple. Do not create
+another hand-maintained config or theme roster.
 
 ### Stack F — depth and adversarial quality
 
@@ -893,7 +819,8 @@ base is stable. They should not stack on each other merely to avoid updating
 
 ## 8. Required PR description and evidence
 
-Every implementation PR must state:
+Before audit registration, every implementation PR must freeze these semantic
+description sections and include their digest in the candidate tuple:
 
 - child issue and parent epic;
 - exact claim being changed;
@@ -909,8 +836,11 @@ Every implementation PR must state:
   provider-issued CI job identities and URLs;
 - generated artifacts changed and why;
 - stack position and dependencies;
-- individual audit reports, finding ledger, rounds, and final audited tuple; and
 - residual limitations.
+
+After dispatch, the round-bundle pointer, finding ledger, round status, and
+final tuple live in machine-owned audit comments and immutable artifacts. They
+are not appended to or edited into the frozen semantic body.
 
 Visual-output PRs must include proportional before/after evidence generated from
 the same named input at immutable base/head revisions. The semantic receipt is
@@ -927,6 +857,9 @@ bun run lint
 bun run test
 ```
 
+After A2 lands, every implementation PR also runs the `fidelity:check` gate;
+focused receipts accelerate iteration but never replace the complete corpus.
+
 A documentation-only PR runs `git diff --check`, repository-path/link
 validation for every changed document, and the documentation audit roles from
 §4. It need not rerun unchanged runtime behavior unless the document is itself
@@ -938,23 +871,25 @@ Add deterministic checks by touched authority:
 | --- | --- |
 | Family parser/renderer/projector | Focused fidelity receipt, parser/renderer family tests, red/green record |
 | Upstream manifest or authority | `upstream-manifest:check`, upstream bench/corpus checks, revision closure |
-| Section A/B, citizenship, receipts | `section-a-report:check`, `section-b-report:check`, `quality:check`, `evidence:check` |
+| Fidelity scope/routes/cases, Section A/B, citizenship, receipts | `fidelity:check`, `section-a-report:check`, `section-b-report:check`, `quality:check`, `evidence:check` |
 | Scene, backend, security, output | Backend conformance, External Scene compatibility, renderer security, affected output/browser checks, `build` |
 | Browser family/catalog | `check:browser-families`, browser-lazy checks, affected browser contracts |
 | Website/package/transport | Website freshness/payload checks, package build, affected CLI/MCP/transport contracts |
 | Official fence, config, or theme matrix | Exact-set corpus/config/theme generator check and every affected named semantic A/B case |
+| Governance policy, workflow, readiness, or touched-authority map | Fixed external/protected meta-gate and union of base/candidate required checks |
 
 The audited tuple must have canonical CI or the A0 equivalent against its exact
 target base; a green run against `main` cannot substitute for a stacked PR whose
 target is a parent branch. A0 defines the required check identities; readiness
 accepts only the newest non-superseded provider-issued run for each identity,
 including every identity derived from the versioned touched-authority map,
-bound to the tested merge tree and required workflow revision. Unknown or
-ambiguous paths fail closed; any exception must be an immutable auditor-approved
-ledger entry. From the first behavioral repair onward, the trusted red/green
-job is a required check and must run the content-addressed revert or sabotage
-in a detached worktree against the exact audited head. A manual command
-transcript cannot satisfy either gate.
+bound to the tested merge tree, semantic-description digest, and protected
+workflow/governance-policy revisions. Candidate changes to those policies
+cannot weaken their own gate. Unknown or ambiguous paths fail closed; any
+exception must be an immutable auditor-approved ledger entry. From the first
+behavioral repair onward, the trusted red/green job is a required check and must
+run the content-addressed revert or sabotage in a detached worktree against the
+exact audited head. A manual command transcript cannot satisfy either gate.
 
 The final programme closure run includes at least:
 
@@ -970,6 +905,8 @@ bun run section-b-report:check
 bun run check:browser-families
 bun run build
 ```
+
+Once A2 lands, the final closure run also includes its `fidelity:check` gate.
 
 Family and browser/output changes add their focused corpus, gallery, browser,
 package, and transport checks. Upstream refresh commands must execute against
@@ -1000,16 +937,20 @@ and generated reports become the live authority.
 
 Close #248 only when all of the following hold:
 
-- every officially authorable construct for every claimed built-in family has
-  an executed receipt;
-- the construct, feature, example, config-key, theme-variable, public-route,
-  and case indexes have exact-set closure with no orphan or ambiguous
-  ownership;
-- every case and config/theme effect covers every applicable generated public
-  route with a named invocation, or carries an evidenced `not-applicable`
-  disposition; missing, unknown, duplicate, and orphaned route entries are
+- the generated family scope equals the 16 families named by #248 unless the
+  issue is explicitly amended, and every unscoped manifest family/row has an
+  explicit out-of-scope disposition;
+- every officially authorable scoped construct has freshly executed coverage;
+- the scoped construct, feature, example, config-key, theme-variable, source,
+  public-route, semantic-cell, route-conformance, and case indexes have exact-set
+  closure with no orphan or ambiguous ownership;
+- every construct × named source × applicable core stage has a semantic
+  invocation and oracle/diagnostic, and every public route × accepted input ×
+  operation/selector/output contract has conformance evidence or an evidenced
+  `not-applicable` disposition; route-specific branches also have direct
+  affected-construct cases; missing, unknown, duplicate, and orphaned cells are
   zero;
-- every official fence has a reviewed disposition;
+- every scoped official fence has a reviewed disposition;
 - every nonblank statement is modeled, preserved with an exact route-specific
   typed runtime diagnostic, or rejected; no silent semantic preservation can
   satisfy closure;
@@ -1019,16 +960,19 @@ Close #248 only when all of the following hold:
 - agent parse, verification, native render, serialization, mutation, Scene,
   applicable output, accessibility, and interaction behavior agree with the
   case policy;
-- every structured applicable construct is covered by at least one named typed
-  mutation result, every declared mutation has a discriminating oracle, and its
-  preservation oracles prove that unrelated semantic facets remain unchanged;
-- every config key and expanded theme-variable leaf path has exactly one
-  executable effect disposition joined to a named A/B invocation pair;
-- capability and citizenship reports derive from passing receipts and
-  downgrade divergences automatically;
+- every applicable public mutation/build route is exercised through that real
+  route; a native cell has a discriminating result oracle and preservation
+  oracles, while unsupported operations are exactly diagnosed or evidenced
+  not-applicable;
+- every applicable `(config/theme authority, family, input dialect)` semantic
+  cell has exactly one executable effect disposition, with every wired effect
+  joined to a named A/B comparison, and each accepting route passes its
+  conformance or route-specific A/B case;
+- capability and citizenship reports derive in the same `fidelity:check` run
+  from passing receipts and downgrade divergences automatically;
 - every enrolled family has a complete, versioned semantic projector and every
-  shipped runtime/report claim comes from the compact aggregate index; raw
-  cases, Mermaid oracles, receipts, and snapshots are absent from runtime,
+  shipped runtime/report claim comes from the compact aggregate index; cases,
+  Mermaid oracles, ephemeral raw receipts, and snapshots are absent from runtime,
   browser, CLI, MCP, hosted, and package artifacts;
 - all upstream oracle revisions are closed and reproducible;
 - every Phase 0 defect is fixed or truthfully downgraded with a discriminating

--- a/docs/project/issue-248-fidelity-delivery-plan.md
+++ b/docs/project/issue-248-fidelity-delivery-plan.md
@@ -1,0 +1,695 @@
+# Issue #248 construct-level Mermaid fidelity delivery plan
+
+Status: proposed. This document turns
+[#248](https://github.com/adewale/agentic-mermaid/issues/248) into a staged
+delivery programme. The issue remains the authority for the audited findings
+and closure criteria; this plan owns sequencing, PR boundaries, dependency
+policy, and review discipline.
+
+## 1. Decision
+
+Treat #248 as a tracking epic, not a single implementation PR. Deliver it as a
+small number of infrastructure stacks followed by focused family repair PRs.
+Every PR must be independently reviewable and green against its declared base.
+
+The programme has two inseparable outcomes:
+
+1. every known construct-level loss is fixed or represented by an exact,
+   executable compatibility disposition; and
+2. capability and citizenship claims are generated from construct-level
+   semantic receipts so the same class of overclaim cannot recur.
+
+Fixing only the audit's defect table does not close #248. Building only the
+evidence framework while leaving silent corruption in place does not close it
+either.
+
+## 2. PR #192 is not a programme prerequisite
+
+Work on #248 should start from `main` without waiting for
+[#192](https://github.com/adewale/agentic-mermaid/pull/192).
+
+The following work is independent of #192 and should not be based on its
+branch:
+
+- upstream revision closure;
+- the fidelity contract, receipt runner, and semantic projector API;
+- capability/citizenship aggregation from receipts;
+- agent/native-render seam contracts;
+- parser statement-consumption and token-boundary guardrails;
+- official-example classification infrastructure;
+- the generated config-effect matrix;
+- non-Sankey family fixes; and
+- generic typed local Scene resources, including gradients and compositing.
+
+Sankey-specific native receipts and final Sankey closure do depend on a Sankey
+family implementation landing. That may be #192 after it is rebased and
+narrowed, or a replacement stack that extracts its generic infrastructure and
+then lands family enrollment separately.
+
+Do not stack the general #248 infrastructure on #192. At the time this plan was
+written, #192 was behind `main`, conflicted, and mixed Sankey work with generated
+cross-family artifacts. Making it the base of the programme would couple every
+other family and evidence change to that integration risk.
+
+Preferred Sankey sequence:
+
+1. land typed local Scene paint resources from `main`;
+2. rebase and narrow #192, or replace it with a smaller Sankey-enrollment PR;
+3. stack Sankey semantic receipts and any remaining renderer fixes on the
+   enrollment PR;
+4. merge in dependency order; and
+5. rerun the final Sankey audit after rebasing onto the merged bases.
+
+The epic can therefore begin immediately, but under #248's current 16-family
+scope it cannot close until Sankey is enrolled with truthful receipts. If a
+separate product decision abandons Sankey, #248's authority, scope, and
+acceptance criteria must be explicitly amended before that decision can affect
+epic closure.
+
+## 3. Non-negotiable delivery rules
+
+### 3.1 One semantic claim, one executable receipt
+
+A construct may be reported `native` only when a receipt proves its applicable
+semantic implications. File existence, hook invocation, source preservation,
+successful parsing, non-empty output, stable serialization, and SVG byte
+difference are useful evidence but are not sufficient individually or in the
+aggregate.
+
+Every receipt must identify:
+
+- stable case ID, family, construct IDs, and upstream authority coordinates;
+- exact upstream authority revision;
+- minimal authored source;
+- expected agent disposition: `structured`, `opaque`, or `reject`;
+- expected render disposition: `native`, `diagnosed`, or `reject`;
+- normalized semantic expectation;
+- exact expected diagnostics;
+- applicable serialization, mutation, layout, Scene, SVG, terminal,
+  interaction, configuration, and accessibility implications; and
+- a named divergence ID when local behavior intentionally differs.
+
+### 3.2 No silent statement loss
+
+Every nonblank, non-comment family statement must be modeled, preserved with a
+typed reason, or rejected with a named error. A parser must never return a
+visually plausible partial diagram after silently skipping an authored
+statement.
+
+### 3.3 Fail-closed public claims
+
+Receipt aggregation uses the following policy:
+
+- `native`: every applicable receipt required by the claim passes;
+- `source-preserved`: source survives but native semantics are not established;
+- `diagnosed`: a named unsupported or divergent behavior is surfaced exactly;
+- `not-applicable`: the upstream behavior genuinely cannot apply to authored
+  source or the output surface; and
+- `absent`: there is neither implementation nor an honest supported envelope.
+
+Unknown, uncovered, opaque-only, and divergent cases cannot contribute to a
+family-wide native claim. `diagnosed` is valid only when the actual public path
+emits the exact asserted runtime diagnostic. A divergence-ledger entry alone
+cannot manufacture diagnosed behavior. Silent loss remains `source-preserved`
+or `absent`, as applicable, until a runtime diagnostic or native fix lands.
+Divergence ledgers are inputs to aggregation, not parallel documentation.
+
+### 3.4 Every regression test must discriminate
+
+For each behavioral fix, demonstrate that the focused test or receipt is red on
+the defective implementation and green with the fix. Where a literal revert is
+impractical, use a bounded sabotage that removes the relevant parser token,
+config read, style implication, diagnostic, or Scene projection and show that
+the contract fails.
+
+### 3.5 Generated evidence follows its authority
+
+Generated reports, manifests, receipts, and galleries must be regenerated by
+their owning PR. Do not manually merge hashes or defer required freshness to a
+later integration PR. Generated binary evidence should appear only when the PR
+makes a visual claim that requires it.
+
+## 4. Mandatory multi-agent audit loop for every PR
+
+Every PR in this programme, including this plan PR and documentation-only PRs,
+must pass the following loop before it is marked ready or merged.
+
+### 4.1 Freeze and prepare the audit candidate
+
+1. Finish the scoped implementation.
+2. Commit the complete candidate and require a clean working tree. An
+   uncommitted or dirty candidate cannot begin a formal audit round.
+3. Run the mandatory baseline and touched-authority checks from §9.
+4. Record the exact target branch, target-tip SHA, merge-base SHA, head SHA, and
+   intended merge strategy. This tuple identifies the effective candidate.
+5. Freeze implementation work while the auditors inspect that tuple.
+
+### 4.2 Run at least three independent agent audits
+
+Use one distinct, read-only agent/session per role in independent contexts.
+Auditors must not see or coordinate with the other auditors before submitting
+their first report. The implementation agent may orchestrate the audit but must
+not count as an auditor or reuse one session for multiple roles.
+
+Required audit roles:
+
+1. **Upstream and semantic fidelity auditor** — checks the pinned Mermaid
+   authority, authored witness, normalized expectation, divergence policy, and
+   whether the change preserves the intended domain meaning.
+2. **Architecture, integration, and security auditor** — checks registry and
+   transport seams, source preservation, agent/native agreement, Scene/output
+   lowering, deterministic IDs, offline/security boundaries, stacking
+   assumptions, and generated authorities.
+3. **Adversarial test and evidence auditor** — attempts to invalidate the tests,
+   looks for assertions that pass with the defect restored, checks malformed and
+   boundary inputs, and verifies that reports are derived from the new receipt
+   rather than merely citing it.
+
+For a documentation-only PR, reinterpret the same roles as authority/scope,
+architecture/dependency feasibility, and enforceability/adversarial review.
+
+Each auditor must return:
+
+- `APPROVE` or `CHANGES_REQUIRED`;
+- stable finding IDs ordered by severity;
+- exact file, contract, or upstream evidence for each finding;
+- the smallest acceptable correction; and
+- residual risks or explicitly tested non-findings.
+
+An audit that only summarizes the PR is not an approval.
+
+### 4.3 Fix, retest, and audit again
+
+1. Preserve each auditor's first report verbatim, then consolidate the findings
+   without weakening them by majority vote.
+2. Fix every actionable finding. A scope suggestion may be rejected only with a
+   written explanation showing that it is not a defect in the PR's claim or
+   acceptance criteria.
+3. Rerun focused and affected wider checks.
+4. Start a new independent audit round against the new candidate tuple.
+5. Repeat until every auditor returns `APPROVE` with no actionable findings.
+
+Any change to the head SHA, target-tip SHA, merge-base SHA, target branch, or
+intended merge strategy invalidates checks and approval and requires another
+round. This includes target-branch advancement, retargeting, parent-PR merge,
+and rebasing even when the child head tree appears unchanged. Immediately
+before merge, compare the current tuple with the final audit record and fail
+closed on any difference.
+
+### 4.4 Preserve audit evidence in the PR
+
+The PR conversation must preserve each individual first report verbatim or by
+an immutable link and identify the distinct session/role that produced it. It
+must also contain an audit table with:
+
+| Round | Target | Target tip | Merge base | Head | Strategy | Individual reports | Result |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+
+Maintain a persistent finding ledger with:
+
+| Finding ID | Originating auditor | Severity | Disposition | Correction commit or rejection rationale | Validating round |
+| --- | --- | --- | --- | --- | --- |
+
+Post one consolidated audit comment per round in addition to the individual
+reports. The final row must identify the audited tuple and show approval from
+every role with no unresolved finding. Reviewers must be able to trace a
+finding to its correction without accessing an ephemeral agent transcript.
+Readiness automation added by A0 must reject a missing report, reused role,
+unresolved finding, or approval bound to a stale tuple; implementer-authored
+summary text alone is not audit evidence.
+
+## 5. Evidence architecture
+
+### 5.1 Construct authority and exact-set joins
+
+The current syntax-feature inventory is derived largely from documentation
+headings; it is not by itself a construct-complete grammar authority. A1 must
+establish a stable construct roster from the pinned grammar/spec blocks,
+official fences, and config authority, with reviewed many-to-many mappings to
+documentation headings and existing manifest coordinates.
+
+Exact-set validation must prove:
+
+- every pinned built-in construct maps to at least one fidelity case;
+- every case maps back to one or more stable construct IDs;
+- every manifest `syntaxFeature`, official `example`, and `configKey` appears in
+  its own typed index;
+- every construct exercised by an official fence is enumerated rather than
+  treating the fence as one atomic feature;
+- multiple witnesses may exercise the same construct without inventing new
+  feature IDs; and
+- orphan constructs, orphan cases, stale authorities, and ambiguous ownership
+  fail generation.
+
+### 5.2 `FamilyFidelityContract`
+
+Add a typed registry beside the built-in family descriptors, projected from the
+construct authority and existing upstream manifest rather than maintained as a
+second roster. The conceptual core is:
+
+```ts
+type FidelityAuthorityRef =
+  | { kind: 'feature'; id: string }
+  | { kind: 'example'; id: string }
+  | { kind: 'config-key'; id: string }
+
+type SurfaceApplicability =
+  | { state: 'applicable' }
+  | { state: 'not-applicable'; reasonCode: string; upstreamEvidence: string[] }
+
+type FidelityExpectation =
+  | {
+      renderDisposition: 'native'
+      semanticSnapshot: FamilySemanticSnapshot
+      expectedDiagnostics: readonly string[]
+    }
+  | {
+      renderDisposition: 'diagnosed' | 'reject'
+      semanticSnapshot?: FamilySemanticSnapshot
+      expectedDiagnostics: readonly [string, ...string[]]
+    }
+
+interface FamilyFidelityCase {
+  caseId: string
+  familyId: string
+  constructIds: readonly [string, ...string[]]
+  authority: FidelityAuthorityRef
+  upstreamRevision: string
+  source: string
+  expectedAgentDisposition: 'structured' | 'opaque' | 'reject'
+  expectation: FidelityExpectation
+  surfaces: Record<FidelitySurface, SurfaceApplicability>
+  divergenceId?: string
+}
+```
+
+`FamilySemanticSnapshot` must be a versioned, family-discriminated union rather
+than `unknown`. Schema validation must reject a native case without a semantic
+snapshot, a diagnosed/rejected case without an exact diagnostic, and any
+`not-applicable` surface without a typed reason and upstream evidence. Keep
+expectations deterministic; do not encode arbitrary executable callbacks in
+generated JSON authorities.
+
+Pinned Mermaid rejecting the source is the only ordinary basis for local
+`reject`. An official fence may also be rejected when it is proven partial or
+config-only. If pinned Mermaid accepts a complete fence, local rejection must
+be an executable named diagnosed compatibility divergence.
+
+### 5.3 Receipt runner
+
+The runner executes the same source through:
+
+```text
+detection
+  -> agent parse/body
+  -> verification
+  -> native parser and layout
+  -> normalized family semantic projection
+  -> Scene and output implication
+  -> canonical serialize/reparse
+  -> declared mutation round trip
+```
+
+It records disposition and semantic results, not just thrown/not-thrown status.
+Opaque agent success paired with native render failure must be an explicit
+diagnosed policy rather than `verify.ok === true` under an unqualified native
+claim.
+
+### 5.4 Family semantic projectors
+
+Create renderer-independent projectors for all built-in families. At minimum:
+
+- Flowchart: nodes, shapes, edge endpoints, edge identities, classes, styles;
+- State: states, transitions, nesting, classes, comments;
+- Sequence: participants, messages, arrow kinds, blocks, activation intervals;
+- Class: class IDs, annotations, members, relationships, tooltips;
+- ER: entities, attributes, cardinalities, relationship identities;
+- Journey and Timeline: ordered sections/periods, events, actors, scores, text;
+- Architecture and Mindmap: hierarchy, services/nodes, edges, icon resolution;
+- XY, Pie, Quadrant, and Radar: series/points, domains, labels, values, identity,
+  configured appearance;
+- Gantt: tasks, sections, resolved dates, dependencies, statuses;
+- GitGraph: commits, parents, branches, heads, tags, cherry-pick ancestry; and
+- Sankey: nodes, links, layers, widths, endpoint paint, and overlap compositing.
+
+Compare local projections with the pinned Mermaid parser/DB where executable,
+then verify that the required identities and implications survive Scene/output
+lowering.
+
+Upstream parser/DB adapters are offline test and evidence tooling only. They
+must never enter production, browser, CLI, or hosted runtime bundles. Each
+adapter binds to the declared revision, resets or isolates mutable upstream DB
+state per case, and emits a deterministic typed/versioned snapshot consumed by
+the receipt.
+
+### 5.5 Capability and citizenship projection
+
+Replace blanket built-in capability evidence with aggregation over passing
+receipts. Section A, the syntax capability ledger, citizenship, CLI discovery,
+and generated docs must consume the same result. A report freshness check must
+fail when behavior, a receipt, a divergence, or an upstream revision changes
+without regenerating the public claims.
+
+## 6. Delivery stacks and work packages
+
+Stacks are encouraged where they keep each review focused. Keep stacks shallow
+(normally no more than four open PRs), identify the parent PR in every
+description, and ensure every PR is green against its actual target branch.
+
+### A0 — programme governance prerequisite
+
+Land this before opening non-`main`-targeted implementation stacks:
+
+- make canonical CI run for every pull-request target branch, or provide an
+  equivalent required reusable/manual workflow bound to the exact target-tip,
+  merge-base, and head tuple;
+- extend the PR template and readiness tooling to require three distinct
+  individual audit reports, the finding ledger, and the current tuple;
+- fail readiness when reports are missing, roles are reused, findings remain
+  unresolved, or approvals/checks are stale; and
+- add the pre-merge tuple comparison required by §4.3.
+
+The existing CI workflow runs pull requests targeting `main`; without A0, a
+child PR targeting its immediate parent can appear reviewable without a
+canonical CI result against its actual base.
+
+### Stack A — authority and truthful evidence
+
+1. **A1: upstream revision closure**
+   - choose the canonical Mermaid 11.16 revision;
+   - make all executable artifacts name it or an explicit reviewed
+     compatibility revision;
+   - establish the construct-complete roster and many-to-many authority joins
+     from §5.1; and
+   - fail generation on unacknowledged splits or roster gaps.
+2. **A2: fidelity contract and runner skeleton**
+   - add stable `caseId`, discriminated authority references, construct IDs,
+     deterministic receipt schema, exact-set indexes for features/examples/
+     config keys, and a small cross-family exemplar set;
+   - do not change public capability claims yet.
+3. **A3: semantic projector API and initial projectors**
+   - establish normalized snapshot/versioning rules;
+   - land enough projectors to exercise the Phase 0 defects.
+4. **A4: receipt-driven reports and citizenship**
+   - feed divergences and receipts into capability aggregation;
+   - deliberately downgrade every not-yet-receipted claim during migration;
+   - classify known defects from actual behavior: `diagnosed` only when the
+     public path emits the exact asserted diagnostic, otherwise
+     `source-preserved` or `absent` as applicable; and
+   - commit and review the expected transitional report state before repairs
+     promote individual constructs.
+
+Primary dependency graph:
+
+```text
+A0 ───────────────────────────────> every stacked implementation PR
+A1 -> A2 -> A3 -> A4
+          |           |-> family repairs + relevant B guardrail/projector
+          |           |-> Stack D official-example closure
+          |           `-> Stack E config-effect closure
+          |-> Stack B parser/seam work where the receipt API is required
+          `-> Stack C may start independently from main, but C4 consumes A4
+```
+
+Family repairs depend on A4 plus their family projector and relevant guardrail.
+Stacks D and E depend on the receipt schema and aggregation base. B and generic
+C infrastructure may begin earlier where they do not consume those authorities.
+
+### Stack B — parser and seam guardrails
+
+1. **B1: statement-consumption contract** — consume, typed-preserve, or reject
+   every nonblank statement.
+2. **B2: shared comment/delimiter normalization and agent/native seam** — run
+   each fidelity source through both paths and require compatible dispositions.
+3. **B3: keyword-boundary and dual-vocabulary checks** — detect prefix regexes
+   and unexplained parser vocabulary drift.
+4. **B4: shared identity grammar contracts** — reuse declaration/reference/
+   mutation ID parsing within each family.
+
+These PRs may stack on A2/A3 where they need the receipt API, but should not wait
+for A4's report migration.
+
+### Stack C — typed Scene resources and Sankey
+
+1. **C1: typed local paint resources**
+   - introduce a typed resource union with globally unique definition IDs and
+     references across marker and paint resources;
+   - decide and test the core Scene contract-version migration;
+   - explicitly version exposure through External Scene or deliberately reject
+     the new resource in the existing external contract;
+   - bound snapshot/admission/validation, stop counts, and resource bytes;
+   - require every built-in graphical backend to prove the new resource through
+     conformance fixtures; and
+   - test reference ownership, namespacing, deterministic serialization, local-
+     only references, and external-reference rejection.
+2. **C2: typed compositing**
+   - add the bounded blend-mode behavior required for upstream Sankey overlap;
+   - update backend capability claims and conformance so unsupported backends
+     cannot retain a false native resource claim; and
+   - add explicit terminal loss/projection diagnostics for gradients and
+     compositing.
+3. **C3: Sankey enrollment** — rebased/narrowed #192 or its replacement,
+   with C1 and C2 as hard merge dependencies. The only exception is a C3 that
+   rejects or emits exact runtime diagnostics for gradient/compositing and keeps
+   every affected capability/report row downgraded.
+4. **C4: Sankey receipts and closure** — source-to-target gradient stops,
+   multiply overlap, contrast behavior, header consistency, and final report
+   state.
+
+If #192 is used as C3, that PR itself must pass the complete audit loop after
+its final rebase. If it merges before this programme can audit it, the first
+C-stack PR must audit the imported Sankey implementation against its effective
+merged base before relying on it.
+
+### Family repair PRs — Phase 0
+
+Create focused child issues and PRs for:
+
+- Sequence half-arrows, semicolon statements, `critical option`, and rect fill;
+- State trailing comments and spaced class targets;
+- Class annotations, bare dashed relationships, and escaped/backtick IDs;
+- ER word-form aliases;
+- Timeline `%` comments and unsupported header directions;
+- XY Chart unknown-statement rejection; and
+- Sankey gradients/compositing and header claim consistency through Stack C.
+
+Each family PR adds the receipt first, proves it discriminates, fixes both agent
+and native paths as applicable, and regenerates the affected claim rows.
+
+### Family implication PRs — Phase 1
+
+Follow with focused work for:
+
+- Flowchart edge-class paint and animation implications;
+- Class safe tooltips;
+- ER multiple-class syntax and stale subgraph diagnostics;
+- Gantt config effects, inline task comments, and explicit duration divergence;
+- Journey fractional scores;
+- Timeline semantic line breaks and mutation-safe clock/URL colons;
+- GitGraph float precision, duplicate-ID fence classification, and explicit
+  synthetic-ID divergence;
+- XY data-label placement, axis rotation, and theme data-label color;
+- Pie duplicate-label identity semantics;
+- Architecture unresolved registered icons and the bare-header extension;
+- Mindmap unresolved host icon-font classes; and
+- executable uncertainty receipts for Quadrant and Radar duplicate/lexer edge
+  cases.
+
+### Stack D — exhaustive official examples
+
+1. generate one case record for every harvested official fence;
+2. review all 331 audited fences as structured, opaque, reject, partial, or
+   config-only;
+3. enumerate every construct exercised by each fence and join it to the
+   construct authority rather than treating the fence as one feature;
+4. attach one or more semantic receipts or a named diagnosed compatibility
+   divergence;
+5. permit `reject` only when pinned Mermaid also rejects the source or the fence
+   is proven partial/config-only; otherwise require an executable named
+   diagnosed divergence;
+6. require exact-set closure for construct, feature, example, and case indexes
+   so new, removed, orphaned, or multiply ambiguous entries cannot disappear;
+   and
+7. keep selected galleries as visual reviewer evidence, not native proof.
+
+Classification may discover new defects. File each as a child of #248 and add
+it to the appropriate severity phase; do not weaken the case expectation to
+match current behavior.
+
+### Stack E — generated config-effect matrix
+
+For every pinned built-in-family config key, generate exactly one disposition:
+
+- `wired`, with an A/B predicate over typed semantics, geometry, paint, or
+  interaction;
+- `diagnosed-noop`, with unchanged semantics and an exact warning; or
+- `unsupported`, with a named reason.
+
+Join the upstream config inventory, descriptor declarations, runtime resolver
+reads, docs, and tests. Fail on missing or multiply owned keys. Do not create a
+third hand-maintained config roster.
+
+### Stack F — depth and adversarial quality
+
+After truthful baseline coverage exists:
+
+- add comment/delimiter/whitespace metamorphic laws;
+- add duplicate and permutation tests for identity-bearing families;
+- add statement-deletion sentinels;
+- add config A/B semantic probes;
+- sample gradients at source/midpoint/target and overlap;
+- add bounded parser/diagnostic sabotage profiles; and
+- add controlled upstream visual/geometry comparisons with explicit tolerances
+  and divergence IDs.
+
+## 7. Stacked PR operating procedure
+
+Every stacked PR description must include:
+
+| Position | PR | Base | Purpose | Merge dependency |
+| --- | --- | --- | --- | --- |
+
+Rules:
+
+1. target the immediate parent branch, not `main`, while the parent is open;
+2. keep each diff meaningful when viewed against that parent;
+3. do not hide generated artifacts or unrelated refactors in the top stack PR;
+4. after a parent merges, rebase or retarget descendants promptly;
+5. rerun checks and the full multi-agent audit loop after every rebase;
+6. merge from the bottom of the stack upward; and
+7. split a stack if reviewers must understand more than one semantic decision
+   to approve a PR.
+
+Family repair PRs may proceed in parallel once their required receipt/projector
+base is stable. They should not stack on each other merely to avoid updating
+`main`.
+
+## 8. Required PR description and evidence
+
+Every implementation PR must state:
+
+- child issue and parent epic;
+- exact claim being changed;
+- upstream witness and revision;
+- current incorrect disposition;
+- intended semantic result or named divergence;
+- focused receipt/test and a reproducible red/green record containing the
+  defective base SHA or deterministic sabotage/probe ID, patch/hash, exact
+  command, expected failure signature, observed red failure, and green result
+  on the audited head;
+- mandatory baseline and touched-authority checks, with exact-head CI job URLs
+  or command/result records;
+- generated artifacts changed and why;
+- stack position and dependencies;
+- individual audit reports, finding ledger, rounds, and final audited tuple; and
+- residual limitations.
+
+Visual-output PRs must include proportional before/after evidence generated from
+the same named input at immutable base/head revisions. The semantic receipt is
+the oracle; the image helps a reviewer inspect the consequence.
+
+## 9. Validation ladder
+
+Run the smallest relevant checks while iterating, then freeze a committed head
+and run the mandatory audit baseline. Every implementation PR runs:
+
+```bash
+bun run typecheck
+bun run lint
+bun run test
+```
+
+A documentation-only PR runs `git diff --check`, repository-path/link
+validation for every changed document, and the documentation audit roles from
+§4. It need not rerun unchanged runtime behavior unless the document is itself
+an executable/generated authority.
+
+Add deterministic checks by touched authority:
+
+| Touched authority | Required additions to the baseline |
+| --- | --- |
+| Family parser/renderer/projector | Focused fidelity receipt, parser/renderer family tests, red/green record |
+| Upstream manifest or authority | `upstream-manifest:check`, upstream bench/corpus checks, revision closure |
+| Section A/B, citizenship, receipts | `section-a-report:check`, `section-b-report:check`, `quality:check`, `evidence:check` |
+| Scene, backend, security, output | Backend conformance, External Scene compatibility, renderer security, affected output/browser checks, `build` |
+| Browser family/catalog | `check:browser-families`, browser-lazy checks, affected browser contracts |
+| Website/package/transport | Website freshness/payload checks, package build, affected CLI/MCP/transport contracts |
+| Official fence or config matrix | Exact-set corpus/config generator check and every affected semantic A/B case |
+
+The audited tuple must have canonical CI or the A0 equivalent against its exact
+target base; a green run against `main` cannot substitute for a stacked PR whose
+target is a parent branch.
+
+The final programme closure run includes at least:
+
+```bash
+bun run typecheck
+bun run test
+bun run lint
+bun run quality:check
+bun run evidence:check
+bun run upstream-manifest:check
+bun run section-a-report:check
+bun run section-b-report:check
+bun run check:browser-families
+bun run build
+```
+
+Family and browser/output changes add their focused corpus, gallery, browser,
+package, and transport checks. Upstream refresh commands must execute against
+the exact declared checkout revision and leave committed artifacts reproducible.
+
+## 10. Programme tracking
+
+Create child issues before implementation starts. Each child must name its
+work package, acceptance receipt, expected stack/base, and whether it blocks a
+public claim. Link child PRs back to #248; do not use PR prose as the only
+backlog.
+
+Maintain a checklist on #248 grouped by:
+
+- authority/evidence infrastructure;
+- parser and seam guardrails;
+- Phase 0 silent-corruption fixes;
+- Phase 1 implication/config/interaction fixes;
+- official-fence classification;
+- config-effect closure;
+- per-family projector and receipt closure; and
+- depth/hardening and final audit.
+
+The audit artifact remains historical evidence. Current executable receipts
+and generated reports become the live authority.
+
+## 11. Closure criteria
+
+Close #248 only when all of the following hold:
+
+- every officially authorable construct for every claimed built-in family has
+  an executed receipt;
+- the construct, feature, example, config-key, and case indexes have exact-set
+  closure with no orphan or ambiguous ownership;
+- every official fence has a reviewed disposition;
+- every nonblank statement is modeled, typed-preserved, or rejected;
+- agent parse, verification, native render, serialization, mutation, Scene,
+  applicable output, accessibility, and interaction behavior agree with the
+  case policy;
+- every config key has exactly one executable effect disposition;
+- capability and citizenship reports derive from passing receipts and
+  downgrade divergences automatically;
+- all upstream oracle revisions are closed and reproducible;
+- every Phase 0 defect is fixed or truthfully downgraded with a discriminating
+  regression receipt;
+- Sankey receipts observe endpoint stops and overlap compositing, not merely a
+  changed stroke byte;
+- generated authorities have no unexplained drift;
+- the full validation ladder passes; and
+- a final cross-programme multi-agent audit of the closure head returns
+  unanimous `APPROVE` with no actionable findings.
+
+## 12. Strengths to preserve
+
+Do not weaken the repository's existing deterministic layout/output contracts,
+typed registry enrollment, role/primitive Scene admission, opaque source
+preservation, canonical serialization, source maps, mutation surfaces, strict
+output security, or property-based geometry tests. The fidelity layer joins
+these strengths to construct-level semantic evidence; it does not replace them.

--- a/docs/project/issue-248-fidelity-delivery-plan.md
+++ b/docs/project/issue-248-fidelity-delivery-plan.md
@@ -284,7 +284,7 @@ trusted runner artifacts and automation.
 
 ## 5. Evidence architecture
 
-### 5.1 Construct authority and exact-set joins
+### 5.1 Construct and public-route authority with exact-set joins
 
 The current syntax-feature inventory is derived largely from documentation
 headings; it is not by itself a construct-complete grammar authority. A1 must
@@ -292,17 +292,32 @@ establish a stable construct roster from the pinned grammar/spec blocks,
 official fences, and config authority, with reviewed many-to-many mappings to
 documentation headings and existing manifest coordinates.
 
+A2 must also generate a versioned public-route registry from the canonical
+SDK, CLI, MCP, hosted, browser/editor, and output adapter declarations. A route
+ID represents one executable public entry path and records its family/input
+applicability, accepted config/theme surfaces, reachable stages, and owning
+adapter. It is not a hand-maintained list inside the cases. Adding, removing, or
+renaming a public entry point or route adapter without regenerating this
+authority must fail.
+
 Exact-set validation must prove:
 
 - every pinned built-in construct maps to at least one fidelity case;
 - every case maps back to one or more stable construct IDs;
 - every manifest `syntaxFeature`, official `example`, `configKey`, and
   `themeVariable` appears in its own typed index;
+- every generated public-route ID maps to exactly one owning adapter and every
+  public adapter maps back to one route ID;
+- every case and config/theme effect has one coverage entry for every registry
+  route that can accept the relevant family/input, either an applicable named
+  invocation or an evidenced `not-applicable` disposition;
 - every construct exercised by an official fence is enumerated rather than
   treating the fence as one atomic feature;
 - multiple witnesses may exercise the same construct without inventing new
-  feature IDs; and
+  feature IDs;
 - orphan constructs, orphan cases, stale authorities, and ambiguous ownership
+  fail generation; and
+- missing, unknown, duplicate, or orphaned route IDs and route-coverage entries
   fail generation.
 
 ### 5.2 `FamilyFidelityContract`
@@ -371,7 +386,7 @@ type FidelityStageExpectation =
 interface FidelityInvocation {
   invocationId: string
   sourceRef: string
-  publicRoute: string
+  publicRoute: PublicRouteId
   renderOptions: Readonly<Record<string, JSONValue>>
   config?: Readonly<Record<string, JSONValue>>
   backendId?: string
@@ -379,6 +394,35 @@ interface FidelityInvocation {
   security?: Readonly<Record<string, JSONValue>>
   interaction?: Readonly<Record<string, JSONValue>>
 }
+
+type PublicRouteId = string & { readonly __publicRouteId: unique symbol }
+
+interface FidelityPublicRoute {
+  routeId: PublicRouteId
+  schemaVersion: number
+  surface: 'sdk' | 'cli' | 'mcp' | 'hosted' | 'browser' | 'editor' | 'output'
+  adapterId: string
+  familyIds: readonly [string, ...string[]]
+  acceptedInputs: readonly [
+    'source' | 'config' | 'theme' | 'interaction',
+    ...('source' | 'config' | 'theme' | 'interaction')[],
+  ]
+  stages: readonly [FidelityStage, ...FidelityStage[]]
+}
+
+type FidelityRouteCoverage =
+  | {
+      routeId: PublicRouteId
+      state: 'applicable'
+      invocationIds: readonly [string, ...string[]]
+    }
+  | {
+      routeId: PublicRouteId
+      state: 'not-applicable'
+      invocationIds: readonly []
+      reasonCode: string
+      authorityEvidence: readonly [string, ...string[]]
+    }
 
 interface FidelitySource {
   sourceId: string
@@ -432,6 +476,7 @@ interface FamilyFidelityCase {
   upstreamRevision: string
   sources: readonly [FidelitySource, ...FidelitySource[]]
   invocations: readonly [FidelityInvocation, ...FidelityInvocation[]]
+  routeCoverage: readonly [FidelityRouteCoverage, ...FidelityRouteCoverage[]]
   mutationPlan: FidelityMutationPlan
   comparisons: readonly FidelityComparison[]
   stages: readonly [FidelityStageExpectation, ...FidelityStageExpectation[]]
@@ -456,8 +501,12 @@ opaque preservation caps the aggregate at `source-preserved` even when
 downstream native rendering succeeds.
 
 Every source reference, expectation, diagnostic, result reference, and mutation
-input resolves to a declared object, and every declared route has an exact
-stage-coverage policy. A comparison names the exact invocation-stage or
+input resolves to a declared object. For each case, the route-coverage route-ID
+set must equal the applicable generated registry set. Every applicable entry
+resolves to at least one invocation on that exact route and has the route's
+exact stage-coverage policy; every `not-applicable` entry carries governed
+authority evidence. Unknown routes, uncovered registry routes, and orphaned
+invocations fail validation. A comparison names the exact invocation-stage or
 mutation result it consumes; an oracle cannot substitute a hidden source,
 stage, invocation, or mutation. Define the stage dependency graph explicitly.
 A locally blocked downstream stage remains semantically
@@ -550,7 +599,8 @@ Use a two-tier dataflow:
    versioned aggregate capability index consumed by runtime family descriptors,
    CLI discovery, and public report generators;
 3. freshness hashes bind the aggregate to case definitions, receipt results,
-   projector/oracle/schema versions, divergence ledgers, and upstream revision;
+   the public-route registry and adapter versions, projector/oracle/schema
+   versions, divergence ledgers, and upstream revision;
    and
 4. build metafile, tarball, and bundle negative tests prove that Mermaid oracle
    code, case source, raw receipts, and semantic snapshots do not enter Node,
@@ -621,8 +671,9 @@ implementer-authored manual results are not substitutes after bootstrap.
 2. **A2: fidelity contract and runner skeleton**
    - add stable `caseId`, discriminated authority references, construct IDs,
      deterministic receipt schema, exact-set indexes for features/examples/
-     config keys/theme variables, named route invocations, typed mutations, A/B
-     comparisons, and a small cross-family exemplar set;
+     config keys/theme variables/public routes, typed route applicability and
+     named invocations, typed mutations, A/B comparisons, and a small cross-
+     family exemplar set;
    - keep cases, raw receipts, snapshots, and upstream adapters behind an
      enforced test/eval-only import boundary;
    - add the deterministic compact-index generator contract and initial bundle
@@ -951,8 +1002,13 @@ Close #248 only when all of the following hold:
 
 - every officially authorable construct for every claimed built-in family has
   an executed receipt;
-- the construct, feature, example, config-key, theme-variable, and case indexes
-  have exact-set closure with no orphan or ambiguous ownership;
+- the construct, feature, example, config-key, theme-variable, public-route,
+  and case indexes have exact-set closure with no orphan or ambiguous
+  ownership;
+- every case and config/theme effect covers every applicable generated public
+  route with a named invocation, or carries an evidenced `not-applicable`
+  disposition; missing, unknown, duplicate, and orphaned route entries are
+  zero;
 - every official fence has a reviewed disposition;
 - every nonblank statement is modeled, preserved with an exact route-specific
   typed runtime diagnostic, or rejected; no silent semantic preservation can

--- a/docs/project/issue-248-fidelity-delivery-plan.md
+++ b/docs/project/issue-248-fidelity-delivery-plan.md
@@ -68,6 +68,11 @@ needs them.
 type FidelityDisposition = 'native' | 'source-preserved' | 'diagnosed' | 'absent'
 type FidelitySurface = 'agent' | 'render' | 'serialize' | 'mutate'
 
+interface FidelityDiagnosticExpectation {
+  surface: FidelitySurface
+  code: string
+}
+
 interface FidelityCase {
   id: string
   family: string
@@ -75,7 +80,7 @@ interface FidelityCase {
   source: string
   upstreamReference: string
   expected: Partial<Record<FidelitySurface, FidelityDisposition>>
-  expectedDiagnostics?: string[]
+  expectedDiagnostics?: FidelityDiagnosticExpectation[]
   assertSemantics?: (result: unknown) => void
 }
 ```
@@ -84,6 +89,12 @@ Each case should contain the smallest source that demonstrates one meaningful
 claim. Semantic assertions should inspect normalized family data—participants,
 edges, dates, cardinalities, labels, paint stops, or similar domain meaning—not
 just non-empty output or changed SVG bytes.
+
+An omitted surface is one where the construct genuinely does not apply. If an
+earlier failure prevents an applicable later surface from running, the runner
+must record that surface as blocked by the failing stage; it must not silently
+turn it into an omission or `not-applicable` result. Match expected diagnostics
+by their stable code and surface rather than by free-form message text.
 
 Where pinned Mermaid exposes a stable parser or database, compare normalized
 local and upstream meaning. Where it does not, use the official syntax reference
@@ -111,6 +122,12 @@ result or diagnostics.
 A route needs a direct construct case only when it transforms the input or
 result in a way that can change meaning. Simple pass-through routes should not
 duplicate every family case.
+
+Route conformance should assert typed request and result equivalence at the
+adapter boundary: the same source and options reach the core, and the adapter
+preserves the resulting disposition, semantics, and diagnostics. Do not infer
+conformance merely from the absence of route-specific branches or from a small
+fixture count.
 
 Mutation tests follow the same rule: directly test each advertised operation
 that changes a construct, and separately assert that unrelated meaning survives.
@@ -162,10 +179,13 @@ Flowchart, Gantt, Journey, Pie, icons, and the remaining family seams. Split
 shared parser or identity work from family-specific rendering work when that
 keeps review smaller.
 
-### 4. Scene resources and Sankey
+### 4. Scene paint, compositing, and Sankey
 
-Land generic typed local gradients and compositing from `main`. These resources
-must remain deterministic and must not introduce external references.
+Land generic typed local gradients from `main`. Model blend/compositing
+separately as typed mark behavior and a backend capability, not as a gradient or
+definition resource. Decide how both concepts are represented and versioned in
+core Scene and External Scene before publishing a native claim. They must remain
+deterministic and must not introduce external references.
 
 Then rebase and narrow PR #192, or replace it with a smaller Sankey enrollment
 PR. Add Sankey semantic cases only after the family implementation is available.
@@ -195,7 +215,9 @@ Every implementation PR should include:
 - confirmation that the case fails when the fix is removed, where practical;
 - the relevant family and route tests;
 - regenerated capability output when the public claim changes; and
-- visual evidence only when pixels are part of the claim.
+- visual evidence only when pixels are part of the claim. For newly supported
+  output, preserve the real prior error or unsupported state as the baseline;
+  never manufacture a successful "before" render.
 
 Run the normal repository CI. Additional independent review is welcome for
 cross-family or security-sensitive changes, but it is not a bespoke release

--- a/docs/project/issue-248-fidelity-delivery-plan.md
+++ b/docs/project/issue-248-fidelity-delivery-plan.md
@@ -1,1127 +1,250 @@
-# Issue #248 construct-level Mermaid fidelity delivery plan
-
-Status: proposed. This document turns
-[#248](https://github.com/adewale/agentic-mermaid/issues/248) into a staged
-delivery programme. The issue remains the tracking and historical-evidence
-record. This repository document supplies the initial scoped family authority;
-after A1, the checked-in, versioned `FidelityScopeAuthority` is the sole
-executable closure authority. Editing the issue alone cannot change programme
-scope. This plan also owns sequencing, PR boundaries, dependency policy, and
-review discipline.
-
-## 1. Decision
-
-Treat #248 as a tracking epic, not a single implementation PR. Deliver it as a
-small number of infrastructure stacks followed by focused family repair PRs.
-Every PR must be independently reviewable and green against its declared base.
-
-The programme has two inseparable outcomes:
-
-1. every known construct-level loss is fixed or represented by an exact,
-   executable compatibility disposition; and
-2. capability and citizenship claims are generated from construct-level
-   semantic receipts so the same class of overclaim cannot recur.
-
-The architecture is deliberately factored. One generated authority fixes the
-16-family scope. Family cases prove construct semantics once through the
-canonical core. Generated route-conformance cases prove that CLI, SDK, MCP,
-editor, website, and output adapters preserve or accurately diagnose those
-semantics. One executable gate joins both results into the compact public
-capability index. A0 enforces candidate identity and evidence provenance; it is
-not a mandate to build a general-purpose governance platform.
-
-Fixing only the audit's defect table does not close #248. Building only the
-evidence framework while leaving silent corruption in place does not close it
-either.
-
-## 2. PR #192 is not a programme prerequisite
-
-Work on #248 should start from `main` without waiting for
-[#192](https://github.com/adewale/agentic-mermaid/pull/192).
-
-The following work is independent of #192 and should not be based on its
-branch:
-
-- upstream revision closure;
-- the fidelity contract, receipt runner, and semantic projector API;
-- capability/citizenship aggregation from receipts;
-- agent/native-render seam contracts;
-- parser statement-consumption and token-boundary guardrails;
-- official-example classification infrastructure;
-- the generated config-effect matrix;
-- non-Sankey family fixes; and
-- generic typed local Scene resources, including gradients and compositing.
-
-Sankey-specific native receipts and final Sankey closure do depend on a Sankey
-family implementation landing. That may be #192 after it is rebased and
-narrowed, or a replacement stack that extracts its generic infrastructure and
-then lands family enrollment separately.
-
-Do not stack the general #248 infrastructure on #192. At the time this plan was
-written, #192 was behind `main`, conflicted, and mixed Sankey work with generated
-cross-family artifacts. Making it the base of the programme would couple every
-other family and evidence change to that integration risk.
-
-Preferred Sankey sequence:
-
-1. land typed local Scene paint resources from `main`;
-2. rebase and narrow #192, or replace it with a smaller Sankey-enrollment PR;
-3. stack Sankey semantic receipts and any remaining renderer fixes on the
-   enrollment PR;
-4. merge in dependency order; and
-5. rerun the final Sankey audit after rebasing onto the merged bases.
-
-The epic can therefore begin immediately, but under #248's current 16-family
-scope it cannot close until Sankey is enrolled with truthful receipts. If a
-separate product decision abandons Sankey, #248's authority, scope, and
-acceptance criteria must be explicitly amended before that decision can affect
-epic closure.
-
-## 3. Non-negotiable delivery rules
-
-### 3.1 One semantic claim, one executable receipt
-
-A construct may be reported `native` only when a receipt proves its applicable
-semantic implications. File existence, hook invocation, source preservation,
-successful parsing, non-empty output, stable serialization, and SVG byte
-difference are useful evidence but are not sufficient individually or in the
-aggregate.
-
-Every receipt must identify:
-
-- stable case ID, family, construct IDs, and upstream authority coordinates;
-- exact upstream authority revision;
-- minimal authored source;
-- a typed expectation for every pipeline stage, including whether it applies;
-- a versioned semantic oracle for every applicable native stage;
-- exact structured diagnostic expectations for every public non-native
-  disposition and an explicit dependency for every blocked stage;
-- applicable serialization, mutation, layout, Scene, SVG, terminal,
-  interaction, configuration, and accessibility implications; and
-- a named divergence ID when local behavior intentionally differs.
-
-### 3.2 No silent statement loss
-
-Every nonblank, non-comment family statement must be modeled, preserved with a
-route-specific typed runtime diagnostic, or rejected with a named error. A
-parser must never return a visually plausible partial diagram after silently
-skipping an authored statement. Lossless preservation by a serialization stage
-may be silent only when every applicable public parse, verify, and render route
-models the construct natively; preservation does not excuse a semantic gap on
-another route.
-
-### 3.3 Fail-closed public claims
-
-Receipt aggregation uses the following policy:
-
-- `native`: every applicable receipt required by the claim passes;
-- `source-preserved`: source survives, native semantics are not established,
-  and the applicable public route emits the exact typed diagnostic;
-- `diagnosed`: a named unsupported or divergent behavior is surfaced exactly;
-- `not-applicable`: the upstream behavior genuinely cannot apply to authored
-  source or the output surface; and
-- `absent`: there is neither implementation nor an honest supported envelope.
-
-Unknown, uncovered, opaque, and divergent cases cannot contribute to a
-family-wide native claim. Whenever the agent surface applies, `native`
-aggregation requires a structured agent disposition, a passing structured
-semantic projection, and native render semantics. An opaque agent case caps
-the construct and public claim at `source-preserved` even when the native
-renderer succeeds. `diagnosed` is valid only when the actual public path
-emits the exact asserted runtime diagnostic. A divergence-ledger entry alone
-cannot manufacture diagnosed behavior. Silent semantic loss is `absent`,
-blocks programme closure, and may be promoted only when an exact runtime
-diagnostic or native fix lands. Divergence ledgers are inputs to aggregation,
-not parallel documentation.
-
-`uncovered` is an internal migration state, not a public capability
-disposition. It carries no behavioral claim, always projects to public
-`absent`, and cannot satisfy native, diagnosed, or final-closure coverage.
-
-### 3.4 Every regression test must discriminate
-
-For each behavioral fix, demonstrate that the focused test or receipt is red on
-the defective implementation and green with the fix. Where a literal revert is
-impractical, use a bounded sabotage that removes the relevant parser token,
-config read, style implication, diagnostic, or Scene projection and show that
-the contract fails.
-
-### 3.5 Generated evidence follows its authority
-
-Generated reports, manifests, receipts, and galleries must be regenerated by
-their owning PR. Do not manually merge hashes or defer required freshness to a
-later integration PR. Generated binary evidence should appear only when the PR
-makes a visual claim that requires it.
-
-## 4. Mandatory multi-agent audit loop for every PR
-
-Every PR in this programme, including this plan PR and documentation-only PRs,
-must pass the following loop before it is marked ready or merged.
-
-### 4.1 Freeze and prepare the audit candidate
-
-1. Finish the scoped implementation.
-2. Commit the complete candidate and require a clean working tree. An
-   uncommitted or dirty candidate cannot begin a formal audit round.
-3. Freeze the complete semantic PR title/body. Record its SHA-256 and GitHub
-   `lastEditedAt`; dynamic workflow run IDs and audit status do not belong in
-   that body.
-4. Record the candidate tuple: repository ID, PR number, target branch,
-   target-tip SHA, merge-base SHA, head SHA, intended merge strategy, protected
-   governance-policy revision, and semantic-description digest. Recompute and
-   record the head tree and canonical delta digest as derived integrity receipts
-   rather than additional identity fields. `git-raw-tree-delta-v1` is SHA-256
-   over the exact NUL-delimited stdout of:
-
-   ```text
-   git -c core.abbrev=40 -c color.ui=false diff-tree --no-commit-id -r --raw -z --abbrev=40 --no-renames <merge-base> <head>
-   ```
-
-   Record the repository object format. Rendered patches, abbreviated object
-   IDs, textconv, external diff drivers, rename heuristics, locale, and object-
-   count-dependent abbreviation are not identity inputs; a binary patch may be
-   retained only as human-readable review evidence.
-5. Run the mandatory baseline and touched-authority checks from §9 against that
-   exact frozen state. A0 checks attest the semantic digest; during bootstrap,
-   every accepted provider run must start after `lastEditedAt`.
-6. Immediately before registration, reread the live PR metadata, target tip,
-   tuple, digests, and newest required runs. Any difference restarts preparation.
-7. Before dispatch, create a content-addressed round manifest that registers
-   the three role/session/run IDs, prompt/scope hashes, candidate tuple, tree/
-   canonical-delta digest, and timestamp.
-8. Freeze implementation and semantic-description work while the auditors
-   inspect that registered candidate.
-
-### 4.2 Run at least three independent agent audits
-
-Use one distinct, trusted-runner-issued read-only agent/session per role in
-independent contexts.
-Auditors must not see or coordinate with the other auditors before submitting
-their first report. The implementation agent may orchestrate the audit but must
-not count as an auditor or reuse one session for multiple roles.
-
-Required audit roles:
-
-1. **Upstream and semantic fidelity auditor** — checks the pinned Mermaid
-   authority, authored witness, normalized expectation, divergence policy, and
-   whether the change preserves the intended domain meaning.
-2. **Architecture, integration, and security auditor** — checks registry and
-   transport seams, source preservation, agent/native agreement, Scene/output
-   lowering, deterministic IDs, offline/security boundaries, stacking
-   assumptions, and generated authorities.
-3. **Adversarial test and evidence auditor** — attempts to invalidate the tests,
-   looks for assertions that pass with the defect restored, checks malformed and
-   boundary inputs, and verifies that reports are derived from the new receipt
-   rather than merely citing it.
-
-For a documentation-only PR, reinterpret the same roles as authority/scope,
-architecture/dependency feasibility, and enforceability/adversarial review.
-
-Each auditor must return:
-
-- `APPROVED` or `CHANGES_REQUIRED`;
-- stable finding IDs ordered by severity;
-- exact file, contract, or upstream evidence for each finding;
-- the smallest acceptable correction; and
-- residual risks or explicitly tested non-findings.
-
-An audit that only summarizes the PR is not an approval.
-
-Every commissioned run must resolve to a recorded first report, failure,
-timeout, or cancellation. Do not replace or omit an unfavorable, failed, or
-abandoned run. A replacement requires a new manifest and a new round containing
-the complete registered role set.
-
-### 4.3 Fix, retest, and audit again
-
-1. Preserve each auditor's first report verbatim, then consolidate the findings
-   without weakening them by majority vote.
-2. Fix every actionable finding. A scope suggestion may be rejected only with a
-   written explanation showing that it is not a defect in the PR's claim or
-   acceptance criteria.
-3. Rerun focused and affected wider checks.
-4. Start a new independent audit round against the new candidate tuple.
-5. Repeat until every auditor returns `APPROVED` with no actionable findings.
-
-`AuditVerdict` is exactly `APPROVED | CHANGES_REQUIRED`. Manifests, prompts,
-reconciliation, readiness parsers, and examples must reject every other token.
-
-Any change to the repository/PR identity, semantic title/body digest, head SHA,
-target-tip SHA, merge-base SHA, target branch, intended merge strategy, or
-protected governance-policy revision invalidates checks and approval and
-requires another round. This includes target-branch advancement, semantic PR
-description edits, retargeting, parent-PR merge, and rebasing even when the
-child head tree appears unchanged. Immediately before merge, compare the
-current tuple, tree/canonical-delta and semantic-description digests, required workflow
-and governance-policy revisions, and newest non-superseded provider-issued
-check runs with the final audit record and fail closed on any difference. A
-newer failed or cancelled run for the same tuple supersedes an older success.
-
-### 4.4 Preserve audit evidence in the PR
-
-The trusted runner preserves each individual first report as a content-addressed
-immutable payload. One detached signed or protected round envelope records all
-payload hashes, roles, actor/session/run identities, candidate tuple, tree/
-canonical-delta
-and semantic-description digests, prompt/scope hashes, timestamps, commissioned-
-run reconciliation, and finding ledger. Never require a payload to contain its
-own byte hash. The PR conversation needs one machine-owned comment per round
-pointing to this bundle; it does not duplicate each report as a separate pasted
-comment. The bundle contains an audit table with:
-
-| Round | Target | Target tip | Merge base | Head | Strategy | Individual reports | Result |
-| --- | --- | --- | --- | --- | --- | --- | --- |
-
-Maintain a persistent finding ledger with:
-
-| Finding ID | Originating auditor | Severity | Disposition | Correction commit or rejection rationale | Validating round |
-| --- | --- | --- | --- | --- | --- |
-
-The final row must identify the audited tuple and show approval from every role
-with no unresolved finding. Reviewers must be able to trace a finding to its
-correction without accessing an ephemeral agent transcript. Audit results and
-the finding ledger live in the immutable round bundle, referenced by its
-machine-owned comment, not in mutable semantic PR-body sections. Readiness
-automation added by A0 must reject a missing report, reused role, unreconciled
-commissioned run, unresolved finding, invalid payload/envelope hash, or approval
-bound to a stale tuple/digest; implementer-authored summary text alone is not
-audit evidence. The final readiness job runs after the final audit and accepts
-only the newest required provider-issued check for each declared check
-identity.
-
-### 4.5 Manual bootstrap for this plan and A0
-
-This plan PR and the A0 governance PR necessarily precede the trusted audit
-runner. They use one explicit, temporary bootstrap protocol; no later PR may
-claim this exception:
-
-1. commit a clean candidate, freeze its semantic title/body, and record its
-   digest and GitHub `lastEditedAt` together with repository/PR identity, target
-   tip, merge base, head, tree, canonical delta digest, protected policy
-   revision, and squash strategy;
-2. run `git diff --check <merge-base>...<head>`, verify the changed-path set,
-   and compute the canonical `git-raw-tree-delta-v1` receipt from §4.1;
-3. validate the external issue/PR links with `gh issue view 248` and
-   `gh pr view 192`, and require every target-bound `gh pr checks` identity to
-   start after the recorded `lastEditedAt` and be complete and green before
-   registration or dispatch;
-4. before dispatch, anchor a canonical round-manifest payload in an
-   independently controlled append-only record that does not mutate the frozen
-   candidate: a protected audit ref, signed annotated tag, or server-issued
-   immutable record. A detached envelope records the manifest payload hash,
-   session IDs, prompt/scope hashes, tuple, tree/canonical-delta and semantic-description
-   digests, timestamp, and anchor object/URL. A PR comment points to that anchor
-   but is not its authority;
-5. require each auditor to publish the first report through an independently
-   authenticated identity or a server-issued immutable transcript/artifact;
-   record the provider artifact/transcript ID, immutable URL, actor/run identity,
-   origin timestamp, and payload hash before accepting an implementer-preserved
-   copy; an implementer-pasted report alone is invalid;
-6. post the round-bundle pointer under one stable comment ID, record the
-   manifest/report payload and envelope SHA-256 values plus comment
-   `created_at`/`updated_at` in the bundle, and have an independent human witness
-   compare the preserved bytes with the origin artifacts and anchored manifest
-   before final readiness;
-7. reconcile every commissioned session and the committed manifest, fix every
-   actionable finding, and
-   repeat against each new tuple until unanimous approval; and
-8. have a human maintainer verify the final tuple, hashes, comments, and checks
-   before merge.
-
-A0 must add a deterministic package script named `check:programme-docs` for
-future plan/governance link and path validation and replace this bootstrap with
-trusted runner artifacts and automation.
-
-## 5. Evidence architecture
-
-### 5.1 Scoped family, construct, and public-route authorities
-
-The current syntax-feature inventory is derived largely from documentation
-headings and the upstream manifest covers families outside #248. A1 must first
-generate one repository-versioned `FidelityScopeAuthority` containing exactly
-these initial family IDs: `flowchart`, `state`, `sequence`, `timeline`, `class`,
-`er`, `journey`, `architecture`, `xychart`, `pie`, `quadrant`, `gantt`,
-`mindmap`, `gitgraph`, `radar`, and `sankey`. It then establishes the scoped
-construct roster from pinned grammar/spec blocks, official fences, and config
-authority, with reviewed many-to-many mappings to documentation headings and
-manifest coordinates. Manifest rows outside this family authority remain in an
-explicit unsupported/out-of-scope envelope; they do not silently enter this
-programme or require projectors and cases. A scope amendment requires an
-audited repository PR that changes the authority and its digest; synchronize the
-tracking issue, but do not treat it as a trust root.
-
-A2 generates a versioned public-route registry from canonical SDK declarations,
-CLI command/selector tables, MCP tool declarations, browser/editor/website
-entrypoints, and `RENDER_TRANSPORT_SURFACES` × `RENDER_OUTPUTS`. A route records
-independent transport, operation, entrypoint, selector, and optional output
-dimensions plus its owning adapter. One adapter may own many routes; every route
-has exactly one owner. No semantic dimension is hidden only inside a route-ID
-string or hand-maintained in cases.
-
-Exact-set validation must prove:
-
-- the in-scope family-ID set equals the repository-versioned scope authority;
-- every scoped construct and manifest authority generates at least one coverage
-  obligation, every case maps back to scoped constructs and authorities, and
-  final closure requires every obligation to be discharged by executable cases;
-- every scoped manifest `syntaxFeature`, official `example`, `configKey`, and
-  `themeVariable` appears in its typed index, while every unscoped row has an
-  explicit out-of-scope disposition;
-- every generated route maps to one owner, every public entrypoint/selector/
-  output cell maps back to a route, and an adapter may map to multiple routes;
-- every construct exercised by an official fence is enumerated rather than
-  treating the fence as one atomic feature;
-- multiple witnesses may exercise the same construct without inventing new
-  feature IDs; and
-- orphan constructs, cases, sources, invocations, authorities, routes, and
-  ambiguous ownership fail generation.
-
-### 5.2 Factored semantic and route contracts
-
-Do not materialize a construct × source × public-route × stage Cartesian
-product. Most public adapters are transport projections over the same semantic
-core, so repeating every construct through every transport adds cost without
-independent evidence. Use two exact, joined contracts instead:
-
-1. family cases prove construct/source semantics through the canonical agent and
-   native core routes; and
-2. route-conformance cases prove every public adapter's accepted inputs,
-   operation, selector, output, diagnostics, and pass-through/projection rules.
-
-Factored conformance is permitted only when an adapter proves a refinement to
-the canonical core for every generated route contract. An `opaque-transport`
-adapter must prove across its complete transitive production dependency closure
-that it cannot inspect or modify family, construct, source, options,
-diagnostics, semantic results, Scene data, or output bytes except through
-schema-checked lossless envelope serialization. Caching, normalization,
-coercion, security/option projection, diagnostic mapping, mutation/build
-handling, output conversion, truncation, and output-size policy are
-transformations, not opaque transport.
-
-A2 generates an exact-set `RouteTransformAuthority`. Every transformation has a
-stable contract ID, declared affected input and semantic-implication IDs, and a
-versioned refinement oracle. The runner records normalized source/request,
-operation, selector, output, config/theme/interaction/options, core result, and
-diagnostic identities at the adapter handoff, then proves that the public result
-equals the declared projection. Every semantic cell declares the implication
-IDs it proves. Missing, extra, dynamic, unclassified, or orphaned joins fail
-generation. Absence of family/construct branching is insufficient; a transform
-without a finite authoritative implication mapping is `route-specific` and
-requires direct affected-construct coverage. Touched-authority invalidation
-includes the adapter's transitive codecs, projectors, and dependencies.
-
-A2 owns the precise TypeScript schema; this plan requires the following records
-and joins rather than freezing implementation syntax:
-
-| Record | Required data |
-| --- | --- |
-| Family case | Stable case/family IDs, non-empty construct and authority IDs, upstream revision, sources, canonical invocations, semantic cells, comparisons, optional divergence ID |
-| Source | Stable ID, exact source, authored/metamorphic/boundary/malformed role, and base/transform IDs for a derived variant |
-| Invocation | Stable ID, source/mutation/build kind, canonical core or public route ID, source or family input, and declarative options/operations |
-| Semantic cell | Stable ID, construct ID, invocation ID, stage, disposition, oracle/diagnostic requirements, or governed blocking/not-applicable evidence |
-| Public route | Generated transport, operation, entrypoint, selector, optional output, owning adapter, opaque-transport/refined-transform/route-specific mode, family/input applicability, and reachable stages |
-| Route transform | Stable contract ID, affected input/implication IDs, transitive dependency coordinates, handoff/result identity fields, and refinement oracle |
-| Route-conformance case | Stable ID, route ID, transform/contract IDs, fixture invocation IDs, core-handoff witness, refinement oracle, and diagnostic expectations |
-| Comparison | Stable ID, construct IDs, two exact invocation-stage results, and a versioned oracle |
-| Coverage obligation | Stable authority coordinate, required family/input/stage or route contract, state (`uncovered` or `discharged`), and resolving case/cell IDs when discharged |
-
-Coverage obligations are generated exhaustively from scope and route
-authorities before cases are authored. `uncovered` is permitted only during
-migration: it maps to public `absent`, cannot satisfy a claim, and fails final
-programme closure. This preserves exact-set accounting while evidence lands.
-
-`FidelityStage` covers detection, agent parse, verification, native parse,
-configuration, layout, Scene, SVG, PNG, terminal, serialization, mutation,
-accessibility, and interaction. `FidelityInputKind` includes source, config,
-theme, interaction, mutation, and build inputs. Transport, operation, and output
-IDs are generated branded types, not handwritten unions in the cases. Oracle
-IDs resolve through a runner-owned typed registry whose outputs are versioned,
-family-discriminated semantic or implication snapshots; generated JSON never
-embeds arbitrary executable callbacks.
-
-The generator derives two required grids. The semantic grid contains exactly one
-cell for every construct × named source × applicable core stage. Every source
-must participate in a canonical semantic invocation; orphan sources are
-rejected. Every metamorphic source must name its derivation and participate in a
-comparison with its base. Multi-construct official fences produce separate
-construct/source cells even when one invocation exercises several constructs.
-
-The route grid contains exactly one conformance result for every generated
-public route × accepted input kind × operation/selector/output contract. It
-checks real transport admission, option/config/theme/interaction pass-through,
-diagnostic envelopes, mutation atomicity, serialization, output bytes, and
-security rules as applicable. Use one discriminating case for every generated
-route-transform contract and equivalence class. A small cross-family fixture set
-provides concrete controls for declared pass-through/refinement invariants; it
-is not their sole proof. Property or metamorphic cases cover generic transforms
-and boundary policies that exact digest equality cannot establish. Cache
-conformance proves every semantic request field participates in the cache key.
-A `route-specific` adapter also generates direct required family-case cells for
-each affected construct or implicated semantic type. Aggregation permits a
-public native claim only when both its semantic cells and applicable route-
-conformance/refinement cells pass.
-
-Every invocation, cell, diagnostic, comparison, source, route case, and
-authority reference must resolve and have reverse coverage. Public mutation and
-build conformance must execute the real route; runner-internal operations cannot
-stand in for CLI, MCP, SDK, or other public admission, batching, diagnostics,
-verification, and serialization behavior. A native mutation/build semantic
-cell requires a result oracle and preservation oracles for unrelated semantic
-facets. A route that does not support an operation must emit an exact diagnosed
-outcome or carry governed `not-applicable` evidence; the programme does not
-require inventing a mutation API merely to satisfy a native render claim.
-
-The generator also derives exact mutation/build membership indexes without
-multiplying constructs across transports. Direct mutation membership is the
-exact generated set of `(case ID, construct ID, source ID, applicable mutation-
-operation ID)` tuples. Every advertised operation whose governed schema can
-target that construct executes through the canonical real public route and has
-a discriminating direct-result oracle; survival under an unrelated mutation
-cannot discharge a direct membership. Each direct membership also has a
-separate preservation obligation, exercised by a governed unrelated operation
-or operation equivalence class, whose oracle proves that operation's target changed
-while unrelated semantic facets survived. `not-applicable` is typed per
-construct and mutation-operation ID and is valid only when authority proves
-that operation cannot exercise the membership. Missing, unknown, duplicate, or
-orphaned direct or preservation memberships fail generation.
-
-For build, every advertised `(family ID, construct ID, build-operation ID)`
-membership participates in at least one real-route sequence whose result oracle
-proves the requested construct and whose preservation oracles prove later
-operations retain unrelated constructs already built. Additional transports use
-route conformance; canonical memberships are not repeated per route. Missing,
-unknown, or orphaned required memberships fail generation, while multiple
-witnesses may satisfy one membership.
-
-Schema validation rejects a native applicable cell without an oracle, a
-source-preserved cell without both a preservation oracle and at least one
-expected runtime diagnostic, a diagnosed/rejected cell without at least one
-expected diagnostic, invalid diagnostic cardinalities, and a not-applicable
-cell without a typed reason and authority evidence. Silent loss is not a
-compatibility disposition. When agent parse applies, native aggregation
-additionally requires a structured agent oracle; opaque preservation caps the
-aggregate at `source-preserved` even when downstream rendering succeeds.
-Schema validation also rejects a pass-through route result without a complete
-core-handoff/refinement witness, or a projected result without a versioned
-projection oracle.
-
-Define the stage dependency graph explicitly. A locally blocked downstream
-stage remains applicable, identifies the blocking invocation/stage and required
-oracle, stays in the claim denominator, and inherits the blocking disposition
-as an aggregate cap. Agent parsing does not block an independently executable
-native-render invocation. Diagnostics and oracles are bound to their exact
-invocation, route, construct, and stage; they cannot select hidden sources,
-routes, configuration variants, backends, mutations, or builds.
-
-Config and theme semantic effects use the same family cells. Ownership is exact
-per `(authority ID, family ID, input dialect)`, so a shared global theme path
-has one disposition for every applicable in-scope family rather than one
-arbitrary family owner. Route conformance separately proves pass-through for
-each accepting public route; a route-specific transformation requires its own
-A/B case. Every wired effect joins to an explicit named A/B comparison. Pinned
-Mermaid rejecting the source is the ordinary basis for local `reject`; if pinned
-Mermaid accepts a complete fence, local rejection requires an executable named
-diagnosed compatibility divergence.
-
-### 5.3 Receipt runner
-
-The runner executes every named declarative invocation through its real public
-route adapter and the applicable dependency graph:
-
-```text
-detection
-  |-> agent parse/body -> verification -> agent semantic projection
-  `-> native parser -> layout -> native semantic projection
-                                     |-> Scene and output implication
-                                     |-> canonical serialize/reparse
-                                     `-> public mutation/build invocation
-  named A/B and metamorphic comparisons join declared invocation-stage results
+# Delivery plan for issue #248
+
+Status: proposed.
+
+This document turns [issue #248](https://github.com/adewale/agentic-mermaid/issues/248)
+into an implementation sequence. The issue remains the source of truth for the
+audit findings, reproductions, and upstream evidence. This plan deliberately
+does not repeat that material.
+
+## The problem
+
+Agentic Mermaid has strong tests for family enrollment, deterministic output,
+source preservation, and basic rendering. Those tests do not prove that every
+Mermaid construct keeps its authored meaning.
+
+Issue #248 found examples that parse or render successfully while losing
+topology, identity, style, configuration, interaction, or paint. A family can
+therefore look fully supported even when a specific construct is silently
+changed or dropped.
+
+We need one missing layer: small executable cases that prove the semantics of
+individual constructs and feed the public capability report.
+
+## Decisions
+
+1. Treat #248 as a tracking epic, not one large implementation PR.
+2. Add a small construct-level case registry and runner before fixing every
+   family independently.
+3. Test construct semantics once through the canonical family implementation.
+   Test public routes separately for transport and diagnostic consistency.
+4. Generate capability claims from passing cases. Do not maintain another
+   handwritten support ledger.
+5. Start from `main`. Most work does not depend on PR #192; only Sankey-specific
+   work and final Sankey closure do.
+6. Use the repository's normal CI and review process. This programme does not
+   require custom audit manifests, locked evidence branches, mandatory agent
+   counts, or a separate maintainer-witness ceremony.
+
+## What the evidence must prove
+
+For every scoped construct, a case must answer three questions:
+
+1. What can a Mermaid author write?
+2. What meaning should survive?
+3. What does each applicable Agentic Mermaid surface actually do?
+
+A public claim uses one of four outcomes:
+
+- `native`: the applicable structured semantic assertion passes;
+- `source-preserved`: source survives, but native semantics are not claimed;
+- `diagnosed`: the public route returns the expected unsupported or divergent
+  diagnostic;
+- `absent`: there is no supported or accurately diagnosed behavior.
+
+Unknown and untested cases are `absent`. Opaque source preservation is useful,
+but it cannot contribute to a `native` claim.
+
+Every nonblank statement must be modeled, preserved with an accurate public
+diagnostic, or rejected. A plausible partial diagram after silently dropping a
+statement is always a bug.
+
+## Minimal case model
+
+Keep the test-only case definition small. Add fields only when a real finding
+needs them.
+
+```ts
+type FidelityDisposition = 'native' | 'source-preserved' | 'diagnosed' | 'absent'
+type FidelitySurface = 'agent' | 'render' | 'serialize' | 'mutate'
+
+interface FidelityCase {
+  id: string
+  family: string
+  feature: string
+  source: string
+  upstreamReference: string
+  expected: Partial<Record<FidelitySurface, FidelityDisposition>>
+  expectedDiagnostics?: string[]
+  assertSemantics?: (result: unknown) => void
+}
 ```
 
-It records disposition and semantic results, not just thrown/not-thrown status.
-Every opaque agent outcome caps the applicable construct/public claim at
-`source-preserved` and requires its exact route-specific typed diagnostic,
-regardless of native-render success. Opaque agent success paired with render
-failure additionally requires an exact diagnosed policy rather than
-`verify.ok === true` under an unqualified claim.
-
-A2 adds one deterministic package script, `fidelity:check`. It executes every
-registered semantic and route-conformance case against the pinned upstream
-revision, validates the complete generated coverage-obligation grids, derives
-public `absent` for every uncovered obligation, builds raw receipts in a
-temporary directory, derives the compact capability index in the same process,
-and compares generated committed outputs. Committed or manually edited raw
-result files are never trusted as inputs. CI may retain the raw receipts as
-immutable debugging artifacts, but a freshness-only check cannot substitute
-for execution.
-
-### 5.4 Family semantic projectors
-
-Create renderer-independent projectors for all built-in families. At minimum:
-
-- Flowchart: nodes, shapes, edge endpoints, edge identities, classes, styles;
-- State: states, transitions, nesting, classes, comments;
-- Sequence: participants, messages, arrow kinds, blocks, activation intervals;
-- Class: class IDs, annotations, members, relationships, tooltips;
-- ER: entities, attributes, cardinalities, relationship identities;
-- Journey and Timeline: ordered sections/periods, events, actors, scores, text;
-- Architecture and Mindmap: hierarchy, services/nodes, edges, icon resolution;
-- XY, Pie, Quadrant, and Radar: series/points, domains, labels, values, identity,
-  configured appearance;
-- Gantt: tasks, sections, resolved dates, dependencies, statuses;
-- GitGraph: commits, parents, branches, heads, tags, cherry-pick ancestry; and
-- Sankey: nodes, links, layers, widths, endpoint paint, and overlap compositing.
-
-Compare local projections with the pinned Mermaid parser/DB where executable,
-then verify that the required identities and implications survive Scene/output
-lowering.
-
-Upstream parser/DB adapters are offline test and evidence tooling only. They
-must never enter production, browser, CLI, or hosted runtime bundles. Each
-adapter binds to the declared revision, resets or isolates mutable upstream DB
-state per case, and emits a deterministic typed/versioned snapshot consumed by
-the receipt.
-
-### 5.5 Runtime projection boundary
-
-Use a two-tier dataflow:
-
-1. case definitions, authored witnesses, upstream adapters, semantic
-   expectations, ephemeral raw receipts, and divergence authorities live in
-   test/eval-only modules that production code cannot import;
-2. `fidelity:check` validates and executes those authorities, then emits a
-   compact, versioned aggregate capability index consumed by runtime family
-   descriptors, CLI discovery, and public report generators;
-3. freshness hashes bind the aggregate to case definitions, the executed result
-   summary, the scope authority's schema version, blob ID, and content digest,
-   the public-route/transform registries and transitive adapter dependency
-   versions, projector/oracle/schema versions, divergence ledgers, and upstream
-   revision;
-   and
-4. build metafile, tarball, and bundle negative tests prove that Mermaid oracle
-   code, case source, raw receipts, and semantic snapshots do not enter Node,
-   browser, CLI, MCP, hosted, or package runtime artifacts.
-
-Runtime surfaces consume the derived index, never the dev-only runner. Public
-reports and runtime discovery therefore share one generated result without
-shipping the evidence corpus.
-
-### 5.6 Capability and citizenship projection
-
-Replace blanket built-in capability evidence with aggregation over freshly
-executed passing receipts. Section A, the syntax capability ledger, citizenship,
-CLI discovery, and generated docs must consume the same result.
-`fidelity:check` must fail when behavior, a case, a divergence, an authority, or
-an upstream revision changes without a matching execution-derived public claim.
-
-## 6. Delivery stacks and work packages
-
-Stacks are encouraged where they keep each review focused. Keep stacks shallow
-(normally no more than four open PRs), identify the parent PR in every
-description, and ensure every PR is green against its actual target branch.
-
-### A0 — programme governance prerequisite
-
-Land this immediately after the plan and before every implementation or
-adoption PR. Only this plan and A0 may use the manual bootstrap in §4.5:
-
-- make canonical trusted CI run for every programme pull-request target branch
-  and attest the repository/PR identity, semantic-description digest, exact
-  target tip, merge base, head, tested merge result, workflow revision, and
-  governance-policy revision;
-- protect every temporary programme base with a ruleset or sole merge bot,
-  disallow bypass and force-push, and enforce the declared squash strategy;
-- evaluate readiness workflows and the path/dependency-to-authority policy from
-  a protected target revision or external service, never solely from candidate
-  bytes. A governance-changing PR is checked against the union of base and
-  candidate policies, receives fixed meta-checks, and activates its new policy
-  only after merge;
-- add trusted multi-agent runner artifacts, pre-registered round manifests,
-  distinct actor/session/run identities, content hashes, and reconciliation of
-  failed/timed-out/abandoned runs;
-- isolate hostile candidate content from audit authority: dependency acquisition
-  uses a vetted cache stage; candidate tests and auditors run without secrets or
-  write tokens, without network after acquisition, and with the candidate
-  mounted read-only for auditors. A separate narrowly privileged publisher that
-  never executes candidate bytes emits audit artifacts/checks. Privileged
-  `pull_request_target` checkout or execution of candidate bytes is forbidden;
-- extend the PR template and readiness tooling to require one immutable round
-  bundle containing the three individual reports, finding ledger, newest check
-  identities, and current tuple/tree/canonical-delta/semantic-description
-  digests;
-- fail readiness when reports are missing, roles are reused, findings remain
-  unresolved, runs are unreconciled, or approvals/checks are stale or
-  superseded;
-- own a versioned path/dependency-to-authority map, derive the complete affected
-  authority set from the full diff, fail closed on unknown or ambiguous paths,
-  and require the newest trusted/provider-issued result for every derived check
-  identity; an exception is valid only as an immutable auditor-approved ledger
-  entry;
-- from the first behavioral repair, run a trusted exact-head red/green job in a
-  detached worktree that applies the content-addressed revert/sabotage, verifies
-  the expected red signature, restores the audited tree, and verifies green;
-- add the `check:programme-docs` package script; and
-- run the final readiness/tuple comparison from §4.3 after the final audit.
-
-The existing CI workflow runs pull requests targeting `main`; without A0, a
-child PR targeting its immediate parent can appear reviewable without canonical
-CI or an enforceable merge gate against its actual base. Locally recorded or
-implementer-authored manual results are not substitutes after bootstrap.
-
-### Stack A — authority and truthful evidence
-
-1. **A1: upstream revision closure**
-   - choose the canonical Mermaid 11.16 revision;
-   - make all executable artifacts name it or an explicit reviewed
-     compatibility revision;
-   - land the repository-versioned exact 16-family scope authority, explicit
-     out-of-scope envelope, construct-complete roster, and many-to-many
-     authority joins from §5.1; and
-   - fail generation on unacknowledged splits or roster gaps.
-2. **A2: fidelity contract and runner skeleton**
-   - add stable `caseId`, discriminated authority references, construct IDs,
-     generated coverage obligations, exact-set indexes for scoped features/
-     examples/config keys/theme variables/public routes/route transforms/
-     mutation-build memberships, route-bound source/mutation/build invocations,
-     A/B comparisons, and a small cross-family exemplar set;
-   - add `fidelity:check` to execute all registered cases, reject missing,
-     unknown, or orphaned obligations, permit explicit migration-only
-     `uncovered` obligations, project them as public `absent`, and derive the
-     compact index in one process;
-   - keep cases, ephemeral raw receipts, snapshots, and upstream adapters behind
-     an enforced test/eval-only import boundary;
-   - add the deterministic compact-index generator contract and initial bundle
-     exclusion tests;
-   - do not change public capability claims yet.
-3. **A3: semantic projectors for enrolled families plus deferred Sankey**
-   - A3.0 establishes the runner-owned oracle registry and normalized snapshot/
-     versioning rules and one vertical slice that validates A4 aggregation;
-   - independent A3.x shards add projectors for all 15 families currently on
-     `main`, with exact-set tracking;
-   - A4 depends on A3.0, not completion of every family shard. Unprojected
-     obligations remain present and project as public `absent`; and
-   - the Sankey projector shard alone depends on C3 enrollment and is required
-     for C4 and final 16-family closure.
-4. **A4: receipt-driven reports and citizenship**
-   - depend on A1, A2, and A3.0, then migrate reports before every family
-     projector is complete;
-   - feed divergences and freshly executed receipts into capability aggregation;
-   - generate the compact versioned runtime/report index and bind its freshness
-     hash to scope, cases, executed result summary, routes, projectors/oracles/
-     schemas, divergences, and upstream revision;
-   - make `evidence:check` invoke `fidelity:check`; a hash-only or
-     generated-file-only check is insufficient;
-   - prove raw evidence and Mermaid oracle code are absent from every shipped
-     bundle and tarball;
-   - deliberately downgrade every uncovered, unprojected, or not-yet-receipted
-     claim to `absent` during migration;
-   - classify known defects from actual behavior: `diagnosed` only when the
-     public path emits the exact asserted diagnostic, otherwise
-     `source-preserved` or `absent` as applicable; and
-   - commit and review the expected transitional report state before repairs
-     promote individual constructs.
-
-Primary dependency graph:
-
-```text
-A0 ─────────────────────────────────────> every implementation/adoption PR
-A1 -> A2 -> A3.0 -> A4
-       |       |-> A3.<family> -> corresponding repair / D / E shard
-       |       `-> A3.sankey (after C3) -> C4
-       |-> Stack B parser/seam work where the receipt API is required
-       `-> generic C1/C2 may start independently from main
-
-C1 + C2 -> C3 -> A3.sankey
-A4 + A3.sankey -> C4 -> final 16-family closure
-```
-
-Each non-Sankey family repair and D/E shard depends only on A4, its own completed
-family projector, and its relevant guardrail. No non-Sankey work depends on C3
-or the Sankey projector. B and generic C infrastructure may begin earlier where
-they do not consume those authorities.
-
-### Stack B — parser and seam guardrails
-
-1. **B1: statement-consumption contract** — consume, preserve with an exact
-   route-specific typed diagnostic, or reject every nonblank statement.
-2. **B2: shared comment/delimiter normalization and agent/native seam** — run
-   each fidelity source through both paths and require compatible dispositions.
-3. **B3: keyword-boundary and dual-vocabulary checks** — detect prefix regexes
-   and unexplained parser vocabulary drift.
-4. **B4: shared identity grammar contracts** — reuse declaration/reference/
-   mutation ID parsing within each family.
-
-These PRs may stack on A2/A3 where they need the receipt API, but should not wait
-for A4's report migration.
-
-### Stack C — typed Scene resources and Sankey
-
-1. **C1: typed local paint resources**
-   - introduce a typed resource union with globally unique definition IDs and
-     references across marker and paint resources;
-   - decide and test the core Scene contract-version migration;
-   - explicitly version exposure through External Scene or deliberately reject
-     the new resource in the existing external contract;
-   - bound snapshot/admission/validation, stop counts, and resource bytes;
-   - require every built-in graphical backend to prove the new resource through
-     conformance fixtures; and
-   - test reference ownership, namespacing, deterministic serialization, local-
-     only references, and external-reference rejection.
-2. **C2: typed compositing**
-   - model compositing as an explicit Scene feature/field independent of paint
-     resources, with a bounded blend-mode set and deterministic inheritance/
-     defaulting rules;
-   - decide and test the core Scene contract-version migration separately from
-     C1, including old snapshot and consumer compatibility;
-   - explicitly version compositing through External Scene or deliberately
-     reject it at that boundary with an exact diagnostic;
-   - add backend-specific Scene-to-output conformance fixtures for every
-     supported mode rather than inferring compositing from gradient support;
-   - update backend capability claims and conformance so unsupported backends
-     cannot retain a false native compositing claim; and
-   - add explicit terminal loss/projection diagnostics for gradients and
-     compositing.
-3. **C3: Sankey enrollment** — rebased/narrowed #192 or its replacement,
-   with C1 and C2 as hard merge dependencies. The only exception is a C3 that
-   rejects or emits exact runtime diagnostics for gradient/compositing and keeps
-   every affected capability/report row downgraded.
-4. **C4: Sankey receipts and closure** — source-to-target gradient stops,
-   multiply overlap, contrast behavior, header consistency, quoted-field
-   whitespace identity, and final report state. The identity receipt must prove
-   that leading/trailing whitespace inside quoted fields follows the pinned
-   Mermaid normalization (currently trim-before-node-identity), or record an
-   exact diagnosed divergence; preserving the whitespace while claiming native
-   identity is a failure.
-
-If #192 is used as C3, it cannot merge or contribute to any programme claim
-until that PR itself passes the complete audit loop on its final tuple. If it
-has already merged before A0 can enforce that gate, treat the imported Sankey
-diff as quarantined: a dedicated adoption PR must identify and audit the entire
-effective imported diff, add the required receipts, and pass the loop before
-any later C-stack work or public claim may rely on it. Retrospective inspection
-inside an otherwise unrelated C-stack PR is not sufficient.
-
-### Family repair PRs — Phase 0
-
-Create focused child issues and PRs for:
-
-- Sequence half-arrows, semicolon statements, `critical option`, and rect fill;
-- State trailing comments and spaced class targets;
-- Class annotations, bare dashed relationships, and escaped/backtick IDs;
-- ER word-form aliases;
-- Timeline `%` comments and unsupported header directions;
-- XY Chart unknown-statement rejection; and
-- Sankey gradients/compositing, quoted-field whitespace identity, and header
-  claim consistency through Stack C.
-
-Each family PR adds the receipt first, proves it discriminates, fixes both agent
-and native paths as applicable, and regenerates the affected claim rows.
-
-### Family implication PRs — Phase 1
-
-Follow with focused work for:
-
-- Flowchart edge-class paint and animation implications;
-- Class safe tooltips;
-- ER multiple-class syntax and stale subgraph diagnostics;
-- Gantt config effects, inline task comments, and explicit duration divergence;
-- Journey fractional scores;
-- Timeline semantic line breaks and mutation-safe clock/URL colons;
-- GitGraph float precision, duplicate-ID fence classification, and explicit
-  synthetic-ID divergence;
-- XY data-label placement, axis rotation, and theme data-label color;
-- Pie duplicate-label identity semantics;
-- Architecture unresolved registered icons and the bare-header extension;
-- Mindmap unresolved host icon-font classes; and
-- executable uncertainty receipts for Quadrant and Radar duplicate/lexer edge
-  cases.
-
-### Stack D — exhaustive official examples
-
-1. generate one case record for every official fence projected through the
-   16-family scope authority;
-2. review the complete generated scoped set (331 in the audit baseline) as
-   structured, opaque, reject, partial, or config-only; do not use a hard-coded
-   count as the authority;
-3. enumerate every construct exercised by each fence and join it to the
-   construct authority rather than treating the fence as one feature;
-4. attach one or more semantic receipts or a named diagnosed compatibility
-   divergence;
-5. permit `reject` only when pinned Mermaid also rejects the source or the fence
-   is proven partial/config-only; otherwise require an executable named
-   diagnosed divergence;
-6. require exact-set closure for scoped family, construct, feature, example,
-   source, semantic-cell, route-conformance, and case indexes, plus explicit dispositions for
-   out-of-scope manifest rows, so new, removed, orphaned, or ambiguous entries
-   cannot disappear; and
-7. keep selected galleries as visual reviewer evidence, not native proof.
-
-Classification may discover new defects. File each as a child of #248 and add
-it to the appropriate severity phase; do not weaken the case expectation to
-match current behavior.
-
-### Stack E — generated config and theme-effect matrix
-
-For every applicable `(authority path, family ID, input dialect)` semantic cell,
-generate exactly one disposition:
-
-- `wired`, with an A/B predicate over typed semantics, geometry, paint, or
-  interaction;
-- `diagnosed-noop`, with unchanged semantics and an exact warning; or
-- `unsupported`, with a named reason and exact warning or rejection on every
-  public route that accepts the configuration.
-
-Join the upstream config and `semanticInventory.themeVariables` inventories,
-descriptor declarations, runtime resolver/theme reads, docs, and tests. Expand
-object-valued or `any` authorities to reviewed leaf paths from the pinned type/
-default authority, or explicitly enumerate their nested effect cases; a shallow
-`xyChart: any` row cannot hide `dataLabelColor`. Expand shared global paths such
-as `primaryColor` across every applicable in-scope family instead of assigning
-one arbitrary owner. Route-conformance cases prove unchanged admission and
-pass-through for every accepting route; a route-specific transformation adds a
-direct A/B case. Every wired disposition references a named A/B invocation pair.
-Fail on missing cells or duplicate ownership of the same tuple. Do not create
-another hand-maintained config or theme roster.
-
-### Stack F — depth and adversarial quality
-
-After truthful baseline coverage exists:
-
-- add comment/delimiter/whitespace metamorphic laws;
-- add duplicate and permutation tests for identity-bearing families;
-- add statement-deletion sentinels;
-- add config A/B semantic probes;
-- sample gradients at source/midpoint/target and overlap;
-- add bounded parser/diagnostic sabotage profiles; and
-- add controlled upstream visual/geometry comparisons with explicit tolerances
-  and divergence IDs.
-
-## 7. Stacked PR operating procedure
-
-Every stacked PR description must include:
-
-| Position | PR | Base | Purpose | Merge dependency |
-| --- | --- | --- | --- | --- |
-
-Rules:
-
-1. target the immediate parent branch, not `main`, while the parent is open;
-2. keep each diff meaningful when viewed against that parent;
-3. do not hide generated artifacts or unrelated refactors in the top stack PR;
-4. after a parent merges, rebase or recreate each descendant on the merged
-   parent when the parent was squash-merged; retargeting alone is permitted only
-   when ancestry was preserved and exact merge-base/diff proof shows that the
-   child candidate is unchanged;
-5. rerun checks and the full multi-agent audit loop after every rebase;
-6. merge from the bottom of the stack upward; and
-7. split a stack if reviewers must understand more than one semantic decision
-   to approve a PR.
-
-Family repair PRs may proceed in parallel once their required receipt/projector
-base is stable. They should not stack on each other merely to avoid updating
-`main`.
-
-## 8. Required PR description and evidence
-
-Before audit registration, every implementation PR must freeze these semantic
-description sections and include their digest in the candidate tuple:
-
-- child issue and parent epic;
-- exact claim being changed;
-- upstream witness and revision;
-- current incorrect disposition;
-- intended semantic result or named divergence;
-- focused receipt/test and a reproducible red/green record containing the
-  defective base SHA or deterministic sabotage/probe ID, patch/hash, exact
-  command, expected failure signature, observed red failure, and green result
-  on the audited head, all linked to the required trusted exact-head job rather
-  than supplied only as implementer-authored prose;
-- required baseline and touched-authority check names and commands. Provider
-  run IDs, attempts, URLs, timestamps, and results belong in the pre-dispatch
-  manifest and machine-owned audit comment, not the frozen semantic body;
-- generated artifacts changed and why;
-- stack position and dependencies;
-- residual limitations.
-
-After dispatch, the round-bundle pointer, finding ledger, round status, and
-final tuple live in machine-owned audit comments and immutable artifacts. They
-are not appended to or edited into the frozen semantic body.
-
-Visual-output PRs use the same named input/config at immutable base and head
-revisions. When both revisions render, include proportional before/after
-evidence. When the base does not support the surface or fails before producing
-an artifact, preserve that exact error or unsupported receipt as the honest
-baseline and provide the head image; never fabricate a before render. The
-semantic receipt is the oracle, the image helps inspect the consequence, and
-the description states the evidence's material limitation.
-
-## 9. Validation ladder
-
-Run the smallest relevant checks while iterating, then freeze a committed head
-and run the mandatory audit baseline. Every implementation PR runs:
-
-```bash
-bun run typecheck
-bun run lint
-bun run test
-```
-
-After A2 lands, every implementation PR also runs the `fidelity:check` gate;
-focused receipts accelerate iteration but never replace the complete corpus.
-
-A documentation-only PR runs `git diff --check`, repository-path/link
-validation for every changed document, and the documentation audit roles from
-§4. It need not rerun unchanged runtime behavior unless the document is itself
-an executable/generated authority.
-
-Add deterministic checks by touched authority:
-
-| Touched authority | Required additions to the baseline |
-| --- | --- |
-| Family parser/renderer/projector | Focused fidelity receipt, parser/renderer family tests, red/green record |
-| Upstream manifest or authority | `upstream-manifest:check`, upstream bench/corpus checks, revision closure |
-| Fidelity scope/routes/cases, Section A/B, citizenship, receipts | `fidelity:check`, `section-a-report:check`, `section-b-report:check`, `quality:check`, `evidence:check` |
-| Scene, backend, security, output | Backend conformance, External Scene compatibility, renderer security, affected output/browser checks, `build` |
-| Browser family/catalog | `check:browser-families`, browser-lazy checks, affected browser contracts |
-| Website/package/transport | Website freshness/payload checks, package build, affected CLI/MCP/transport contracts |
-| Official fence, config, or theme matrix | Exact-set corpus/config/theme generator check and every affected named semantic A/B case |
-| Governance policy, workflow, readiness, or touched-authority map | Fixed external/protected meta-gate and union of base/candidate required checks |
-
-The audited tuple must have canonical CI or the A0 equivalent against its exact
-target base; a green run against `main` cannot substitute for a stacked PR whose
-target is a parent branch. A0 defines the required check identities; readiness
-accepts only the newest non-superseded provider-issued run for each identity,
-including every identity derived from the versioned touched-authority map,
-bound to the tested merge tree, semantic-description digest, and protected
-workflow/governance-policy revisions. Candidate changes to those policies
-cannot weaken their own gate. Unknown or ambiguous paths fail closed; any
-exception must be an immutable auditor-approved ledger entry. From the first
-behavioral repair onward, the trusted red/green job is a required check and must
-run the content-addressed revert or sabotage in a detached worktree against the
-exact audited head. A manual command transcript cannot satisfy either gate.
-
-The final programme closure run includes at least:
-
-```bash
-bun run typecheck
-bun run test
-bun run lint
-bun run quality:check
-bun run evidence:check
-bun run upstream-manifest:check
-bun run section-a-report:check
-bun run section-b-report:check
-bun run check:browser-families
-bun run build
-```
-
-Once A2 lands, the final closure run also includes its `fidelity:check` gate.
-
-Family and browser/output changes add their focused corpus, gallery, browser,
-package, and transport checks. Upstream refresh commands must execute against
-the exact declared checkout revision and leave committed artifacts reproducible.
-
-## 10. Programme tracking
-
-Create child issues before implementation starts. Each child must name its
-work package, acceptance receipt, expected stack/base, and whether it blocks a
-public claim. Link child PRs back to #248; do not use PR prose as the only
-backlog.
-
-Maintain a checklist on #248 grouped by:
-
-- authority/evidence infrastructure;
-- parser and seam guardrails;
-- Phase 0 silent-corruption fixes;
-- Phase 1 implication/config/interaction fixes;
-- official-fence classification;
-- config/theme-effect closure;
-- per-family projector and receipt closure; and
-- depth/hardening and final audit.
-
-The audit artifact remains historical evidence. Current executable receipts
-and generated reports become the live authority.
-
-## 11. Closure criteria
-
-Close #248 only when all of the following hold:
-
-- the generated family scope equals the current repository-versioned
-  `FidelityScopeAuthority`, and every unscoped manifest family/row has an
-  explicit out-of-scope disposition;
-- every officially authorable scoped construct has freshly executed coverage;
-- the scoped construct, feature, example, config-key, theme-variable, source,
-  public-route, route-transform, semantic-cell, route-conformance,
-  mutation/build-membership, coverage-obligation, and case indexes have exact-
-  set closure with no orphan or ambiguous ownership;
-- every construct × named source × applicable core stage has a semantic
-  invocation and oracle/diagnostic, and every public route × accepted input ×
-  operation/selector/output contract has conformance evidence or an evidenced
-  `not-applicable` disposition; every factored route has a passing core-handoff/
-  refinement witness, every unproved transformation is route-specific, and
-  route-specific transforms have direct affected-construct cases; uncovered,
-  missing, unknown, duplicate, and orphaned cells are zero;
-- every scoped official fence has a reviewed disposition;
-- every nonblank statement is modeled, preserved with an exact route-specific
-  typed runtime diagnostic, or rejected; no silent semantic preservation can
-  satisfy closure;
-- every applicable agent-native claim has a passing structured agent oracle;
-  an opaque agent outcome remains capped at `source-preserved` even if native
-  rendering succeeds;
-- agent parse, verification, native render, serialization, mutation, Scene,
-  applicable output, accessibility, and interaction behavior agree with the
-  case policy;
-- the mutation/build membership indexes have exact-set closure; every required
-  `(case ID, construct ID, source ID, applicable mutation-operation ID)`
-  membership executes that advertised operation through the canonical real
-  route with a discriminating direct-result oracle, plus a separately discharged
-  unrelated-operation preservation obligation; every advertised buildable
-  construct/operation membership has a real-route discriminating result and
-  unrelated-facet preservation oracle; genuinely unavailable operations carry
-  governed per-operation `not-applicable` evidence; and applicable public
-  adapters separately pass route conformance;
-- every applicable `(config/theme authority, family, input dialect)` semantic
-  cell has exactly one executable effect disposition, with every wired effect
-  joined to a named A/B comparison, and each accepting route passes its
-  conformance or route-specific A/B case;
-- capability and citizenship reports derive in the same `fidelity:check` run
-  from passing receipts and downgrade divergences automatically;
-- every enrolled family has a complete, versioned semantic projector and every
-  shipped runtime/report claim comes from the compact aggregate index; cases,
-  Mermaid oracles, ephemeral raw receipts, and snapshots are absent from runtime,
-  browser, CLI, MCP, hosted, and package artifacts;
-- all upstream oracle revisions are closed and reproducible;
-- every Phase 0 defect is fixed or truthfully downgraded with a discriminating
-  regression receipt;
-- Sankey receipts observe endpoint stops and overlap compositing, not merely a
-  changed stroke byte, and prove pinned trim-before-identity behavior for
-  leading/trailing whitespace in quoted fields or an exact diagnosed
-  divergence;
-- generated authorities have no unexplained drift;
-- the full validation ladder passes; and
-- a final cross-programme multi-agent audit of the closure head returns
-  unanimous `APPROVED` with no actionable findings.
-
-## 12. Governance risks and ownership
-
-A0 has one named maintainer owner and is itself a merge prerequisite, not an
-optional reporting enhancement. Repository rules or the sole merge bot must
-prevent a privileged bypass from merging a programme PR without exact-base CI,
-complete audit artifacts, and final readiness. Any emergency bypass is a
-programme stop: quarantine the resulting diff and use the adoption procedure
-defined for #192 before relying on it.
-
-Multi-agent review reduces blind spots but does not prove independence when all
-auditors use correlated models, prompts, or training data. The trusted runner
-must preserve prompt/scope hashes and actor/session/run identities, rotate or
-diversify audit implementations where available, and record correlated-model
-risk in the final residual-risk report. Human maintainer verification remains
-mandatory for the manual bootstrap and final programme closure.
-
-## 13. Strengths to preserve
-
-Do not weaken the repository's existing deterministic layout/output contracts,
-typed registry enrollment, role/primitive Scene admission, opaque source
-preservation, canonical serialization, source maps, mutation surfaces, strict
-output security, or property-based geometry tests. The fidelity layer joins
-these strengths to construct-level semantic evidence; it does not replace them.
+Each case should contain the smallest source that demonstrates one meaningful
+claim. Semantic assertions should inspect normalized family data—participants,
+edges, dates, cardinalities, labels, paint stops, or similar domain meaning—not
+just non-empty output or changed SVG bytes.
+
+Where pinned Mermaid exposes a stable parser or database, compare normalized
+local and upstream meaning. Where it does not, use the official syntax reference
+plus a focused local semantic assertion. Do not build a second Mermaid
+implementation merely to test the first.
+
+Cases, upstream adapters, and raw results stay in tests. Production code only
+needs a compact generated capability summary.
+
+## Avoiding a construct-by-route test explosion
+
+Use two layers:
+
+### Construct cases
+
+Run each construct through the canonical family parser, model, serializer, and
+renderer stages that matter to its claim. These cases prove the semantics.
+
+### Route conformance
+
+Use a small shared suite to prove that CLI, SDK, MCP, editor, website, and output
+adapters pass source and options to the same core behavior and preserve its
+result or diagnostics.
+
+A route needs a direct construct case only when it transforms the input or
+result in a way that can change meaning. Simple pass-through routes should not
+duplicate every family case.
+
+Mutation tests follow the same rule: directly test each advertised operation
+that changes a construct, and separately assert that unrelated meaning survives.
+
+## Runner and capability reporting
+
+The first implementation PR should add one command that:
+
+1. discovers the checked-in case registry;
+2. rejects duplicate or unknown case and feature IDs;
+3. runs the applicable semantic assertions and diagnostics;
+4. emits a machine-readable result;
+5. derives the compact capability summary consumed by existing reports; and
+6. fails if a claimed native feature has no passing case.
+
+The generated result must be freshness-bound to its cases and projector code so
+stale output cannot be published accidentally. Existing capability and
+citizenship reports should consume this result instead of inferring semantics
+from file presence, family enrollment, or one smoke fixture.
+
+## Delivery sequence
+
+### 1. Foundation
+
+Land the case type, registry, runner, result format, and capability projection.
+Prove the design with a few existing high-signal failures rather than trying to
+cover every family in the first PR.
+
+Good initial cases include one silent statement loss, one parser/render seam,
+one appearance implication, and one accurately diagnosed unsupported behavior.
+
+### 2. Silent corruption and identity
+
+Fix the highest-risk findings first, in small family-focused PRs:
+
+- Sequence token and statement splitting;
+- State trailing comments and class targets;
+- Class relationships, annotations, and escaped identities;
+- ER word aliases;
+- Timeline comments and direction handling; and
+- XY Chart unknown-statement handling.
+
+Each fix adds a discriminating case that fails when the fix is reverted.
+
+### 3. Remaining semantic implications
+
+Address the confirmed style, configuration, mutation, and identity findings in
+Flowchart, Gantt, Journey, Pie, icons, and the remaining family seams. Split
+shared parser or identity work from family-specific rendering work when that
+keeps review smaller.
+
+### 4. Scene resources and Sankey
+
+Land generic typed local gradients and compositing from `main`. These resources
+must remain deterministic and must not introduce external references.
+
+Then rebase and narrow PR #192, or replace it with a smaller Sankey enrollment
+PR. Add Sankey semantic cases only after the family implementation is available.
+Sankey closure must prove endpoint gradient stops, overlap compositing, header
+handling, and node identity—not merely a changed stroke color.
+
+### 5. Completeness
+
+After the confirmed defects are covered:
+
+- classify every harvested official example as native, source-preserved,
+  diagnosed, or intentionally out of scope;
+- classify every pinned configuration key as effective, diagnosed no-op, or
+  unsupported;
+- close any remaining parser/agent/render disagreements; and
+- make the generated capability report the only source of public native claims.
+
+## PR boundaries and evidence
+
+Keep implementation PRs narrow: one family, one shared parser seam, or one
+clearly related infrastructure change.
+
+Every implementation PR should include:
+
+- the #248 finding or child issue it addresses;
+- the focused case that proves the behavior;
+- confirmation that the case fails when the fix is removed, where practical;
+- the relevant family and route tests;
+- regenerated capability output when the public claim changes; and
+- visual evidence only when pixels are part of the claim.
+
+Run the normal repository CI. Additional independent review is welcome for
+cross-family or security-sensitive changes, but it is not a bespoke release
+protocol.
+
+## Dependency on PR #192
+
+Do not base the general evidence work or non-Sankey fixes on PR #192.
+
+The following can proceed directly from `main`:
+
+- the case registry and runner;
+- capability projection;
+- parser and agent/render seam fixes;
+- non-Sankey family fixes;
+- official-example and configuration classification; and
+- generic local Scene resources.
+
+Only Sankey enrollment, Sankey receipts, and final all-family closure wait for a
+rebased/narrowed #192 or a replacement Sankey PR.
+
+## Completion criteria
+
+Issue #248 is complete when:
+
+- every confirmed finding has a passing regression case or an explicit public
+  downgrade;
+- every officially authorable construct in the scoped built-ins has a reviewed
+  case or disposition;
+- no parser silently drops a nonblank statement;
+- applicable agent, parser, serializer, mutation, render, and output behavior
+  agree with each case's disposition;
+- every harvested official example has a reviewed disposition;
+- every pinned configuration key is effective, diagnosed no-op, or unsupported;
+- public capability reports are generated from current passing cases; and
+- the upstream revision used by cases is pinned and reproducible.
+
+## Risks
+
+- **Overengineering:** keep the case schema and runner small; add machinery only
+  for a reproduced failure.
+- **Brittle upstream comparisons:** normalize domain meaning and pin the upstream
+  revision instead of comparing unstable SVG bytes.
+- **Parser drift:** prefer shared tokenization where practical and keep seam
+  cases where separate parsers remain.
+- **Large generated diffs:** isolate generated capability changes from unrelated
+  family fixes.
+- **Sankey coupling:** keep generic Scene work and all non-Sankey fixes independent
+  of the enrollment PR.
+
+The aim is straightforward: make public support claims follow executable
+construct semantics, then fix the known gaps in reviewable pieces.

--- a/docs/project/issue-248-fidelity-delivery-plan.md
+++ b/docs/project/issue-248-fidelity-delivery-plan.md
@@ -81,10 +81,9 @@ Every receipt must identify:
 - stable case ID, family, construct IDs, and upstream authority coordinates;
 - exact upstream authority revision;
 - minimal authored source;
-- expected agent disposition: `structured`, `opaque`, or `reject`;
-- expected render disposition: `native`, `diagnosed`, or `reject`;
-- normalized semantic expectation;
-- exact expected diagnostics;
+- a typed expectation for every pipeline stage, including whether it applies;
+- a versioned semantic oracle for every applicable native stage;
+- exact structured diagnostic expectations for every non-native stage;
 - applicable serialization, mutation, layout, Scene, SVG, terminal,
   interaction, configuration, and accessibility implications; and
 - a named divergence ID when local behavior intentionally differs.
@@ -107,8 +106,12 @@ Receipt aggregation uses the following policy:
   source or the output surface; and
 - `absent`: there is neither implementation nor an honest supported envelope.
 
-Unknown, uncovered, opaque-only, and divergent cases cannot contribute to a
-family-wide native claim. `diagnosed` is valid only when the actual public path
+Unknown, uncovered, opaque, and divergent cases cannot contribute to a
+family-wide native claim. Whenever the agent surface applies, `native`
+aggregation requires a structured agent disposition, a passing structured
+semantic projection, and native render semantics. An opaque agent case caps
+the construct and public claim at `source-preserved` even when the native
+renderer succeeds. `diagnosed` is valid only when the actual public path
 emits the exact asserted runtime diagnostic. A divergence-ledger entry alone
 cannot manufacture diagnosed behavior. Silent loss remains `source-preserved`
 or `absent`, as applicable, until a runtime diagnostic or native fix lands.
@@ -141,12 +144,18 @@ must pass the following loop before it is marked ready or merged.
    uncommitted or dirty candidate cannot begin a formal audit round.
 3. Run the mandatory baseline and touched-authority checks from §9.
 4. Record the exact target branch, target-tip SHA, merge-base SHA, head SHA, and
-   intended merge strategy. This tuple identifies the effective candidate.
-5. Freeze implementation work while the auditors inspect that tuple.
+   intended merge strategy, plus the head tree and full diff digest. This tuple
+   and digest identify the effective candidate.
+5. Before dispatch, create a content-addressed round manifest that registers
+   the three role/session/run IDs, prompt/scope hashes, candidate tuple, tree/
+   diff digest, and timestamp.
+6. Freeze implementation work while the auditors inspect that registered
+   candidate.
 
 ### 4.2 Run at least three independent agent audits
 
-Use one distinct, read-only agent/session per role in independent contexts.
+Use one distinct, trusted-runner-issued read-only agent/session per role in
+independent contexts.
 Auditors must not see or coordinate with the other auditors before submitting
 their first report. The implementation agent may orchestrate the audit but must
 not count as an auditor or reuse one session for multiple roles.
@@ -178,6 +187,11 @@ Each auditor must return:
 
 An audit that only summarizes the PR is not an approval.
 
+Every commissioned run must resolve to a recorded first report, failure,
+timeout, or cancellation. Do not replace or omit an unfavorable, failed, or
+abandoned run. A replacement requires a new manifest and a new round containing
+the complete registered role set.
+
 ### 4.3 Fix, retest, and audit again
 
 1. Preserve each auditor's first report verbatim, then consolidate the findings
@@ -193,14 +207,19 @@ Any change to the head SHA, target-tip SHA, merge-base SHA, target branch, or
 intended merge strategy invalidates checks and approval and requires another
 round. This includes target-branch advancement, retargeting, parent-PR merge,
 and rebasing even when the child head tree appears unchanged. Immediately
-before merge, compare the current tuple with the final audit record and fail
-closed on any difference.
+before merge, compare the current tuple, tree/diff digest, required workflow
+revision, and newest non-superseded provider-issued check runs with the final
+audit record and fail closed on any difference. A newer failed or cancelled run
+for the same tuple supersedes an older success.
 
 ### 4.4 Preserve audit evidence in the PR
 
-The PR conversation must preserve each individual first report verbatim or by
-an immutable link and identify the distinct session/role that produced it. It
-must also contain an audit table with:
+The trusted runner must preserve each individual first report as a
+content-addressed immutable artifact. Each artifact records role, actor/session/
+run identity, candidate tuple, tree/diff digest, prompt/scope hash, timestamp,
+verbatim report, and artifact hash. The PR conversation contains immutable
+pointers and hashes; mutable pasted comments are not the sole evidence. It must
+also contain an audit table with:
 
 | Round | Target | Target tip | Merge base | Head | Strategy | Individual reports | Result |
 | --- | --- | --- | --- | --- | --- | --- | --- |
@@ -215,8 +234,35 @@ reports. The final row must identify the audited tuple and show approval from
 every role with no unresolved finding. Reviewers must be able to trace a
 finding to its correction without accessing an ephemeral agent transcript.
 Readiness automation added by A0 must reject a missing report, reused role,
-unresolved finding, or approval bound to a stale tuple; implementer-authored
-summary text alone is not audit evidence.
+unreconciled commissioned run, unresolved finding, invalid artifact hash, or
+approval bound to a stale tuple/digest; implementer-authored summary text alone
+is not audit evidence. The final readiness job runs after the final audit and
+accepts only the newest required provider-issued check for each declared check
+identity.
+
+### 4.5 Manual bootstrap for this plan and A0
+
+This plan PR and the A0 governance PR necessarily precede the trusted audit
+runner. They use one explicit, temporary bootstrap protocol; no later PR may
+claim this exception:
+
+1. commit a clean candidate and record target tip, merge base, head, tree, diff
+   digest, and squash strategy;
+2. run `git diff --check <merge-base>...<head>` and verify the changed-path set;
+3. validate the external issue/PR links with `gh issue view 248` and
+   `gh pr view 192`, and require the target-bound `gh pr checks` result;
+4. pre-register the three sessions in a timestamped PR comment before dispatch;
+5. post every individual first report under a stable comment ID, record its
+   SHA-256 in the finding ledger, and verify that its GitHub `updated_at` value
+   has not changed at final readiness;
+6. reconcile every commissioned session, fix every actionable finding, and
+   repeat against each new tuple until unanimous approval; and
+7. have a human maintainer verify the final tuple, hashes, comments, and checks
+   before merge.
+
+A0 must add a deterministic `bun run check:programme-docs` command for future
+plan/governance link and path validation and replace this bootstrap with trusted
+runner artifacts and automation.
 
 ## 5. Evidence architecture
 
@@ -253,20 +299,37 @@ type FidelityAuthorityRef =
   | { kind: 'example'; id: string }
   | { kind: 'config-key'; id: string }
 
-type SurfaceApplicability =
-  | { state: 'applicable' }
-  | { state: 'not-applicable'; reasonCode: string; upstreamEvidence: string[] }
+type FidelityDiagnosticExpectation = {
+  stage: FidelityStage
+  code: string
+  stableFields: Readonly<Record<string, string | number | boolean>>
+  cardinality: { min: number; max: number }
+  order: 'exact' | 'any'
+}
 
-type FidelityExpectation =
+type FidelityStageExpectation =
   | {
-      renderDisposition: 'native'
-      semanticSnapshot: FamilySemanticSnapshot
-      expectedDiagnostics: readonly string[]
+      state: 'not-applicable'
+      reasonCode: string
+      upstreamEvidence: readonly [string, ...string[]]
     }
   | {
-      renderDisposition: 'diagnosed' | 'reject'
-      semanticSnapshot?: FamilySemanticSnapshot
-      expectedDiagnostics: readonly [string, ...string[]]
+      state: 'applicable'
+      disposition: 'native'
+      oracle: { id: string; schemaVersion: number }
+      diagnostics: readonly FidelityDiagnosticExpectation[]
+    }
+  | {
+      state: 'applicable'
+      disposition: 'source-preserved'
+      oracle: { id: string; schemaVersion: number }
+      diagnostics: readonly FidelityDiagnosticExpectation[]
+    }
+  | {
+      state: 'applicable'
+      disposition: 'diagnosed' | 'reject'
+      oracle?: { id: string; schemaVersion: number }
+      diagnostics: readonly [FidelityDiagnosticExpectation, ...FidelityDiagnosticExpectation[]]
     }
 
 interface FamilyFidelityCase {
@@ -276,19 +339,33 @@ interface FamilyFidelityCase {
   authority: FidelityAuthorityRef
   upstreamRevision: string
   source: string
-  expectedAgentDisposition: 'structured' | 'opaque' | 'reject'
-  expectation: FidelityExpectation
-  surfaces: Record<FidelitySurface, SurfaceApplicability>
+  stages: Record<FidelityStage, FidelityStageExpectation>
   divergenceId?: string
 }
 ```
 
-`FamilySemanticSnapshot` must be a versioned, family-discriminated union rather
-than `unknown`. Schema validation must reject a native case without a semantic
-snapshot, a diagnosed/rejected case without an exact diagnostic, and any
-`not-applicable` surface without a typed reason and upstream evidence. Keep
-expectations deterministic; do not encode arbitrary executable callbacks in
-generated JSON authorities.
+`FidelityStage` covers detection, agent parse, verification, native parse,
+configuration, layout, Scene, SVG, PNG, terminal, serialization, mutation,
+accessibility, and interaction. Oracle IDs resolve through a runner-owned typed
+registry whose outputs are versioned, family-discriminated semantic or
+implication snapshots; generated JSON never embeds arbitrary executable
+callbacks.
+
+Schema validation must reject a native applicable stage without an oracle, a
+source-preserved stage without a preservation oracle, a diagnosed/rejected
+stage without an exact structured diagnostic, and any not-applicable stage
+without a typed reason and upstream evidence. Source preservation may be silent
+and therefore does not imply a public diagnostic. When agent parse applies,
+native aggregation additionally requires a structured agent oracle; opaque
+preservation caps the aggregate at `source-preserved` even when downstream
+native rendering succeeds.
+
+Define short-circuiting explicitly: detection or native parse rejection makes
+dependent downstream stages not applicable with a `blocked-by:<stage>` reason;
+opaque agent preservation still executes independently applicable native-render
+checks but cannot be promoted to an agent-native claim. Stage-specific
+diagnostics must identify the public route that emitted them and cannot be
+satisfied by a warning from another surface.
 
 Pinned Mermaid rejecting the source is the only ordinary basis for local
 `reject`. An official fence may also be rejected when it is proven partial or
@@ -311,9 +388,10 @@ detection
 ```
 
 It records disposition and semantic results, not just thrown/not-thrown status.
-Opaque agent success paired with native render failure must be an explicit
-diagnosed policy rather than `verify.ok === true` under an unqualified native
-claim.
+Every opaque agent outcome caps the applicable construct/public claim at
+`source-preserved`, regardless of native-render success. Opaque agent success
+paired with render failure additionally requires an exact diagnosed policy
+rather than `verify.ok === true` under an unqualified claim.
 
 ### 5.4 Family semantic projectors
 
@@ -342,7 +420,28 @@ adapter binds to the declared revision, resets or isolates mutable upstream DB
 state per case, and emits a deterministic typed/versioned snapshot consumed by
 the receipt.
 
-### 5.5 Capability and citizenship projection
+### 5.5 Runtime projection boundary
+
+Use a two-tier dataflow:
+
+1. case definitions, authored witnesses, upstream adapters, semantic
+   expectations, raw receipts, and divergence authorities live in test/eval-
+   only modules that production code cannot import;
+2. one deterministic generator validates those authorities and emits a compact,
+   versioned aggregate capability index consumed by runtime family descriptors,
+   CLI discovery, and public report generators;
+3. freshness hashes bind the aggregate to case definitions, receipt results,
+   projector/oracle/schema versions, divergence ledgers, and upstream revision;
+   and
+4. build metafile, tarball, and bundle negative tests prove that Mermaid oracle
+   code, case source, raw receipts, and semantic snapshots do not enter Node,
+   browser, CLI, MCP, hosted, or package runtime artifacts.
+
+Runtime surfaces consume the derived index, never the dev-only runner. Public
+reports and runtime discovery therefore share one generated result without
+shipping the evidence corpus.
+
+### 5.6 Capability and citizenship projection
 
 Replace blanket built-in capability evidence with aggregation over passing
 receipts. Section A, the syntax capability ledger, citizenship, CLI discovery,
@@ -358,20 +457,33 @@ description, and ensure every PR is green against its actual target branch.
 
 ### A0 — programme governance prerequisite
 
-Land this before opening non-`main`-targeted implementation stacks:
+Land this immediately after the plan and before every implementation or
+adoption PR. Only this plan and A0 may use the manual bootstrap in §4.5:
 
-- make canonical CI run for every pull-request target branch, or provide an
-  equivalent required reusable/manual workflow bound to the exact target-tip,
-  merge-base, and head tuple;
-- extend the PR template and readiness tooling to require three distinct
-  individual audit reports, the finding ledger, and the current tuple;
+- make canonical trusted CI run for every programme pull-request target branch
+  and attest the exact target tip, merge base, head, tested merge result, and
+  workflow revision;
+- protect every temporary programme base with a ruleset or sole merge bot,
+  disallow bypass and force-push, and enforce the declared squash strategy;
+- add trusted multi-agent runner artifacts, pre-registered round manifests,
+  distinct actor/session/run identities, content hashes, and reconciliation of
+  failed/timed-out/abandoned runs;
+- extend the PR template and readiness tooling to require the three immutable
+  individual reports, finding ledger, newest check identities, and current
+  tuple/tree/diff digest;
 - fail readiness when reports are missing, roles are reused, findings remain
-  unresolved, or approvals/checks are stale; and
-- add the pre-merge tuple comparison required by §4.3.
+  unresolved, runs are unreconciled, or approvals/checks are stale or
+  superseded;
+- from the first behavioral repair, run a trusted exact-head red/green job in a
+  detached worktree that applies the content-addressed revert/sabotage, verifies
+  the expected red signature, restores the audited tree, and verifies green;
+- add `bun run check:programme-docs`; and
+- run the final readiness/tuple comparison from §4.3 after the final audit.
 
 The existing CI workflow runs pull requests targeting `main`; without A0, a
-child PR targeting its immediate parent can appear reviewable without a
-canonical CI result against its actual base.
+child PR targeting its immediate parent can appear reviewable without canonical
+CI or an enforceable merge gate against its actual base. Locally recorded or
+implementer-authored manual results are not substitutes after bootstrap.
 
 ### Stack A — authority and truthful evidence
 
@@ -386,12 +498,24 @@ canonical CI result against its actual base.
    - add stable `caseId`, discriminated authority references, construct IDs,
      deterministic receipt schema, exact-set indexes for features/examples/
      config keys, and a small cross-family exemplar set;
+   - keep cases, raw receipts, snapshots, and upstream adapters behind an
+     enforced test/eval-only import boundary;
+   - add the deterministic compact-index generator contract and initial bundle
+     exclusion tests;
    - do not change public capability claims yet.
-3. **A3: semantic projector API and initial projectors**
-   - establish normalized snapshot/versioning rules;
-   - land enough projectors to exercise the Phase 0 defects.
+3. **A3: semantic projectors for the complete family roster**
+   - A3.0 establishes the runner-owned oracle registry and normalized snapshot/
+     versioning rules, then lands enough projectors for Phase 0;
+   - A3.x family shards complete projectors for all 15 families currently on
+     `main`, with exact-set tracking; and
+   - the Sankey projector shard depends on C3 enrollment.
 4. **A4: receipt-driven reports and citizenship**
    - feed divergences and receipts into capability aggregation;
+   - generate the compact versioned runtime/report index and bind its freshness
+     hash to cases, results, projectors/oracles/schemas, divergences, and upstream
+     revision;
+   - prove raw evidence and Mermaid oracle code are absent from every shipped
+     bundle and tarball;
    - deliberately downgrade every not-yet-receipted claim during migration;
    - classify known defects from actual behavior: `diagnosed` only when the
      public path emits the exact asserted diagnostic, otherwise
@@ -402,7 +526,7 @@ canonical CI result against its actual base.
 Primary dependency graph:
 
 ```text
-A0 ───────────────────────────────> every stacked implementation PR
+A0 ───────────────────────────────> every implementation/adoption PR
 A1 -> A2 -> A3 -> A4
           |           |-> family repairs + relevant B guardrail/projector
           |           |-> Stack D official-example closure
@@ -412,8 +536,9 @@ A1 -> A2 -> A3 -> A4
 ```
 
 Family repairs depend on A4 plus their family projector and relevant guardrail.
-Stacks D and E depend on the receipt schema and aggregation base. B and generic
-C infrastructure may begin earlier where they do not consume those authorities.
+Each family shard in Stacks D and E depends on that family's completed projector
+as well as the receipt schema and aggregation base. B and generic C
+infrastructure may begin earlier where they do not consume those authorities.
 
 ### Stack B — parser and seam guardrails
 
@@ -443,9 +568,17 @@ for A4's report migration.
    - test reference ownership, namespacing, deterministic serialization, local-
      only references, and external-reference rejection.
 2. **C2: typed compositing**
-   - add the bounded blend-mode behavior required for upstream Sankey overlap;
+   - model compositing as an explicit Scene feature/field independent of paint
+     resources, with a bounded blend-mode set and deterministic inheritance/
+     defaulting rules;
+   - decide and test the core Scene contract-version migration separately from
+     C1, including old snapshot and consumer compatibility;
+   - explicitly version compositing through External Scene or deliberately
+     reject it at that boundary with an exact diagnostic;
+   - add backend-specific Scene-to-output conformance fixtures for every
+     supported mode rather than inferring compositing from gradient support;
    - update backend capability claims and conformance so unsupported backends
-     cannot retain a false native resource claim; and
+     cannot retain a false native compositing claim; and
    - add explicit terminal loss/projection diagnostics for gradients and
      compositing.
 3. **C3: Sankey enrollment** — rebased/narrowed #192 or its replacement,
@@ -456,10 +589,13 @@ for A4's report migration.
    multiply overlap, contrast behavior, header consistency, and final report
    state.
 
-If #192 is used as C3, that PR itself must pass the complete audit loop after
-its final rebase. If it merges before this programme can audit it, the first
-C-stack PR must audit the imported Sankey implementation against its effective
-merged base before relying on it.
+If #192 is used as C3, it cannot merge or contribute to any programme claim
+until that PR itself passes the complete audit loop on its final tuple. If it
+has already merged before A0 can enforce that gate, treat the imported Sankey
+diff as quarantined: a dedicated adoption PR must identify and audit the entire
+effective imported diff, add the required receipts, and pass the loop before
+any later C-stack work or public claim may rely on it. Retrospective inspection
+inside an otherwise unrelated C-stack PR is not sufficient.
 
 ### Family repair PRs — Phase 0
 
@@ -554,7 +690,10 @@ Rules:
 1. target the immediate parent branch, not `main`, while the parent is open;
 2. keep each diff meaningful when viewed against that parent;
 3. do not hide generated artifacts or unrelated refactors in the top stack PR;
-4. after a parent merges, rebase or retarget descendants promptly;
+4. after a parent merges, rebase or recreate each descendant on the merged
+   parent when the parent was squash-merged; retargeting alone is permitted only
+   when ancestry was preserved and exact merge-base/diff proof shows that the
+   child candidate is unchanged;
 5. rerun checks and the full multi-agent audit loop after every rebase;
 6. merge from the bottom of the stack upward; and
 7. split a stack if reviewers must understand more than one semantic decision
@@ -576,7 +715,8 @@ Every implementation PR must state:
 - focused receipt/test and a reproducible red/green record containing the
   defective base SHA or deterministic sabotage/probe ID, patch/hash, exact
   command, expected failure signature, observed red failure, and green result
-  on the audited head;
+  on the audited head, all linked to the required trusted exact-head job rather
+  than supplied only as implementer-authored prose;
 - mandatory baseline and touched-authority checks, with exact-head CI job URLs
   or command/result records;
 - generated artifacts changed and why;
@@ -618,7 +758,12 @@ Add deterministic checks by touched authority:
 
 The audited tuple must have canonical CI or the A0 equivalent against its exact
 target base; a green run against `main` cannot substitute for a stacked PR whose
-target is a parent branch.
+target is a parent branch. A0 defines the required check identities; readiness
+accepts only the newest non-superseded provider-issued run for each identity,
+bound to the tested merge tree and required workflow revision. From the first
+behavioral repair onward, the trusted red/green job is a required check and must
+run the content-addressed revert or sabotage in a detached worktree against the
+exact audited head. A manual command transcript cannot satisfy either gate.
 
 The final programme closure run includes at least:
 
@@ -670,12 +815,19 @@ Close #248 only when all of the following hold:
   closure with no orphan or ambiguous ownership;
 - every official fence has a reviewed disposition;
 - every nonblank statement is modeled, typed-preserved, or rejected;
+- every applicable agent-native claim has a passing structured agent oracle;
+  an opaque agent outcome remains capped at `source-preserved` even if native
+  rendering succeeds;
 - agent parse, verification, native render, serialization, mutation, Scene,
   applicable output, accessibility, and interaction behavior agree with the
   case policy;
 - every config key has exactly one executable effect disposition;
 - capability and citizenship reports derive from passing receipts and
   downgrade divergences automatically;
+- every enrolled family has a complete, versioned semantic projector and every
+  shipped runtime/report claim comes from the compact aggregate index; raw
+  cases, Mermaid oracles, receipts, and snapshots are absent from runtime,
+  browser, CLI, MCP, hosted, and package artifacts;
 - all upstream oracle revisions are closed and reproducible;
 - every Phase 0 defect is fixed or truthfully downgraded with a discriminating
   regression receipt;
@@ -686,7 +838,23 @@ Close #248 only when all of the following hold:
 - a final cross-programme multi-agent audit of the closure head returns
   unanimous `APPROVE` with no actionable findings.
 
-## 12. Strengths to preserve
+## 12. Governance risks and ownership
+
+A0 has one named maintainer owner and is itself a merge prerequisite, not an
+optional reporting enhancement. Repository rules or the sole merge bot must
+prevent a privileged bypass from merging a programme PR without exact-base CI,
+complete audit artifacts, and final readiness. Any emergency bypass is a
+programme stop: quarantine the resulting diff and use the adoption procedure
+defined for #192 before relying on it.
+
+Multi-agent review reduces blind spots but does not prove independence when all
+auditors use correlated models, prompts, or training data. The trusted runner
+must preserve prompt/scope hashes and actor/session/run identities, rotate or
+diversify audit implementations where available, and record correlated-model
+risk in the final residual-risk report. Human maintainer verification remains
+mandatory for the manual bootstrap and final programme closure.
+
+## 13. Strengths to preserve
 
 Do not weaken the repository's existing deterministic layout/output contracts,
 typed registry enrollment, role/primitive Scene admission, opaque source


### PR DESCRIPTION
## What

Add a practical delivery plan for #248: prove Mermaid constructs semantically, fix the confirmed gaps in small PRs, and generate public capability claims from passing cases.

Tracks #248. Does not close it.

## Why

The repository already proves family enrollment, deterministic output, source preservation, and basic rendering. Issue #248 shows that those checks can still pass when an authored construct is silently dropped or changes meaning.

The previous version of this plan duplicated the issue and grew into a large audit/governance protocol. That made the proposed work difficult to understand and harder to maintain than necessary.

## How

The simplified plan has five parts:

1. Add a small test-only registry of construct-level semantic cases, with typed surface diagnostics and explicit blocked-stage results.
2. Test each construct once through its canonical family implementation.
3. Use a thin shared suite to prove typed request/result equivalence for CLI, SDK, MCP, editor, website, and output routes.
4. Derive capability reporting from current passing cases, failing closed when evidence is missing.
5. Fix confirmed findings in focused family PRs, with Sankey work isolated behind a narrowed or replacement #192.

For visual work, the plan treats gradients and compositing as separate Scene concepts and requires the real prior error or unsupported output as the baseline.

It explicitly uses the repository's normal CI and review process. It does not introduce custom audit manifests, locked evidence branches, mandatory agent counts, or a separate maintainer-witness protocol.

## Testing

- `git diff --check`
- `bun test src/__tests__/docs-consolidation-contract.test.ts` — pass
- `bun run lint:contracts` — pass

The full local quality command was also attempted. Its repository-wide dependency-audit and font-regeneration steps require network and Docker access unavailable in this environment; GitHub CI will run on the pushed head.

## Risk

This is a documentation-only change. It adds no runtime code, dependencies, generated artifacts, or release changes.

The main design risk is overengineering the future evidence runner. The plan addresses that directly: keep the case model small, add machinery only for reproduced failures, and use #248 as the source of detailed findings rather than duplicating them here.
