### PR TITLE
Patch ip-address advisory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ This changelog tracks user-facing changes for **Agentic Mermaid**, a fork of `lu
 - Updated the transitive `fast-uri` override to 3.1.5 for
   GHSA-7p8r-x3mc-p8w7 and pinned transitive `undici` to 7.29.0 for
   GHSA-4cwx-7wf7-3272.
+- Pinned transitive `ip-address` to 10.3.1 for
+  GHSA-mwp4-54f8-5fhr.
 
 ## 0.4.0 — 2026-07-28
 

--- a/bun.lock
+++ b/bun.lock
@@ -36,6 +36,7 @@
     "brace-expansion": "5.0.9",
     "esbuild": "0.28.1",
     "fast-uri": "3.1.5",
+    "ip-address": "10.3.1",
     "lodash-es": "4.18.1",
     "picomatch": "4.0.5",
     "qs": "6.15.3",
@@ -790,7 +791,7 @@
 
     "internmap": ["internmap@2.0.3", "", {}, "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg=="],
 
-    "ip-address": ["ip-address@10.2.0", "", {}, "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA=="],
+    "ip-address": ["ip-address@10.3.1", "", {}, "sha512-1e9d3kb97NHJTIJDZW9rKqW2h6+dFa50Dy0fpPSMQp2ADje5gvKsXmdiK6dwY5t76TaTt5+P5N1Y/LoToIxP6g=="],
 
     "ipaddr.js": ["ipaddr.js@1.9.1", "", {}, "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="],
 

--- a/package.json
+++ b/package.json
@@ -218,6 +218,7 @@
     "brace-expansion": "5.0.9",
     "esbuild": "0.28.1",
     "fast-uri": "3.1.5",
+    "ip-address": "10.3.1",
     "lodash-es": "4.18.1",
     "picomatch": "4.0.5",
     "qs": "6.15.3",

--- a/src/__tests__/dependency-security.test.ts
+++ b/src/__tests__/dependency-security.test.ts
@@ -1,0 +1,32 @@
+import { existsSync, readFileSync } from 'node:fs'
+import { dirname, join, parse } from 'node:path'
+import { createRequire } from 'node:module'
+import { describe, expect, test } from 'bun:test'
+
+function packageVersion(entryPath: string): string {
+  let directory = dirname(entryPath)
+  const root = parse(directory).root
+  while (directory !== root) {
+    const manifestPath = join(directory, 'package.json')
+    if (existsSync(manifestPath)) {
+      const manifest = JSON.parse(readFileSync(manifestPath, 'utf8')) as { version?: unknown }
+      if (typeof manifest.version === 'string') return manifest.version
+    }
+    directory = dirname(directory)
+  }
+  throw new Error(`could not resolve package version for ${entryPath}`)
+}
+
+describe('dependency security overrides', () => {
+  test('express-rate-limit resolves the patched ip-address implementation', () => {
+    const rootRequire = createRequire(import.meta.url)
+    const consumerRequire = createRequire(rootRequire.resolve('express-rate-limit'))
+    const ipAddressEntry = consumerRequire.resolve('ip-address')
+    const { Address4 } = consumerRequire('ip-address') as {
+      Address4: new (address: string) => unknown
+    }
+
+    expect(packageVersion(ipAddressEntry)).toBe('10.3.1')
+    expect(() => new Address4('127.0.0.01')).toThrow()
+  })
+})


### PR DESCRIPTION
## What

Pin transitive `ip-address` 10.3.1, the first release outside the affected `<=10.3.0` range for [GHSA-mwp4-54f8-5fhr](https://github.com/advisories/GHSA-mwp4-54f8-5fhr).

## Why

The advisory began failing the high-severity dependency gate after the previous security fixes merged. Plan PR #249 run `30851019249` reproduced the failure on the unchanged dependency graph through `@modelcontextprotocol/sdk` → `express-rate-limit` → `ip-address`.

The plan PR must remain documentation-only, so this dependency correction is isolated here.

## How

- Add an exact root override for `ip-address` 10.3.1.
- Regenerate only the Bun lockfile entry.
- Add a focused consumer-context regression test that fails if
  `express-rate-limit` resolves an affected copy.
- Record the advisory fix in the Unreleased changelog.
- Leave runtime, renderer, MCP, website, and release identity unchanged.

## Testing

Red evidence on the prior dependency graph:

- PR #249 CI run `30851019249`: `bun audit --audit-level=high` reports `ip-address <=10.3.0` and fails the quality gate.

Green evidence on this head:

- `bun audit --audit-level=high` — no high/critical findings.
- `bun install --frozen-lockfile` — no changes.
- `src/__tests__/dependency-security.test.ts` resolves `ip-address` from
  `express-rate-limit`'s own module context, asserts 10.3.1, and proves its
  `Address4` rejects ambiguous `127.0.0.01` input.
- `npm ls ip-address --all` after a clean frozen install shows the MCP SDK path
  resolving one overridden `ip-address@10.3.1` and no vulnerable nested copy.
- Hosted/MCP/Worker/cache focused suite — 476 pass, 0 fail across 22 files.
- `bun run eval:mcp-conformance` — all five scenarios satisfy the checked-in
  expected-failure baseline.
- `bun run evidence:check` — all eight evidence receipts pass.
- `bun run lint` and `bun run typecheck` pass.
- `git diff --check origin/main...HEAD` passes.

Exact-head GitHub CI is required before audit dispatch.

## Risk

Low. The override moves from 10.2.0 to the first patched 10.x release, which remains inside `express-rate-limit`'s declared `^10.2.0` range. The change is limited to one override, one lockfile resolution, the changelog, and a focused test that is excluded from the published package.

## Audit loop

This PR remains draft until exact-head CI is green. It then goes through an independent three-agent audit/fix/re-audit loop and will not merge until all auditors approve one immutable candidate tuple.

Round 1 on `65c96b1` returned `CHANGES_REQUIRED`: an adversarial auditor found
that the manual probe resolved the new root package while a stale local install
still contained a nested 10.2.0 consumer copy. Commit `f62df71` adds a regression
test that resolves from the real consumer context. The stale tree fails that
contract; a clean frozen install resolves 10.3.1 and passes it. All three roles
must re-audit the new exact tuple after CI.
