### PR TITLE
Document Sankey support in the changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ This changelog tracks user-facing changes for **Agentic Mermaid**, a fork of `lu
 
 ### Added
 - Added human-readable titles to every MCP tool and published canonical directory-listing and hosted-service privacy documentation.
+- Added Sankey as the 16th built-in diagram family, with Mermaid-compatible
+  `sankey` and `sankey-beta` CSV syntax, deterministic SVG, PNG, and ASCII
+  rendering, typed agent editing, and support across the library, CLI, MCP,
+  website, and full and lazy browser bundles.
 
 ### Changed
 - Updated the `brace-expansion` development override to the first 5.x release


### PR DESCRIPTION
## What

Add the missing Unreleased changelog entry for the Sankey diagram family delivered in #192.

## Why

PR #192 added Sankey support and recorded its engineering lessons, but the user-facing changelog was not updated. Without this entry, the next release notes would omit a major new built-in family.

## How

Document the supported Mermaid syntax, SVG/PNG/ASCII outputs, typed agent editing, and library, CLI, MCP, website, and browser integration surfaces under `Unreleased` → `Added`.

## Testing

- `git diff --check`
- Reviewed the final one-file diff against the merged PR #192 description

This changes Markdown release notes only; it has no runtime, generated-output, or visual impact.

## Risk

Minimal. The PR changes one changelog entry and does not modify code, dependencies, generated artifacts, or release behavior.