### PR TITLE
Patch fast-uri and undici advisories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ This changelog tracks user-facing changes for **Agentic Mermaid**, a fork of `lu
 ### Changed
 - Updated the `brace-expansion` development override to the first 5.x release
   patched for GHSA-rgw5-rvv9-x895.
+- Updated the transitive `fast-uri` override to 3.1.5 for
+  GHSA-7p8r-x3mc-p8w7 and pinned transitive `undici` to 7.29.0 for
+  GHSA-4cwx-7wf7-3272.
 
 ## 0.4.0 — 2026-07-28
 

--- a/bun.lock
+++ b/bun.lock
@@ -35,10 +35,11 @@
   "overrides": {
     "brace-expansion": "5.0.9",
     "esbuild": "0.28.1",
-    "fast-uri": "3.1.4",
+    "fast-uri": "3.1.5",
     "lodash-es": "4.18.1",
     "picomatch": "4.0.5",
     "qs": "6.15.3",
+    "undici": "7.29.0",
   },
   "packages": {
     "@antfu/install-pkg": ["@antfu/install-pkg@1.1.0", "", { "dependencies": { "package-manager-detector": "^1.3.0", "tinyexec": "^1.0.1" } }, "sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ=="],
@@ -733,7 +734,7 @@
 
     "fast-string-width": ["fast-string-width@3.0.2", "", { "dependencies": { "fast-string-truncated-width": "^3.0.2" } }, "sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg=="],
 
-    "fast-uri": ["fast-uri@3.1.4", "", {}, "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw=="],
+    "fast-uri": ["fast-uri@3.1.5", "", {}, "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw=="],
 
     "fast-wrap-ansi": ["fast-wrap-ansi@0.2.2", "", { "dependencies": { "fast-string-width": "^3.0.2" } }, "sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q=="],
 
@@ -1071,7 +1072,7 @@
 
     "underscore": ["underscore@1.13.8", "", {}, "sha512-DXtD3ZtEQzc7M8m4cXotyHR+FAS18C64asBYY5vqZexfYryNNnDc02W4hKg3rdQuqOYas1jkseX0+nZXjTXnvQ=="],
 
-    "undici": ["undici@7.28.0", "", {}, "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA=="],
+    "undici": ["undici@7.29.0", "", {}, "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw=="],
 
     "undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
 

--- a/package.json
+++ b/package.json
@@ -217,10 +217,11 @@
   "overrides": {
     "brace-expansion": "5.0.9",
     "esbuild": "0.28.1",
-    "fast-uri": "3.1.4",
+    "fast-uri": "3.1.5",
     "lodash-es": "4.18.1",
     "picomatch": "4.0.5",
-    "qs": "6.15.3"
+    "qs": "6.15.3",
+    "undici": "7.29.0"
   },
   "devDependencies": {
     "@biomejs/biome": "2.5.5",


### PR DESCRIPTION
## What

Patch the two high-severity transitive advisories that began failing the dependency-audit gate after #251 merged:

- `fast-uri` 3.1.4 → 3.1.5 for [GHSA-7p8r-x3mc-p8w7](https://github.com/advisories/GHSA-7p8r-x3mc-p8w7)
- `undici` 7.28.0 → 7.29.0 for [GHSA-4cwx-7wf7-3272](https://github.com/advisories/GHSA-4cwx-7wf7-3272)

## Why

Both advisories were published shortly before #251's final exact-head CI, but did not surface in that audit. They became visible to `bun audit` afterward, first failing #249 run `30847189575` without any dependency-graph change.

The plan PR must remain documentation-only, so this dependency correction is isolated here.

## How

- Move the existing `fast-uri` override to the first patched 3.x release, which remains inside AJV's declared `^3.0.1` range.
- Add an exact `undici` 7.29.0 override for Wrangler/Miniflare's affected 7.x dependency.
- Regenerate only the Bun lockfile and record both fixes in the changelog.
- Keep package/release identity at the still-unpublished `0.4.2`; no runtime, renderer, MCP, website, or release-projection source changes are included.

## Testing

Red evidence on the unchanged dependency graph:

- CI run `30847189575`: `bun audit --audit-level=high` reports exactly the two advisories above and fails the quality gate.

Green evidence on this head:

- `bun run audit:dependencies` — no high/critical findings.
- `bun install --frozen-lockfile` — no changes.
- `bun run eval:mcp-conformance` — all five scenarios satisfy the checked-in expected-failure baseline.
- Focused hosted-MCP, HTTP, cache-policy, and Wrangler parser suite — 130 pass, 0 fail.
- Pinned Wrangler 4.114.0 `deploy --dry-run` succeeds with the overridden Miniflare/Undici graph.
- `bun run evidence:check` — all eight evidence receipts pass.
- `bun run lint` and `bun run typecheck` pass.
- `git diff --check origin/main...HEAD` passes.

## Risk

Low-to-moderate. `fast-uri` stays within AJV's declared semver range. Miniflare currently pins `undici` 7.28.0 exactly, so the 7.29.0 security override is intentionally stronger than its manifest; the focused Worker/MCP checks and full CI matrix are required before merge. No user-facing or visual behavior is intended to change.

## Audit loop

This PR remains draft until exact-head CI is green. It then goes through the same independent three-agent audit/fix/re-audit loop required by the #248 delivery plan; it will not merge until every auditor approves one immutable candidate tuple.
